### PR TITLE
Added cuboid block write method

### DIFF
--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -3,6 +3,7 @@ package org.bukkit;
 
 import java.util.List;
 import org.bukkit.block.Block;
+import org.bukkit.Chunk;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 import org.bukkit.entity.Creature;
@@ -23,6 +24,39 @@ import org.bukkit.entity.Boat;
  * may change with the addition of a functional Nether world
  */
 public interface World {
+
+     /**
+     * Sets a cuboid area with data from 2 arrays.
+     *
+     * The arrays are arranged array[X][Z][Y].  A value of -1 means skip that block.
+     *
+     * @param chunk Chunk containing the blocks to update
+     * @param x X-coordinate of the block with lowest X in the cuboid
+     * @param y Y-coordinate of the block with lowest Y in the cuboid
+     * @param z Z-coordinate of the block with lowest Z in the cuboid
+     * @param type Array containing the type-id information for the blocks
+     * @param data Array containing the data information for the blocks (null means ignore)
+     * @return Returns true if there was no errors when updating the blocks
+     */
+    public boolean setBlockCuboid(int x, int y, int z, int[][][] type, int[][][] data);
+
+     /**
+     * Sets a cuboid area with data from 2 arrays.  The cuboid is restricted to a single Chunk
+     *
+     * Any volume of the cuboid outside the chunk is completely ignored
+     *
+     * The arrays are arranged array[X][Z][Y].  A value of -1 means skip that block.
+     *
+     * @param chunk Chunk containing the blocks to update
+     * @param x X-coordinate of the block with lowest X in the cuboid
+     * @param y Y-coordinate of the block with lowest Y in the cuboid
+     * @param z Z-coordinate of the block with lowest Z in the cuboid
+     * @param type Array containing the type-id information for the blocks
+     * @param data Array containing the data information for the blocks (null means ignore)
+     * @return Returns true if there was no errors when updating the blocks
+     */
+    public boolean setBlockCuboidChunk(Chunk chunk, int x, int y, int z, int[][][] type, int[][][] data);
+
     /**
      * Gets the block at the given location
      *


### PR DESCRIPTION
This pull adds two methods to allow writing of cuboids of blocks to a world.

There is a corresponding CraftBukkit pull.
https://github.com/Bukkit/CraftBukkit/pull/137

This removes the need to write each individual block one block at a time.  The methods take two 3-d arrays as parameters (id and data (data can be set to null)) and an x, y, z location.

One method writes to a single Chunk, while the second one can write a cuboid which covers many chunks.

The second method calls the first.  This means that all writes occur chunk by chunk.  This allows the compressed packet to be used to send the data to clients.  

I ran a test with a 21x21x32 cuboid (height 96 to 127) and the writes are about 30% faster using this method than with the standard methods and there should be a network bandwidth advantage since it should result in compressed packets being used.
