### PR TITLE
World.getBlockTypeIDAt

### DIFF
--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -21,6 +21,16 @@ public interface World {
     public Block getBlockAt(int x, int y, int z);
 
     /**
+     * Gets the type-ID of the block at the given location
+     *
+     * @param x X-coordinate of the block
+     * @param y Y-coordinate of the block
+     * @param z Z-coordinate of the block
+     * @return The type-ID of the block at the given location
+     */
+    public int getBlockTypeIDAt(int x, int y, int z);
+
+    /**
      * Gets the highest non-air coordinate at the given (x,z) location
      * @param x X-coordinate of the blocks
      * @param z Z-coordinate of the blocks


### PR DESCRIPTION
k-zed and me are working on Dynmap, a map generation plugin which uses the Bukkit api to render the map.
We tried to use World.getBlock(...).getTypeID(), but this had two side effects:
1. getBlock is not thread-safe (because of the cache) and therefore this function would lock the whole minecraft-server when used from another thread.
2. we just need the type-ID of a block, getBlockTypeIDAt makes it a lot faster to request that.
