### PR TITLE
Added getMaxVisibleSpeed and setMaxVisibleSpeed to Minecarts

### DIFF
--- a/src/main/java/org/bukkit/entity/Boat.java
+++ b/src/main/java/org/bukkit/entity/Boat.java
@@ -6,4 +6,17 @@ package org.bukkit.entity;
  * @author sk89q
  */
 public interface Boat extends Vehicle {
+    /**
+     * Gets the maximum speed of a minecart. The speed is unrelated to the velocity.
+     *
+     * @param speed
+     */
+    public double getMaxSpeed();
+
+    /**
+     * Sets the maximum speed of a minecart. Must be nonnegative. Default is 0.4D.
+     *
+     * @param speed
+     */
+    public void setMaxSpeed(double speed);
 }

--- a/src/main/java/org/bukkit/entity/Minecart.java
+++ b/src/main/java/org/bukkit/entity/Minecart.java
@@ -1,5 +1,7 @@
 package org.bukkit.entity;
 
+import org.bukkit.util.Vector;
+
 /**
  * Represents a minecart entity.
  * 
@@ -12,25 +14,70 @@ public interface Minecart extends Vehicle {
      * @param damage over 40 to "kill" a minecart
      */
     public void setDamage(int damage);
-    
+
     /**
      * Gets a minecart's damage.
      * 
      * @param damage
      */
     public int getDamage();
-	
-    /**
-     * Gets the maximum visible speed of a minecart. The visible speed is unrelated to the momentum.
-     *
-     * @param visible speed
-     */
-    public double getMaxVisibleSpeed();
 
     /**
-     * Sets the maximum visible speed of a minecart. Must be nonnegative. Default is 0.4D.
+     * Gets the maximum speed of a minecart. The speed is unrelated to the velocity.
+     *
+     * @param speed
+     */
+    public double getMaxSpeed();
+
+    /**
+     * Sets the maximum speed of a minecart. Must be nonnegative. Default is 0.4D.
+     *
+     * @param speed
+     */
+    public void setMaxSpeed(double speed);
+
+    /**
+     * Returns whether this minecart will slow down faster without a passenger occuping it
+     *
+     */
+    public boolean isSlowWhenEmpty();
+
+    /**
+     * Sets whether this minecart will slow down faster without a passenger occuping it
+     *
+     * @param slow
+     */
+    public void setSlowWhenEmpty(boolean slow);
+
+    /**
+     * Gets the flying velocity modifier. Used for minecarts that are in mid-air.
+     * Flying minecarts velocity is multiplied by this factor each tick.
+     *
+     * @param flying velocity modifier
+     */
+    public Vector getFlyingVelocityMod();
+
+    /**
+     * Sets the flying velocity modifier. Used for minecarts that are in mid-air.
+     * Flying minecarts velocity is multiplied by this factor each tick.
+     *
+     * @param flying velocity modifier
+     */
+    public void setFlyingVelocityMod(Vector flying);
+
+    /**
+     * Gets the derailed velocity modifier. Used for minecarts that are on the ground, but not on rails.
+     *
+     * Derailed minecarts velocity is multiplied by this factor each tick.
+     * @param visible speed
+     */
+    public Vector getDerailedVelocityMod();
+
+    /**
+     * Sets the derailed velocity modifier. Used for minecarts that are on the ground, but not on rails.
+     * Derailed minecarts velocity is multiplied by this factor each tick.
      *
      * @param visible speed
      */
-    public void setMaxVisibleSpeed(double speed);
+    public void setDerailedVelocityMod(Vector derailed);
 }

--- a/src/main/java/org/bukkit/entity/Minecart.java
+++ b/src/main/java/org/bukkit/entity/Minecart.java
@@ -19,4 +19,18 @@ public interface Minecart extends Vehicle {
      * @param damage
      */
     public int getDamage();
+	
+    /**
+     * Gets the maximum visible speed of a minecart. The visible speed is unrelated to the momentum.
+     *
+     * @param visible speed
+     */
+    public double getMaxVisibleSpeed();
+
+    /**
+     * Sets the maximum visible speed of a minecart. Must be nonnegative. Default is 0.4D.
+     *
+     * @param visible speed
+     */
+    public void setMaxVisibleSpeed(double speed);
 }


### PR DESCRIPTION
Visible speed is the speed at which the minecart appears to move in the game. Adjusting this could allow for different minecarts to render motion at different speeds. 

There is a matching pull request in the CraftBukkit repository.
