### PR TITLE
Unregister Listeners

### DIFF
--- a/src/main/java/org/bukkit/plugin/PluginManager.java
+++ b/src/main/java/org/bukkit/plugin/PluginManager.java
@@ -101,7 +101,7 @@ public interface PluginManager {
      * @param priority Priority of this event
      * @param plugin Plugin to register
      */
-    public void registerEvent(Event.Type type, Listener listener, Priority priority, Plugin plugin);
+    public RegisteredListener registerEvent(Event.Type type, Listener listener, Priority priority, Plugin plugin);
 
     /**
      * Registers the given event to the specified executor
@@ -112,7 +112,14 @@ public interface PluginManager {
      * @param priority Priority of this event
      * @param plugin Plugin to register
      */
-    public void registerEvent(Event.Type type, Listener listener, EventExecutor executor, Priority priority, Plugin plugin);
+    public RegisteredListener registerEvent(Event.Type type, Listener listener, EventExecutor executor, Priority priority, Plugin plugin);
+
+    /**
+     * Unregisters the given registered listener (returned from registerEvent)
+     *
+     * @param registeredListener
+     */
+    public void unregisterEvent(RegisteredListener registeredListener);
 
     /**
      * Enables the specified plugin

--- a/src/main/java/org/bukkit/plugin/RegisteredListener.java
+++ b/src/main/java/org/bukkit/plugin/RegisteredListener.java
@@ -10,19 +10,22 @@ import org.bukkit.plugin.EventExecutor;
  */
 public class RegisteredListener {
     private final Listener listener;
+    private final Event.Type type;
     private final Event.Priority priority;
     private final Plugin plugin;
     private final EventExecutor executor;
 
-    public RegisteredListener(final Listener pluginListener, final EventExecutor eventExecutor, final Event.Priority eventPriority, final Plugin registeredPlugin ) {
+    public RegisteredListener(final Listener pluginListener, final EventExecutor eventExecutor, final Event.Priority eventPriority, final Plugin registeredPlugin, Event.Type eventType) {
         listener = pluginListener;
+        type = eventType;
         priority = eventPriority;
         plugin = registeredPlugin;
         executor = eventExecutor;
     }
 
-    public RegisteredListener(final Listener pluginListener, final Event.Priority eventPriority, final Plugin registeredPlugin, Event.Type type ) {
+    public RegisteredListener(final Listener pluginListener, final Event.Priority eventPriority, final Plugin registeredPlugin, Event.Type eventType ) {
         listener = pluginListener;
+        type = eventType;
         priority = eventPriority;
         plugin = registeredPlugin;
         executor = registeredPlugin.getPluginLoader().createExecutor( type, pluginListener );
@@ -42,6 +45,15 @@ public class RegisteredListener {
      */
     public Plugin getPlugin() {
         return plugin;
+    }
+
+    /**
+     * Get the type this listener is registered for
+     *
+     * @return Event.Type
+     */
+    public Event.Type getType() {
+        return type;
     }
 
     /**

--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -227,8 +227,10 @@ public final class SimplePluginManager implements PluginManager {
      * @param priority Priority of this event
      * @param plugin Plugin to register
      */
-    public void registerEvent(Event.Type type, Listener listener, Priority priority, Plugin plugin) {
-        getEventListeners( type ).offer(new RegisteredListener(listener, priority, plugin, type));
+    public RegisteredListener registerEvent(Event.Type type, Listener listener, Priority priority, Plugin plugin) {
+        RegisteredListener registeredListener = new RegisteredListener(listener, priority, plugin, type);
+        getEventListeners( type ).offer(registeredListener);
+        return registeredListener;
     }
 
     /**
@@ -240,9 +242,27 @@ public final class SimplePluginManager implements PluginManager {
      * @param priority Priority of this event
      * @param plugin Plugin to register
      */
-    public void registerEvent(Event.Type type, Listener listener, EventExecutor executor, Priority priority, Plugin plugin) {
-        getEventListeners( type ).offer(new RegisteredListener(listener, executor, priority, plugin));
+    public RegisteredListener registerEvent(Event.Type type, Listener listener, EventExecutor executor, Priority priority, Plugin plugin) {
+        RegisteredListener registeredListener = new RegisteredListener(listener, executor, priority, plugin, type);
+        getEventListeners( type ).offer(registeredListener);
+        return registeredListener;
     }
+
+    /**
+     * Unregisters the given registered listener (returned from registerEvent)
+     *
+     * @param registeredListener
+     */
+    public void unregisterEvent(RegisteredListener registeredListener) {
+        if (registeredListener != null) {
+            Event.Type type = registeredListener.getType();
+            PriorityQueue<RegisteredListener> eventListeners = listeners.get(type);
+            if (eventListeners.contains(registeredListener)) {
+                eventListeners.remove(registeredListener);
+            }
+        }
+    }
+
 
     /**
      * Returns a PriorityQueue of RegisteredListener for the specified event type creating a new queue if needed


### PR DESCRIPTION
Changes to PluginManager, SimplePluginManager, and RegisteredListener to support unregistering RegisteredListeners

This is for performance so that all listeners do not have to be registered all the time.
