### PR TITLE
Implemented Painting events

### DIFF
--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -96,6 +96,11 @@ public abstract class Event {
         BLOCK,
 
         /**
+         * Represents Entity-based events
+         */
+        ENTITY,
+
+        /**
          * Represents LivingEntity-based events
          */
         LIVING_ENTITY,
@@ -477,6 +482,24 @@ public abstract class Event {
          * Called when a World is loaded
          */
         WORLD_LOADED (Category.WORLD),
+
+        /**
+         * ENTITY EVENTS
+         */
+
+        /**
+         * Called when a painting is placed by player
+         *
+         * @see org.bukkit.event.painting.PaintingCreateEvent
+         */
+        PAINTING_CREATE (Category.ENTITY),
+
+        /**
+         * Called when a painting is removed
+         *
+         * @see org.bukkit.event.painting.PaintingRemoveEvent
+         */
+        PAINTING_REMOVE(Category.ENTITY),
 
         /**
          * LIVING_ENTITY EVENTS

--- a/src/main/java/org/bukkit/event/entity/EntityListener.java
+++ b/src/main/java/org/bukkit/event/entity/EntityListener.java
@@ -1,6 +1,9 @@
 package org.bukkit.event.entity;
 
 import org.bukkit.event.Listener;
+import org.bukkit.event.painting.PaintingCreateEvent;
+import org.bukkit.event.painting.PaintingPlaceEvent;
+import org.bukkit.event.painting.PaintingRemoveEvent;
 
 /**
  * Handles all events fired in relation to entities
@@ -29,4 +32,11 @@ public class EntityListener implements Listener {
 
     public void onEntityTarget(EntityTargetEvent event) {
     }
+
+    public void onPaintingCreate(PaintingCreateEvent event) {
+    }
+
+    public void onPaintingRemove(PaintingRemoveEvent event) {
+    }
+
 }

--- a/src/main/java/org/bukkit/event/painting/PaintingCreateEvent.java
+++ b/src/main/java/org/bukkit/event/painting/PaintingCreateEvent.java
@@ -1,0 +1,65 @@
+package org.bukkit.event.painting;
+
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Painting;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+
+/**
+ * Triggered when a painting is created in the world
+ *
+ * @author Tanel Suurhans
+ */
+public class PaintingCreateEvent extends PaintingEvent implements Cancellable {
+
+    private boolean cancelled;
+
+    private Player player;
+    private Block block;
+    private BlockFace blockFace;
+
+    public PaintingCreateEvent(final Event.Type type, final Painting painting, final Player player, Block block, BlockFace blockFace) {
+        super(type, painting);
+        this.player = player;
+        this.block = block;
+        this.blockFace = blockFace;
+    }
+
+    /**
+     * Returns the player placing the painting
+     *
+     * @return Entity returns the player placing the painting
+     */
+    public Player getPlayer() {
+        return player;
+    }
+
+    /**
+     * Returns the block painting placed on
+     *
+     * @return Block returns the block painting placed on
+     */
+    public Block getBlock() {
+        return block;
+    }
+
+    /**
+     * Returns the face of the block that the painting was placed on
+     *
+     * @return BlockFace returns the face of the block the painting was placed on
+     */
+    public BlockFace getBlockFace() {
+        return blockFace;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+}

--- a/src/main/java/org/bukkit/event/painting/PaintingEvent.java
+++ b/src/main/java/org/bukkit/event/painting/PaintingEvent.java
@@ -1,0 +1,29 @@
+package org.bukkit.event.painting;
+
+import org.bukkit.entity.Painting;
+import org.bukkit.event.Event;
+
+/**
+ * Represents a painting-related event.
+ *
+ * @author Tanel Suurhans
+ */
+public class PaintingEvent extends Event {
+
+    protected Painting painting;
+
+    protected PaintingEvent(final Type type, final Painting painting) {
+        super(type);
+        this.painting = painting;
+    }
+
+    /**
+     * Get the painting.
+     *
+     * @return the painting
+     */
+    public Painting getPainting() {
+        return painting;
+    }
+
+}

--- a/src/main/java/org/bukkit/event/painting/PaintingPlaceEvent.java
+++ b/src/main/java/org/bukkit/event/painting/PaintingPlaceEvent.java
@@ -1,0 +1,33 @@
+package org.bukkit.event.painting;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Painting;
+import org.bukkit.event.Cancellable;
+
+/**
+ * Triggered when a painting is placed by an entity
+ *
+ * @author Tanel Suurhans
+ */
+public class PaintingPlaceEvent extends PaintingEvent implements Cancellable {
+
+    private boolean cancel;
+    private Entity placer;
+
+    public PaintingPlaceEvent(final Type type, final Painting painting, final Entity entity) {
+        super(type, painting);
+        this.placer = entity;
+    }
+
+    public Entity getPlacer() {
+        return placer;
+    }
+
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+}

--- a/src/main/java/org/bukkit/event/painting/PaintingRemoveByEntityEvent.java
+++ b/src/main/java/org/bukkit/event/painting/PaintingRemoveByEntityEvent.java
@@ -1,0 +1,24 @@
+package org.bukkit.event.painting;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Painting;
+
+/**
+ * Triggered when a painting is removed by an entity
+ *
+ * @author Tanel Suurhans
+ */
+public class PaintingRemoveByEntityEvent extends PaintingRemoveEvent {
+
+    private Entity remover;
+
+    public PaintingRemoveByEntityEvent(final Painting painting, final Entity remover) {
+        super(painting, RemoveCause.ENTITY);
+        this.remover = remover;
+    }
+
+    public Entity getRemover() {
+        return remover;
+    }
+
+}

--- a/src/main/java/org/bukkit/event/painting/PaintingRemoveByWorldEvent.java
+++ b/src/main/java/org/bukkit/event/painting/PaintingRemoveByWorldEvent.java
@@ -1,0 +1,16 @@
+package org.bukkit.event.painting;
+
+import org.bukkit.entity.Painting;
+
+/**
+ * Triggered when a painting is removed by the world (water flowing over it, block damaged behind it)
+ *
+ * @author Tanel Suurhans
+ */
+public class PaintingRemoveByWorldEvent extends PaintingRemoveEvent {
+
+    public PaintingRemoveByWorldEvent(final Painting painting) {
+        super(painting, RemoveCause.WORLD);
+    }
+
+}

--- a/src/main/java/org/bukkit/event/painting/PaintingRemoveEvent.java
+++ b/src/main/java/org/bukkit/event/painting/PaintingRemoveEvent.java
@@ -1,0 +1,51 @@
+package org.bukkit.event.painting;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Painting;
+import org.bukkit.event.Cancellable;
+
+/**
+ * Triggered when a painting is removed
+ *
+ * @author Tanel Suurhans
+ */
+public class PaintingRemoveEvent extends PaintingEvent implements Cancellable {
+
+    private boolean cancelled;
+    private RemoveCause cause;
+
+    public PaintingRemoveEvent(final Painting painting, RemoveCause cause) {
+        super(Type.PAINTING_REMOVE, painting);
+        this.cause = cause;
+    }
+
+    public RemoveCause getCause(){
+        return cause;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    /**
+     * An enum to specify the cause of the removal
+     */
+    public enum RemoveCause {
+
+        /**
+         * Removed by an entity
+         */
+        ENTITY,
+
+        /**
+         * Removed by the world - block destroyed behind, water flowing over etc
+         */
+        WORLD
+
+    }
+
+}

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -18,6 +18,9 @@ import org.bukkit.event.Event;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.*;
 import org.bukkit.event.entity.*;
+import org.bukkit.event.painting.PaintingCreateEvent;
+import org.bukkit.event.painting.PaintingPlaceEvent;
+import org.bukkit.event.painting.PaintingRemoveEvent;
 import org.bukkit.event.player.*;
 import org.bukkit.event.server.*;
 import org.bukkit.event.vehicle.*;
@@ -320,6 +323,19 @@ public final class JavaPluginLoader implements PluginLoader {
         case WORLD_LOADED:
             return new EventExecutor() { public void execute( Listener listener, Event event ) {
                     ((WorldListener)listener).onWorldLoaded( (WorldEvent)event );
+                }
+            };
+
+        // Painting Events
+        case PAINTING_CREATE:
+            return new EventExecutor() { public void execute(Listener listener, Event event) {
+                    ((EntityListener)listener).onPaintingCreate((PaintingCreateEvent) event);
+                }
+            };
+
+        case PAINTING_REMOVE:
+            return new EventExecutor() { public void execute(Listener listener, Event event) {
+                    ((EntityListener)listener).onPaintingRemove((PaintingRemoveEvent) event);
                 }
             };
 


### PR DESCRIPTION
Added two events - PAINTING_CREATE and PAINTING_REMOVE
PAINTING_CREATE is fired on placing the painting, with the event containing info about the placer entity, target block and block face.
PAINTING_REMOVE is fired when the painting is damaged (as it is destroyed in one click, it makes no sense to have a separate DAMAGE event) or when the painting is removed by the world, like destroying a block behind it etc.

Placing a painting will also fire PLAYER _ITEM, although PAINTING_CREATE will only be fired when the placement will be a valid one.

Appropriate changes in CraftBukkit also made.
