### PR TITLE
"Fix" ugly equals methods and add a hashCode method

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We use maven to handle our dependencies.
 * Install [Maven 3](http://maven.apache.org/download.html)
 * Check out this repo and: `mvn clean install`
 
-Coding Conventions
+Coding and Pull Request Conventions
 -----------
 
 * We generally follow the Sun/Oracle coding standards.
@@ -19,5 +19,8 @@ Coding Conventions
 * No trailing whitespaces.
 * No 80 column limit or midstatement newlines.
 * Proper javadoc for each method added/changed to describe what it does.
+* The number of commits in a pull request should be kept to a minimum (squish them into one most of the time - use common sense!).
+* No merges should be included in pull requests unless the pull request's purpose is a merge.
+* Pull requests should be tested (does it compile? AND does it work?) before submission.
 
 Follow the above conventions if you want your pull requests accepted.

--- a/src/main/java/org/bukkit/Location.java
+++ b/src/main/java/org/bukkit/Location.java
@@ -52,7 +52,7 @@ public class Location implements Cloneable {
      * @return Block at the represented location
      */
     public Block getBlock() {
-        return world.getBlockAt(getBlockX(), getBlockY(), getBlockZ());
+        return world.getBlockAt(this);
     }
 
     /**

--- a/src/main/java/org/bukkit/Location.java
+++ b/src/main/java/org/bukkit/Location.java
@@ -175,6 +175,26 @@ public class Location implements Cloneable {
         return pitch;
     }
 
+    /**
+     * Gets a Vector pointing in the direction that this Location is facing
+     *
+     * @return Vector
+     */
+    public Vector getDirection() {
+        Vector vector = new Vector();
+
+        double rotX = this.getYaw();
+        double rotY = this.getPitch();
+
+        vector.setY(-Math.sin(Math.toRadians(rotY)));
+
+        double h = Math.cos(Math.toRadians(rotY));
+        vector.setX(-h*Math.sin(Math.toRadians(rotX)));
+        vector.setZ(h*Math.cos(Math.toRadians(rotX)));
+
+        return vector;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == null) {

--- a/src/main/java/org/bukkit/Location.java
+++ b/src/main/java/org/bukkit/Location.java
@@ -1,6 +1,7 @@
 
 package org.bukkit;
 
+import org.bukkit.block.Block;
 import org.bukkit.util.Vector;
 
 /**
@@ -43,6 +44,15 @@ public class Location implements Cloneable {
      */
     public World getWorld() {
         return world;
+    }
+
+    /**
+     * Gets the block at the represented location
+     *
+     * @return Block at the represented location
+     */
+    public Block getBlock() {
+        return world.getBlockAt(getBlockX(), getBlockY(), getBlockZ());
     }
 
     /**

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -34,6 +34,16 @@ public interface World {
      * @return Block at the given location
      */
     public Block getBlockAt(int x, int y, int z);
+    
+    /**
+     * Gets the block at the given location
+     *
+     * This block will always represent the latest state
+     *
+     * @param location Location of the block
+     * @return Block at the given location
+     */
+    public Block getBlockAt(Location location);
 
     /**
      * Gets the block type-id at the given location
@@ -46,12 +56,27 @@ public interface World {
     public int getBlockTypeIdAt(int x, int y, int z);
 
     /**
+     * Gets the block type-id at the given location
+     *
+     * @param location Location of the block
+     * @return TypeId of the block at the given location
+     */
+    public int getBlockTypeIdAt(Location location);
+
+    /**
      * Gets the highest non-air coordinate at the given (x,z) location
      * @param x X-coordinate of the blocks
      * @param z Z-coordinate of the blocks
      * @return Y-coordinate of the highest non-air block
      */
     public int getHighestBlockYAt(int x, int z);
+
+    /**
+     * Gets the highest non-air coordinate at the given location
+     * @param location Location of the blocks
+     * @return Y-coordinate of the highest non-air block
+     */
+    public int getHighestBlockYAt(Location location);
 
     /**
      * Gets the chunk at the given location
@@ -61,6 +86,14 @@ public interface World {
      * @return Chunk at the given location
      */
     public Chunk getChunkAt(int x, int z);
+
+    /**
+     * Gets the chunk at the given location
+     *
+     * @param location Location of the chunk
+     * @return Chunk at the given location
+     */
+    public Chunk getChunkAt(Location location);
 
     /**
      * Gets the chunk which contains the given block

--- a/src/main/java/org/bukkit/block/MobSpawner.java
+++ b/src/main/java/org/bukkit/block/MobSpawner.java
@@ -7,7 +7,7 @@ import org.bukkit.entity.MobType;
  * 
  * @author sk89q
  * 
- * @deprecated
+ * @deprecated Use CreatureSpawner instead.
  */
 public interface MobSpawner extends BlockState {
     /**

--- a/src/main/java/org/bukkit/command/CommandException.java
+++ b/src/main/java/org/bukkit/command/CommandException.java
@@ -1,0 +1,27 @@
+
+package org.bukkit.command;
+
+/**
+ * Thrown when an unhandled exception occurs during the execution of a Command
+ */
+public class CommandException extends RuntimeException {
+
+    /**
+     * Creates a new instance of <code>CommandException</code> without detail message.
+     */
+    public CommandException() {
+    }
+
+
+    /**
+     * Constructs an instance of <code>CommandException</code> with the specified detail message.
+     * @param msg the detail message.
+     */
+    public CommandException(String msg) {
+        super(msg);
+    }
+
+    public CommandException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/src/main/java/org/bukkit/command/CommandMap.java
+++ b/src/main/java/org/bukkit/command/CommandMap.java
@@ -1,7 +1,6 @@
 package org.bukkit.command;
 
 import java.util.List;
-import org.bukkit.entity.Player;
 
 public interface CommandMap {
     /**
@@ -19,10 +18,12 @@ public interface CommandMap {
      */
     public boolean register(String label, String fallbackPrefix, Command command);
 
-    /** Looks for the requested command and executes it if found.
+    /**
+     * Looks for the requested command and executes it if found.
      *
-     *   @param cmdLine command + arguments. Example: "/test abc 123"
-     *   @return targetFound returns false if no target is found.
+     * @param cmdLine command + arguments. Example: "/test abc 123"
+     * @return targetFound returns false if no target is found.
+     * @throws CommandException Thrown when the executor for the given command fails with an unhandled exception
      */
     public boolean dispatch(CommandSender sender, String cmdLine);
 

--- a/src/main/java/org/bukkit/command/PluginCommand.java
+++ b/src/main/java/org/bukkit/command/PluginCommand.java
@@ -16,7 +16,7 @@ public final class PluginCommand extends Command {
         boolean cmdSuccess = false;
         
         try {
-            owningPlugin.onCommand(sender, this, commandLabel, args);
+            cmdSuccess = owningPlugin.onCommand(sender, this, commandLabel, args);
         } catch (Throwable ex) {
             throw new CommandException("Unhandled exception executing command '" + commandLabel + "' in plugin " + owningPlugin.getDescription().getFullName(), ex);
         }

--- a/src/main/java/org/bukkit/command/PluginCommand.java
+++ b/src/main/java/org/bukkit/command/PluginCommand.java
@@ -1,7 +1,6 @@
 package org.bukkit.command;
 
 import org.bukkit.ChatColor;
-import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
 public final class PluginCommand extends Command {
@@ -14,7 +13,14 @@ public final class PluginCommand extends Command {
     }
 
     public boolean execute(CommandSender sender, String commandLabel, String[] args) {
-        boolean cmdSuccess = owningPlugin.onCommand(sender, this, commandLabel, args);
+        boolean cmdSuccess = false;
+        
+        try {
+            owningPlugin.onCommand(sender, this, commandLabel, args);
+        } catch (Throwable ex) {
+            throw new CommandException("Unhandled exception executing command '" + commandLabel + "' in plugin " + owningPlugin.getDescription().getFullName(), ex);
+        }
+
         if (!cmdSuccess && !usageMessage.isEmpty()) {
             String tmpMsg = usageMessage.replace("<command>", commandLabel);
             String[] usageLines = tmpMsg.split("\\n");

--- a/src/main/java/org/bukkit/command/SimpleCommandMap.java
+++ b/src/main/java/org/bukkit/command/SimpleCommandMap.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import org.bukkit.ChatColor;
 import org.bukkit.Server;
 
-import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginDescriptionFile;
 
@@ -74,7 +73,13 @@ public final class SimpleCommandMap implements CommandMap {
         Command target = knownCommands.get(sentCommandLabel);
         boolean isRegisteredCommand = (target != null);
         if (isRegisteredCommand) {
-            target.execute(sender, sentCommandLabel, args);
+            try {
+                target.execute(sender, sentCommandLabel, args);
+            } catch (CommandException ex) {
+                throw ex;
+            } catch (Throwable ex) {
+                throw new CommandException("Unhandled exception executing '" + commandLine + "' in " + target, ex);
+            }
         }
         return isRegisteredCommand;
     }

--- a/src/main/java/org/bukkit/entity/Entity.java
+++ b/src/main/java/org/bukkit/entity/Entity.java
@@ -42,4 +42,25 @@ public interface Entity {
      * @return Entity id
      */
     public int getEntityId();
+
+    /**
+     * Returns the entity's current fire ticks (ticks before the entity stops being on fire).
+     *
+     * @return int fireTicks
+     */
+    public int getFireTicks();
+
+    /**
+     * Returns the entity's maximum fire ticks.
+     *
+     * @return int maxFireTicks
+     */
+    public int getMaxFireTicks();
+
+    /**
+     * Sets the entity's current fire ticks (ticks before the entity stops being on fire).
+     *
+     * @param ticks
+     */
+    public void setFireTicks(int ticks);
 }

--- a/src/main/java/org/bukkit/entity/LivingEntity.java
+++ b/src/main/java/org/bukkit/entity/LivingEntity.java
@@ -1,23 +1,71 @@
 
 package org.bukkit.entity;
 
+import java.util.HashSet;
+import java.util.List;
+import org.bukkit.block.Block;
+
 /**
  * Represents a living entity, such as a monster or player
  */
 public interface LivingEntity extends Entity {
     /**
-     * Gets the entitys health from 0-20, where 0 is dead and 20 is full
+     * Gets the entity's health from 0-20, where 0 is dead and 20 is full
      *
      * @return Health represented from 0-20
      */
     public int getHealth();
 
     /**
-     * Sets the entitys health from 0-20, where 0 is dead and 20 is full
+     * Sets the entity's health from 0-20, where 0 is dead and 20 is full
      *
      * @param health New health represented from 0-20
      */
     public void setHealth(int health);
+
+    /**
+     * Gets the height of the entity's head above its Location
+     *
+     * @return Height of the entity's eyes above its Location
+     */
+    public double getEyeHeight();
+
+    /**
+     * Gets the height of the entity's head above its Location
+     *
+     * @param boolean If set to true, the effects of sneaking will be ignored
+     * @return Height of the entity's eyes above its Location
+     */
+    public double getEyeHeight(boolean ignoreSneaking);
+
+    /**
+     * Gets all blocks along the player's line of sight
+     * List iterates from player's position to target inclusive
+     *
+     * @param HashSet<Byte> HashSet containing all transparent block IDs. If set to null only air is considered transparent.
+     * @param int This is the maximum distance to scan. This may be further limited by the server, but never to less than 100 blocks.
+     * @return List containing all blocks along the player's line of sight
+     */
+    public List<Block> getLineOfSight(HashSet<Byte> transparent, int maxDistance);
+
+     /**
+     * Gets the block that the player has targeted
+     *
+     * @param HashSet<Byte> HashSet containing all transparent block IDs. If set to null only air is considered transparent.
+     * @param int This is the maximum distance to scan. This may be further limited by the server, but never to less than 100 blocks.
+     * @return Block that the player has targeted
+     */
+    public Block getTargetBlock(HashSet<Byte> transparent, int maxDistance);
+
+     /**
+     * Gets the last two blocks along the player's line of sight.
+     * The target block will be the last block in the list.
+     *
+     * @param HashSet<Byte> HashSet containing all transparent block IDs. If set to null only air is considered transparent.
+     * @param int This is the maximum distance to scan. This may be further limited by the server, but never to less than 100 blocks
+     * @return List containing the last 2 blocks along the player's line of sight
+     */
+    public List<Block> getLastTwoTargetBlocks(HashSet<Byte> transparent, int maxDistance);
 
     /**
      * Throws an egg from the entity.

--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -484,28 +484,6 @@ public abstract class Event {
         CREATURE_SPAWN (Category.LIVING_ENTITY),
 
         /**
-         * Called when a LivingEntity is damaged by the environment (for example,
-         * falling or lava)
-         *
-         * @see org.bukkit.event.entity.EntityDamageByBlockEvent
-         */
-        ENTITY_DAMAGEDBY_BLOCK (Category.LIVING_ENTITY),
-
-        /**
-         * Called when a LivingEntity is damaged by another LivingEntity
-         *
-         * @see org.bukkit.event.entity.EntityDamageByEntityEvent
-         */
-        ENTITY_DAMAGEDBY_ENTITY (Category.LIVING_ENTITY),
-
-        /**
-         * Called when a LivingEntity is damaged by a projectile Entity
-         *
-         * @see org.bukkit.event.entity.EntityDamageByProjectileEvent
-         */
-        ENTITY_DAMAGEDBY_PROJECTILE (Category.LIVING_ENTITY),
-
-        /**
          * Called when a LivingEntity is damaged with no source.
          *
          * @see org.bukkit.event.entity.EntityDamageEvent

--- a/src/main/java/org/bukkit/event/entity/EntityDamageByBlockEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDamageByBlockEvent.java
@@ -14,7 +14,7 @@ public class EntityDamageByBlockEvent extends EntityDamageEvent implements Cance
 
     public EntityDamageByBlockEvent(Block damager, Entity damagee, DamageCause cause, int damage)
     {
-        super(Event.Type.ENTITY_DAMAGEDBY_BLOCK, damagee, cause, damage);
+        super(Event.Type.ENTITY_DAMAGED, damagee, cause, damage);
         this.damager = damager;
     }
 

--- a/src/main/java/org/bukkit/event/entity/EntityDamageByEntityEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDamageByEntityEvent.java
@@ -13,7 +13,7 @@ public class EntityDamageByEntityEvent extends EntityDamageEvent implements Canc
 
     public EntityDamageByEntityEvent(Entity damager, Entity damagee, DamageCause cause, int damage)
     {
-        super(Event.Type.ENTITY_DAMAGEDBY_ENTITY, damagee, cause, damage);
+        super(Event.Type.ENTITY_DAMAGED, damagee, cause, damage);
         this.damager = damager;
     }
 

--- a/src/main/java/org/bukkit/event/entity/EntityDamageByProjectileEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDamageByProjectileEvent.java
@@ -11,7 +11,7 @@ public class EntityDamageByProjectileEvent extends EntityDamageByEntityEvent {
     private boolean bounce;
 
     public EntityDamageByProjectileEvent(Entity damager, Entity damagee, Entity projectile, DamageCause cause, int damage) {
-        super(Event.Type.ENTITY_DAMAGEDBY_PROJECTILE, damager, damagee, cause, damage);
+        super(Event.Type.ENTITY_DAMAGED, damager, damagee, cause, damage);
         this.projectile = projectile;
         Random random = new Random();
         this.bounce = random.nextBoolean();

--- a/src/main/java/org/bukkit/event/entity/EntityListener.java
+++ b/src/main/java/org/bukkit/event/entity/EntityListener.java
@@ -12,15 +12,6 @@ public class EntityListener implements Listener {
     public void onCreatureSpawn(CreatureSpawnEvent event) {
     }
 
-    public void onEntityDamageByBlock(EntityDamageByBlockEvent event) {
-    }
-
-    public void onEntityDamageByEntity(EntityDamageByEntityEvent event) {
-    }
-
-    public void onEntityDamageByProjectile(EntityDamageByProjectileEvent event) {
-    }
-
     public void onEntityCombust(EntityCombustEvent event) {
     }
 

--- a/src/main/java/org/bukkit/event/player/PlayerEggThrowEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerEggThrowEvent.java
@@ -84,7 +84,7 @@ public class PlayerEggThrowEvent extends PlayerEvent {
      *
      * @param hatchType The type of the mob being hatched by the egg
      * 
-     * @deprecated
+     * @deprecated Use setHatchType(CreatureType hatchType) instead.
      */
     public void setHatchType(MobType hatchType) {
         this.hatchType = CreatureType.fromName(hatchType.getName());

--- a/src/main/java/org/bukkit/inventory/ItemStack.java
+++ b/src/main/java/org/bukkit/inventory/ItemStack.java
@@ -1,4 +1,3 @@
-
 package org.bukkit.inventory;
 
 import org.bukkit.Material;
@@ -89,7 +88,7 @@ public class ItemStack {
      */
     public void setTypeId(int type) {
         this.type = type;
-        createData((byte)0);
+        createData((byte) 0);
     }
 
     /**
@@ -160,7 +159,7 @@ public class ItemStack {
     /**
      * Get the maximum stacksize for the material hold in this ItemStack
      * Returns -1 if it has no idea.
-     * 
+     *
      * @return The maximum you can stack this material to.
      */
     public int getMaxStackSize() {
@@ -178,15 +177,28 @@ public class ItemStack {
 
     @Override
     public String toString() {
-        return "ItemStack{"+getType().name()+" x "+getAmount()+"}";
+        return "ItemStack{" + getType().name() + " x " + getAmount() + "}";
     }
 
     @Override
-    public boolean equals(Object object) {
-        return false;
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + amount;
+        result = prime * result + type;
+        return result;
     }
 
-    public boolean equals(ItemStack item) {
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ItemStack)) {
+            return false;
+        }
+        ItemStack item = (ItemStack) obj;
         return item.getAmount() == getAmount() && item.getTypeId() == getTypeId();
     }
+
 }

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -313,21 +313,6 @@ public final class JavaPluginLoader implements PluginLoader {
             };
 
         // Entity Events
-        case ENTITY_DAMAGEDBY_BLOCK:
-            return new EventExecutor() { public void execute( Listener listener, Event event ) {
-                    ((EntityListener)listener).onEntityDamageByBlock( (EntityDamageByBlockEvent)event );
-                }
-            };
-        case ENTITY_DAMAGEDBY_ENTITY:
-            return new EventExecutor() { public void execute( Listener listener, Event event ) {
-                    ((EntityListener)listener).onEntityDamageByEntity( (EntityDamageByEntityEvent)event );
-                }
-            };
-        case ENTITY_DAMAGEDBY_PROJECTILE:
-            return new EventExecutor() { public void execute( Listener listener, Event event ) {
-                    ((EntityListener)listener).onEntityDamageByProjectile( (EntityDamageByProjectileEvent)event );
-                }
-            };
         case ENTITY_DAMAGED:
             return new EventExecutor() { public void execute( Listener listener, Event event ) {
                     ((EntityListener)listener).onEntityDamage( (EntityDamageEvent)event );

--- a/src/main/java/org/bukkit/util/BlockIterator.java
+++ b/src/main/java/org/bukkit/util/BlockIterator.java
@@ -1,0 +1,372 @@
+package org.bukkit.util;
+
+import org.bukkit.World;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.LivingEntity;
+
+import java.util.Iterator;
+import java.util.ArrayList;
+import java.util.NoSuchElementException;
+import java.lang.IllegalStateException;
+import java.lang.Exception;
+
+/**
+ * This class performs ray tracing and iterates along blocks on a line
+ *
+ * @author raphfrk
+ */
+
+public class BlockIterator implements Iterator<Block> {
+
+    private final World  world;
+    private final int    maxDistance;
+
+    private final int    gridSize = 1<<24;
+
+    private boolean      end = false;
+
+    private Block[]      blockQueue = new Block[3];
+    private int          currentBlock = 0;
+    private int          currentDistance = 0;
+    private int          maxDistanceInt;
+
+    private int          secondError;
+    private int          thirdError;
+
+    private int          secondStep;
+    private int          thirdStep;
+
+    private BlockFace    mainFace;
+    private BlockFace    secondFace;
+    private BlockFace    thirdFace;
+
+    /**
+     * Constructs the BlockIterator
+     *
+     * @param world The world to use for tracing
+     * @param start A Vector giving the initial location for the trace
+     * @param direction A Vector pointing in the direction for the trace
+     * @param yOffset The trace begins vertically offset from the start vector by this value
+     * @param maxDistance This is the maximum distance in blocks for the trace. Setting this value above 140 may lead to problems with unloaded chunks. A value of 0 indicates no limit
+     *
+     */
+
+    public BlockIterator(World world, Vector start, Vector direction, double yOffset, int maxDistance) {
+        this.world = world;
+        this.maxDistance = maxDistance;
+
+        Vector startClone = start.clone();
+        startClone.setY(startClone.getY( )+ yOffset);
+
+        currentDistance = 0;
+
+        double mainDirection   = 0;
+        double secondDirection = 0;
+        double thirdDirection  = 0;
+
+        double mainPosition    = 0;
+        double secondPosition  = 0;
+        double thirdPosition   = 0;
+
+        Block startBlock = world.getBlockAt((int)Math.floor(startClone.getX()), (int)Math.floor(startClone.getY()), (int)Math.floor(startClone.getZ()));
+
+        if (getXLength(direction) > mainDirection) {
+            mainFace        = getXFace(direction);
+            mainDirection   = getXLength(direction);
+            mainPosition    = getXPosition(direction, startClone, startBlock);
+
+            secondFace      = getYFace(direction);
+            secondDirection = getYLength(direction);
+            secondPosition  = getYPosition(direction, startClone, startBlock);
+
+            thirdFace       = getZFace(direction);
+            thirdDirection  = getZLength(direction);
+            thirdPosition   = getZPosition(direction, startClone, startBlock);
+        }
+        if (getYLength(direction) > mainDirection) {
+            mainFace        = getYFace(direction);
+            mainDirection   = getYLength(direction);
+            mainPosition    = getYPosition(direction, startClone, startBlock);
+
+            secondFace      = getZFace(direction);
+            secondDirection = getZLength(direction);
+            secondPosition  = getZPosition(direction, startClone, startBlock);
+
+            thirdFace       = getXFace(direction);
+            thirdDirection  = getXLength(direction);
+            thirdPosition   = getXPosition(direction, startClone, startBlock);
+        }
+        if (getZLength(direction) > mainDirection) {
+            mainFace        = getZFace(direction);
+            mainDirection   = getZLength(direction);
+            mainPosition    = getZPosition(direction, startClone, startBlock);
+
+            secondFace      = getXFace(direction);
+            secondDirection = getXLength(direction);
+            secondPosition  = getXPosition(direction, startClone, startBlock);
+
+            thirdFace       = getYFace(direction);
+            thirdDirection  = getYLength(direction);
+            thirdPosition   = getYPosition(direction, startClone, startBlock);
+        }
+
+        // trace line backwards to find intercept with plane perpendicular to the main axis
+
+        double d = mainPosition/mainDirection; // how far to hit face behind
+        double secondd = secondPosition - secondDirection*d;
+        double thirdd  = thirdPosition - thirdDirection*d;
+
+        secondError = (int)(Math.floor(secondd*gridSize));
+        secondStep = (int)(Math.round(secondDirection/mainDirection*gridSize));
+        thirdError = (int)(Math.floor(thirdd*gridSize));
+        thirdStep = (int)(Math.round(thirdDirection/mainDirection*gridSize));
+
+        // Guarantee that the ray will pass though the start block.
+        // It is possible that it would miss due to rounding
+        // This should only move the ray by 1 grid position
+
+        if (secondError + secondStep <= 0) {
+            secondError = -secondStep + 1;
+        }
+
+        if (thirdError + thirdStep <= 0) {
+            thirdError = -thirdStep + 1;
+        }
+
+        Block lastBlock;
+        lastBlock = startBlock.getFace(reverseFace(mainFace));
+
+        if (secondError < 0) {
+            secondError += gridSize;
+            lastBlock = lastBlock.getFace(reverseFace(secondFace));
+        }
+
+        if (thirdError < 0) {
+            thirdError += gridSize;
+            lastBlock = lastBlock.getFace(reverseFace(thirdFace));
+        }
+
+        // This means that when the variables are positive, it means that the coord=1 boundary has been crossed
+        secondError -= gridSize;
+        thirdError -= gridSize;
+
+        blockQueue[0] = lastBlock;
+        currentBlock = -1;
+
+        scan();
+
+        boolean startBlockFound = false;
+
+        for (int cnt=currentBlock; cnt>=0; cnt--) {
+            if (blockEquals(blockQueue[cnt], startBlock)) {
+                currentBlock = cnt;
+                startBlockFound = true;
+                break;
+            }
+        }
+
+        if (!startBlockFound) {
+            throw new IllegalStateException("Start block missed in BlockIterator");
+        }
+
+        // Calculate the number of planes passed to give max distance
+        maxDistanceInt = (int)Math.round(maxDistance/(Math.sqrt(mainDirection*mainDirection + secondDirection*secondDirection + thirdDirection*thirdDirection)/mainDirection));
+
+    }
+
+    private boolean blockEquals(Block a, Block b) {
+        return a.getX() == b.getX() && a.getY() == b.getY() && a.getZ() == b.getZ();
+    }
+
+    private BlockFace reverseFace(BlockFace face) {
+        switch(face) {
+            case UP:     return BlockFace.DOWN;
+            case DOWN:   return BlockFace.UP;
+            case NORTH:  return BlockFace.SOUTH;
+            case SOUTH:  return BlockFace.NORTH;
+            case EAST:   return BlockFace.WEST;
+            case WEST:   return BlockFace.EAST;
+            default:     return null;
+        }
+    }
+
+    private BlockFace getXFace(Vector direction) {
+        return ((direction.getX() > 0) ? BlockFace.SOUTH : BlockFace.NORTH);
+    }
+
+    private BlockFace getYFace(Vector direction) {
+        return ((direction.getY() > 0) ? BlockFace.UP : BlockFace.DOWN);
+    }
+
+    private BlockFace getZFace(Vector direction) {
+        return ((direction.getZ() > 0) ? BlockFace.WEST : BlockFace.EAST);
+    }
+
+    private double getXLength(Vector direction) {
+        return(Math.abs(direction.getX()));
+    }
+
+    private double getYLength(Vector direction) {
+        return(Math.abs(direction.getY()));
+    }
+
+    private double getZLength(Vector direction) {
+        return(Math.abs(direction.getZ()));
+    }
+
+    private double getPosition(double direction, double position, int blockPosition) {
+        return direction > 0 ? (position-blockPosition) : (blockPosition + 1 - position);
+    }
+
+    private double getXPosition(Vector direction, Vector position, Block block) {
+        return getPosition(direction.getX(), position.getX(), block.getX());
+    }
+
+    private double getYPosition(Vector direction, Vector position, Block block) {
+        return getPosition(direction.getY(), position.getY(), block.getY());
+    }
+
+    private double getZPosition(Vector direction, Vector position, Block block) {
+        return getPosition(direction.getZ(), position.getZ(), block.getZ());
+    }
+
+    /**
+     * Constructs the BlockIterator
+     *
+     * @param loc The location for the start of the ray trace
+     * @param yOffset The trace begins vertically offset from the start vector by this value
+     * @param maxDistance This is the maximum distance in blocks for the trace. Setting this value above 140 may lead to problems with unloaded chunks. A value of 0 indicates no limit
+     *
+     */
+
+    public BlockIterator(Location loc, double yOffset, int maxDistance) {
+        this(loc.getWorld(), loc.toVector(), loc.getDirection(), yOffset, maxDistance);
+    }
+
+    /**
+     * Constructs the BlockIterator.
+     *
+     * @param loc The location for the start of the ray trace
+     * @param yOffset The trace begins vertically offset from the start vector by this value
+     *
+     */
+
+    public BlockIterator(Location loc, double yOffset) {
+        this(loc.getWorld(), loc.toVector(), loc.getDirection(), yOffset, 0);
+    }
+
+    /**
+     * Constructs the BlockIterator.
+     *
+     * @param loc The location for the start of the ray trace
+     *
+     */
+
+    public BlockIterator(Location loc) {
+        this(loc, 0D);
+    }
+
+    /**
+     * Constructs the BlockIterator.
+     *
+     * @param entity Information from the entity is used to set up the trace
+     * @param maxDistance  This is the maximum distance in blocks for the trace. Setting this value above 140 may lead to problems with unloaded chunks. A value of 0 indicates no limit
+     *
+     */
+
+    public BlockIterator(LivingEntity entity, int maxDistance) {
+        this(entity.getLocation(), entity.getEyeHeight(), maxDistance);
+    }
+
+
+    /**
+     * Constructs the BlockIterator.
+     *
+     * @param entity Information from the entity is used to set up the trace
+     *
+     */
+
+    public BlockIterator(LivingEntity entity) {
+        this(entity, 0);
+    }
+
+    /**
+     * Returns true if the iteration has more elements
+     *
+     */
+
+    public boolean hasNext() {
+        scan();
+        return currentBlock != -1;
+    }
+
+   /**
+     * Returns the next Block in the trace
+     *
+     * @return the next Block in the trace
+     */
+
+    public Block next() {
+        scan();
+        if (currentBlock <= -1) {
+            throw new NoSuchElementException();
+        } else {
+             return blockQueue[currentBlock--];
+        }
+    }
+
+    public void remove() {
+        throw new UnsupportedOperationException("[BlockIterator] doesn't support block removal");
+    }
+
+    private void scan() {
+        if (currentBlock >= 0) {
+            return;
+        }
+        if (maxDistance != 0 && currentDistance > maxDistanceInt) {
+            end = true;
+            return;
+        }
+        if (end) {
+            return;
+        }
+
+        currentDistance++;
+
+        secondError += secondStep;
+        thirdError += thirdStep;
+
+        if (secondError > 0 && thirdError > 0) {
+            blockQueue[2] = blockQueue[0].getFace(mainFace);
+            if (((long)secondStep) * ((long)thirdError) < ((long)thirdStep) * ((long)secondError)) {
+                blockQueue[1] = blockQueue[2].getFace(secondFace);
+                blockQueue[0] = blockQueue[1].getFace(thirdFace);
+            } else {
+                blockQueue[1] = blockQueue[2].getFace(thirdFace);
+                blockQueue[0] = blockQueue[1].getFace(secondFace);
+            }
+            thirdError -= gridSize;
+            secondError -= gridSize;
+            currentBlock = 2;
+            return;
+        } else if (secondError > 0) {
+            blockQueue[1] = blockQueue[0].getFace(mainFace);
+            blockQueue[0] = blockQueue[1].getFace(secondFace);
+            secondError -= gridSize;
+            currentBlock = 1;
+            return;
+        } else if (thirdError > 0) {
+            blockQueue[1] = blockQueue[0].getFace(mainFace);
+            blockQueue[0] = blockQueue[1].getFace(thirdFace);
+            thirdError -= gridSize;
+            currentBlock = 1;
+            return;
+        } else {
+            blockQueue[0] = blockQueue[0].getFace(mainFace);
+            currentBlock = 0;
+            return;
+        }
+    }
+}

--- a/src/main/java/org/bukkit/util/Vector.java
+++ b/src/main/java/org/bukkit/util/Vector.java
@@ -127,6 +127,19 @@ public class Vector implements Cloneable {
     }
 
     /**
+     * Copies another vector
+     *
+     * @param vec
+     * @return the same vector
+     */
+    public Vector copy(Vector vec) {
+        x = vec.x;
+        y = vec.y;
+        z = vec.z;
+        return this;
+    }
+
+    /**
      * Gets the magnitude of the vector, defined as sqrt(x^2+y^2+z^2). The value
      * of this method is not cached and uses a costly square-root function, so
      * do not repeatedly call this method to get the vector's magnitude. NaN


### PR DESCRIPTION
I "rewrite" (well Eclipse rewrites :p) equals methods, I think it very ugly (Why equals(Object) always return false? Why a equals(ItemStack)?)
I add a hashCode method also.
