### PR TITLE
Added getPlayer method to SignChangeEvent

### DIFF
--- a/src/main/java/org/bukkit/event/block/SignChangeEvent.java
+++ b/src/main/java/org/bukkit/event/block/SignChangeEvent.java
@@ -17,6 +17,16 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
         this.player = thePlayer;
         this.lines = theLines;
     }
+    
+    /**
+     * Gets the player for this event
+     *
+     * @return Player player
+     */
+    public Player getPlayer()
+    {
+        return player;
+    }
 
     /**
      * Gets all of the text lines from this event


### PR DESCRIPTION
This pull adds a getPlayer method to the SignChangeEvent class.

Requested by Steven Scott (Drakia) at: http://leaky.bukkit.org/issues/367
