### PR TITLE
Fix bug in org.bukkit.material.Button and org.bukkit.material.Lever in getAttachedFace()

### DIFF
--- a/src/main/java/org/bukkit/material/Button.java
+++ b/src/main/java/org/bukkit/material/Button.java
@@ -1,4 +1,3 @@
-
 package org.bukkit.material;
 
 import org.bukkit.block.BlockFace;
@@ -40,7 +39,7 @@ public class Button extends MaterialData implements Redstone, Attachable {
      * @return BlockFace attached to
      */
     public BlockFace getAttachedFace() {
-        byte data = (byte) (getData() ^ 0x7);
+        byte data = (byte) (getData() & 0x7);
 
         switch (data) {
             case 0x1:
@@ -51,6 +50,10 @@ public class Button extends MaterialData implements Redstone, Attachable {
                 return BlockFace.EAST;
             case 0x4:
                 return BlockFace.WEST;
+            case 0x5:
+            case 0x6:
+                return BlockFace.DOWN;
+
         }
 
         return null;

--- a/src/main/java/org/bukkit/material/Button.java
+++ b/src/main/java/org/bukkit/material/Button.java
@@ -50,10 +50,6 @@ public class Button extends MaterialData implements Redstone, Attachable {
                 return BlockFace.EAST;
             case 0x4:
                 return BlockFace.WEST;
-            case 0x5:
-            case 0x6:
-                return BlockFace.DOWN;
-
         }
 
         return null;

--- a/src/main/java/org/bukkit/material/Lever.java
+++ b/src/main/java/org/bukkit/material/Lever.java
@@ -1,4 +1,3 @@
-
 package org.bukkit.material;
 
 import org.bukkit.block.BlockFace;
@@ -40,7 +39,7 @@ public class Lever extends MaterialData implements Redstone, Attachable {
      * @return BlockFace attached to
      */
     public BlockFace getAttachedFace() {
-        byte data = (byte) (getData() ^ 0x7);
+        byte data = (byte) (getData() & 0x7);
 
         switch (data) {
             case 0x1:


### PR DESCRIPTION
Using data^0x7 to get the direction resulted in NullPointerException when calling getAttachedFace() while the button or lever were ON. Changed to data&0x7 instead.

Based on http://www.minecraftwiki.net/wiki/Data_values
