### PR TITLE
Plugin Interdependence Fix

### DIFF
--- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
@@ -2,40 +2,21 @@ package org.bukkit.plugin.java;
 
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * A ClassLoader for plugins, to allow shared classes across multiple plugins
  */
 public class PluginClassLoader extends URLClassLoader {
-    private final JavaPluginLoader loader;
-    private final Map<String, Class<?>> classes = new HashMap<String, Class<?>>();
-
-    public PluginClassLoader(final JavaPluginLoader loader, final URL[] urls, final ClassLoader parent) {
+	public PluginClassLoader(final ClassLoader parent) {
+		super(new URL[0], parent);
+	}
+	
+    public PluginClassLoader(final URL[] urls, final ClassLoader parent) {
         super(urls, parent);
-
-        this.loader = loader;
     }
 
-    @Override
-    protected Class<?> findClass(String name) throws ClassNotFoundException {
-        Class<?> result = classes.get(name);
-
-        if (result == null) {
-            result = loader.getClassByName(name);
-
-            if (result == null) {
-                result = super.findClass(name);
-
-                if (result != null) {
-                    loader.setClass(name, result);
-                }
-            }
-
-            classes.put(name, result);
-        }
-
-        return result;
-    }
+	@Override
+	public void addURL(URL url) {
+		super.addURL(url);
+	}
 }


### PR DESCRIPTION
Plugins are currently unable to reference classes from each other. The changes herein solve that by utilizing a single mutable subclass of URLClassLoader to load all plugins.

A new problem arises in that plugins with classes in the default package, or in poorly-named packages, can conflict with each other. This is not really an issue if plugin authors follow Java convention and put their classes in packages with good, unique names. However, possible issues with external libraries may arise from multiple plugins including different versions of a single library. More extensive changes to plugin loading are required to fully address these problems.
