### PR TITLE
added ability to unregister RegisteredListeners

### DIFF
--- a/src/main/java/org/bukkit/plugin/PluginManager.java
+++ b/src/main/java/org/bukkit/plugin/PluginManager.java
@@ -91,9 +91,17 @@ public interface PluginManager {
      * @param priority Priority of this event
      * @param plugin Plugin to register
      */
-    public void registerEvent(Event.Type type, Listener listener, Priority priority, Plugin plugin);
+    public RegisteredListener registerEvent(Event.Type type, Listener listener, Priority priority, Plugin plugin);
 
-    /**
+	/**
+	 * Unregisters the given registered listener (returned from registerEvent)
+	 *
+	 * @param registeredListener
+	 */
+	public void unregisterEvent(RegisteredListener registeredListener);
+
+
+	/**
      * Enables the specified plugin
      *
      * Attempting to enable a plugin that is already enabled will have no effect

--- a/src/main/java/org/bukkit/plugin/RegisteredListener.java
+++ b/src/main/java/org/bukkit/plugin/RegisteredListener.java
@@ -8,15 +8,25 @@ import org.bukkit.event.Listener;
  * Stores relevant information for plugin listeners
  */
 public class RegisteredListener {
+	private final Event.Type type;
     private final Listener listener;
     private final Event.Priority priority;
     private final Plugin plugin;
 
-    public RegisteredListener(final Listener pluginListener, final Event.Priority eventPriority, final Plugin registeredPlugin) {
-        listener = pluginListener;
+    public RegisteredListener(final Event.Type eventType, final Listener pluginListener, final Event.Priority eventPriority, final Plugin registeredPlugin) {
+        type = eventType;
+	    listener = pluginListener;
         priority = eventPriority;
         plugin = registeredPlugin;
     }
+
+	/**
+	 * Gets the type for which this listener was registered
+	 * @return Registered Type
+	 */
+	public Event.Type getType() {
+		return type;
+	}
 
     /**
      * Gets the listener for this registration


### PR DESCRIPTION
- modified registerEvent on PluginManager to return the RegisteredListener instance
- added corresponding unregisterEvent() to support removing RegisteredListener instances

I believe it is important for performance to allow plugins to register/unregister at will.  Not being able to unregister listeners is unnecessary overhead.   This is a breaking change to existing plugins as the signature of registerEvent has changed (return type).

I have generic Groovy scripting plugin that makes uses of this if you'd like to see an example.   github.com/krsmes/GroovyBukkit
