### PR TITLE
explode trigger event (different from existing exlosion event)

### DIFF
--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -486,7 +486,7 @@ public abstract class Event {
          * @todo: add javadoc see comment
          */
         ENTITY_EXPLODE (Category.LIVING_ENTITY),
-        
+
         /**
          * Called when an entity has made a decision to explode.
          * 

--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -486,6 +486,20 @@ public abstract class Event {
          * @todo: add javadoc see comment
          */
         ENTITY_EXPLODE (Category.LIVING_ENTITY),
+        
+        /**
+         * Called when an entity has made a decision to explode.
+         * 
+         * Provides an opportunity to act on the entity, change the explosion radius,
+         * or to change the fire-spread flag.
+         * 
+         * Canceling the event negates the entity's decision to explode.
+         * For EntityCreeper, this resets the fuse but does not kill the Entity.
+         * For EntityFireball and EntityTNTPrimed....?
+         * 
+         * @see org.bukkit.event.entity.EntityExplodeTriggerEvent
+         */
+        ENTITY_EXPLODETRIGGER (Category.LIVING_ENTITY),
 
         /**
          * Called when an entity targets another entity

--- a/src/main/java/org/bukkit/event/entity/EntityExplodeTriggerEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityExplodeTriggerEvent.java
@@ -1,0 +1,42 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Cancellable;
+
+public class EntityExplodeTriggerEvent extends EntityEvent implements Cancellable {
+    private boolean cancel;
+    private float radius;
+    private boolean fire;
+    
+	public EntityExplodeTriggerEvent(Type type, Entity what, float radius, boolean fire) {
+		super(type.ENTITY_EXPLODETRIGGER, what);
+        this.cancel = false;
+        this.radius = radius;
+        this.fire = fire;
+	}
+
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+    
+    public float getRadius() {
+    	return radius;
+    }
+    
+    public void setRadius(float radius) {
+    	this.radius = radius;
+    }
+
+	public boolean getFire() {
+		return fire;
+	}
+
+	public void setFire(boolean fire) {
+		this.fire = fire;
+	}
+
+}

--- a/src/main/java/org/bukkit/event/entity/EntityExplodeTriggerEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityExplodeTriggerEvent.java
@@ -7,13 +7,13 @@ public class EntityExplodeTriggerEvent extends EntityEvent implements Cancellabl
     private boolean cancel;
     private float radius;
     private boolean fire;
-    
-	public EntityExplodeTriggerEvent(Type type, Entity what, float radius, boolean fire) {
-		super(type.ENTITY_EXPLODETRIGGER, what);
+
+    public EntityExplodeTriggerEvent(Type type, Entity what, float radius, boolean fire) {
+        super(type.ENTITY_EXPLODETRIGGER, what);
         this.cancel = false;
         this.radius = radius;
         this.fire = fire;
-	}
+    }
 
     public boolean isCancelled() {
         return cancel;
@@ -24,19 +24,19 @@ public class EntityExplodeTriggerEvent extends EntityEvent implements Cancellabl
     }
     
     public float getRadius() {
-    	return radius;
+        return radius;
     }
     
     public void setRadius(float radius) {
-    	this.radius = radius;
+        this.radius = radius;
     }
 
-	public boolean getFire() {
-		return fire;
-	}
+    public boolean getFire() {
+        return fire;
+    }
 
-	public void setFire(boolean fire) {
-		this.fire = fire;
-	}
+    public void setFire(boolean fire) {
+        this.fire = fire;
+    }
 
 }

--- a/src/main/java/org/bukkit/event/entity/EntityListener.java
+++ b/src/main/java/org/bukkit/event/entity/EntityListener.java
@@ -27,6 +27,9 @@ public class EntityListener implements Listener {
     public void onEntityExplode(EntityExplodeEvent event) {
     }
 
+    public void onEntityExplodeTrigger(EntityExplodeTriggerEvent event) {
+    }
+
     public void onEntityDeath(EntityDeathEvent event) {
     }
 

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -312,6 +312,11 @@ public final class JavaPluginLoader implements PluginLoader {
                     ((EntityListener)listener).onEntityExplode( (EntityExplodeEvent)event );
                 }
             };
+        case ENTITY_EXPLODETRIGGER:
+            return new EventExecutor() { public void execute( Listener listener, Event event ) {
+                    ((EntityListener)listener).onEntityExplodeTrigger( (EntityExplodeTriggerEvent)event );
+                }
+            };
         case ENTITY_TARGET:
             return new EventExecutor() { public void execute( Listener listener, Event event ) {
                     ((EntityListener)listener).onEntityTarget( (EntityTargetEvent)event );


### PR DESCRIPTION
This new event fires when the entity is making its decision to explode. It exposes the entity, the radius of the explosion, and the fire-spread flag to plugins, enabling them to alter these characteristics. It can also be canceled, in which case the world object's explosion is never called.

This defeats client-side prediction in most cases. TNT still suffers from client-side prediction, because the client appears to predict the explosion from the moment the block is struck.

Depends on my changes to craftbukkit - see other pull request.

Take a look at my github for a (poorly written hack of a) plugin that I threw together to test this event.

Thanks for your time.
