### PR TITLE
Add a method to play a NoteBlock and to make a dispenser dispense

### DIFF
--- a/src/main/java/org/bukkit/block/Dispenser.java
+++ b/src/main/java/org/bukkit/block/Dispenser.java
@@ -6,4 +6,8 @@ package org.bukkit.block;
  * @author sk89q
  */
 public interface Dispenser extends BlockState, ContainerBlock {
+    /**
+     * Dispense a random block
+     */
+    public void dispense();
 }

--- a/src/main/java/org/bukkit/block/NoteBlock.java
+++ b/src/main/java/org/bukkit/block/NoteBlock.java
@@ -19,4 +19,9 @@ public interface NoteBlock extends BlockState {
      * @param note
      */
     public void setNote(byte note);
+
+    /**
+     * Plays the noteblock
+     */
+    public void play();
 }


### PR DESCRIPTION
This adds a play() method to the NoteBlock interface and a dispense() method to the Dispenser interface.
See my pull request for CraftBukkit: https://github.com/Bukkit/CraftBukkit/pull/77
