### PR TITLE
Adding EntityDamageEvent.setDamage()

### DIFF
--- a/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
@@ -63,6 +63,15 @@ public class EntityDamageEvent extends EntityEvent implements Cancellable {
     }
 
     /**
+     * Sets the amount of damage caused by the Block
+     * @return The amount of damage caused by the Block
+     */
+    public void setDamage(int damage)
+    {
+        this.damage = damage;
+    }
+
+    /**
      * Gets the cause of the damage.
      * @return A DamageCause value detailing the cause of the damage.
      */


### PR DESCRIPTION
All event triggers already use getDamage() so no CraftBukkit change is needed.
