### PR TITLE
Adds Individualised Listener Queues for Custom Events

### DIFF
--- a/src/main/java/org/bukkit/event/CustomEventListener.java
+++ b/src/main/java/org/bukkit/event/CustomEventListener.java
@@ -10,7 +10,7 @@ public class CustomEventListener implements Listener {
     }
 
     /**
-     * Called when a player joins a server
+     * Called when a custom event is called
      *
      * @param event Relevant event details
      */

--- a/src/main/java/org/bukkit/plugin/PluginManager.java
+++ b/src/main/java/org/bukkit/plugin/PluginManager.java
@@ -104,6 +104,26 @@ public interface PluginManager {
     public void registerEvent(Event.Type type, Listener listener, Priority priority, Plugin plugin);
 
     /**
+     * Registers the given event to the specified listener using a custom event name
+     *
+     * @param eventName Name of event to register
+     * @param listener PlayerListener to register
+     * @param priority Priority of this event
+     * @param plugin Plugin to register
+     */
+    public void registerEvent(String eventName, Listener listener, Priority priority, Plugin plugin);
+
+    /**
+     * Registers the given event to the specified listener using a custom event id number
+     *
+     * @param id Event id to register
+     * @param listener PlayerListener to register
+     * @param priority Priority of this event
+     * @param plugin Plugin to register
+     */
+    public void registerEvent(int id, Listener listener, Priority priority, Plugin plugin);
+
+    /**
      * Registers the given event to the specified executor
      *
      * @param type EventType to register
@@ -113,6 +133,28 @@ public interface PluginManager {
      * @param plugin Plugin to register
      */
     public void registerEvent(Event.Type type, Listener listener, EventExecutor executor, Priority priority, Plugin plugin);
+
+    /**
+     * Registers the given event to the specified listener using a directly passed EventExecutor and a custom event name
+     *
+     * @param eventName Name of event to register
+     * @param listener PlayerListener to register
+     * @param executor EventExecutor to register
+     * @param priority Priority of this event
+     * @param plugin Plugin to register
+     */
+    public void registerEvent(String eventName, Listener listener, EventExecutor executor, Priority priority, Plugin plugin);
+
+    /**
+     * Registers the given event to the specified listener using a directly passed EventExecutor and a custom event id number
+     *
+     * @param int Event id to register
+     * @param listener PlayerListener to register
+     * @param executor EventExecutor to register
+     * @param priority Priority of this event
+     * @param plugin Plugin to register
+     */
+    public void registerEvent(int id, Listener listener, EventExecutor executor, Priority priority, Plugin plugin);
 
     /**
      * Enables the specified plugin


### PR DESCRIPTION
Currently, all custom events trigger the same custom event method and the individual plugins have to discard events that they aren't interested in.

This pull adds the ability to register individual events for callback without the plugin having to receive all custom events.

The current "broadcast" custom events can still be used, if required.

Each custom event type is identified by name.  Each name is matched to a particular integer id number.

The events are still all passed to the onCustomEvent method.  However, each custom event also has an enum as a type.  This allows a case statement to be used by listeners to separate out the custom events that they receive.  

When creating custom events of a particular type, this name can be used (slower) or the id to create the event.  

Only plugins which have registered to receive that particular event will be sent the event.

For example (might contain slight typos, but should essentially work), 
## Registration

```
 int customEventId1 = Event.getNameId("This is the first custom event");
 pm.registerEvent(customEventId1, customListener, Priority.Normal, this);

 pm.registerEvent("This is the second custom event", customListener, Priority.Normal, this);
```
## Event Class

```
private class SyncCustomEvent extends Event {

    enum CustomEnum {

        FIRST, SECOND, THIRD

    }

    SyncCustomEvent(CustomEnum type, String name) {
        super(type, name);
    }

    SyncCustomEvent(CustomEnum type, int id) {
        super(type, id);
    }

}
```
## Listener

```
 public class SyncTestCustomListener extends CustomEventListener {

     final SyncTest p;

     final Server server;

     public SyncTestCustomListener ( SyncTest plugin , Server server ) {
         p = plugin;
         this.server = server;
     };

     public void onCustomEvent(Event event) {
         switch((CustomEnum)event.getCustomType()) {

         case FIRST: System.out.println("FIRST"); break;

         case SECOND: System.out.println("SECOND"); break;

         default: System.out.println("UNKNOWN"); break;
     }

 }
```
## Calling the events

```
 SyncCustomEvent firstEvent = new SyncCustomEvent(SyncCustomEvent.CustomEnum.FIRST , "This is the first custom event");
 SyncCustomEvent secondEvent = new SyncCustomEvent(SyncCustomEvent.CustomEnum.SECOND , "This is the second custom event");

 p.getServer().getPluginManager().callEvent(firstEvent);
 p.getServer().getPluginManager().callEvent(secondEvent);
```
