### PR TITLE
Unregister Listeners

### DIFF
--- a/src/main/java/org/bukkit/plugin/PluginManager.java
+++ b/src/main/java/org/bukkit/plugin/PluginManager.java
@@ -91,9 +91,16 @@ public interface PluginManager {
      * @param priority Priority of this event
      * @param plugin Plugin to register
      */
-    public void registerEvent(Event.Type type, Listener listener, Priority priority, Plugin plugin);
+    public RegisteredListener registerEvent(Event.Type type, Listener listener, Priority priority, Plugin plugin);
 
-    /**
+	/**
+	 * Unregisters the given registered listener (returned from registerEvent)
+	 *
+	 * @param registeredListener
+	 */
+	public void unregisterEvent(RegisteredListener registeredListener);
+
+	/**
      * Enables the specified plugin
      *
      * Attempting to enable a plugin that is already enabled will have no effect

--- a/src/main/java/org/bukkit/plugin/RegisteredListener.java
+++ b/src/main/java/org/bukkit/plugin/RegisteredListener.java
@@ -8,15 +8,25 @@ import org.bukkit.event.Listener;
  * Stores relevant information for plugin listeners
  */
 public class RegisteredListener {
+	private final Event.Type type;
     private final Listener listener;
     private final Event.Priority priority;
     private final Plugin plugin;
 
-    public RegisteredListener(final Listener pluginListener, final Event.Priority eventPriority, final Plugin registeredPlugin) {
+    public RegisteredListener(final Event.Type eventType, final Listener pluginListener, final Event.Priority eventPriority, final Plugin registeredPlugin) {
+        type = eventType;
         listener = pluginListener;
         priority = eventPriority;
         plugin = registeredPlugin;
     }
+
+    /**
+	 * Gets the type for which this listener was registered
+	 * @return Registered Type
+	 */
+	public Event.Type getType() {
+		return type;
+	}
 
     /**
      * Gets the listener for this registration

--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -215,7 +215,7 @@ public final class SimplePluginManager implements PluginManager {
      * @param priority Priority of this event
      * @param plugin Plugin to register
      */
-    public void registerEvent(Event.Type type, Listener listener, Priority priority, Plugin plugin) {
+    public RegisteredListener registerEvent(Event.Type type, Listener listener, Priority priority, Plugin plugin) {
         PriorityQueue<RegisteredListener> eventListeners = listeners.get(type);
 
         if (eventListeners == null) {
@@ -229,6 +229,26 @@ public final class SimplePluginManager implements PluginManager {
             listeners.put(type, eventListeners);
         }
 
-        eventListeners.offer(new RegisteredListener(listener, priority, plugin));
+
+	    RegisteredListener registeredListener = new RegisteredListener(type, listener, priority, plugin);
+	    eventListeners.offer(registeredListener);
+	    return registeredListener;
     }
+
+	/**
+	 * Unregisters the given registered listener (returned from registerEvent)
+	 *
+	 * @param registeredListener
+	 */
+	public void unregisterEvent(RegisteredListener registeredListener) {
+		if (registeredListener != null) {
+			Event.Type type = registeredListener.getType();
+			PriorityQueue<RegisteredListener> eventListeners = listeners.get(type);
+
+			if (eventListeners.contains(registeredListener)) {
+				eventListeners.remove(registeredListener);
+			}
+		}
+	}
+
 }


### PR DESCRIPTION
Changes to PluginManager, SimplePluginManager, and RegisteredListener to support unregistering RegisteredListeners

This is for performance so that all listeners do not have to be registered all the time.
