### PR TITLE
Block update method that bypasses the cache

### DIFF
--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -61,6 +61,29 @@ public interface World {
     public int getBlockTypeIdAt(Location location);
 
     /**
+     * Sets the block type ID for the block at the given coordinates
+     *
+     * @param x X-coordinate of the block
+     * @param y Y-coordinate of the block
+     * @param z Z-coordinate of the block
+     * @param id Id for the block at the given coordinates
+     * @return Returns true on success
+     */
+    public boolean setBlockTypeIdAt(int x, int y, int z, int typeId);
+
+    /**
+     * Sets the block type ID and data for the block at the given coordinates
+     *
+     * @param x X-coordinate of the block
+     * @param y Y-coordinate of the block
+     * @param z Z-coordinate of the block
+     * @param id Id for the block at the given coordinates
+     * @param data Data setting for block
+     * @return Returns true on success
+     */
+    public boolean setBlockTypeIdAndDataAt(int x, int y, int z, int typeId, int data);
+
+    /**
      * Gets the highest non-air coordinate at the given coordinates
      *
      * @param x X-coordinate of the blocks


### PR DESCRIPTION
The block cache never clears.  

This means that a plugin which makes modifications to many blocks will cause memory usage to increase.

The new methods are in the same "series" as getBlockTypeId.

setBlockTypeIdAt(x, y, z, id)

setBlockTypeIdAndDataAt(x, y, z, id, data)

There is a corresponding CraftBukkit pull:
https://github.com/Bukkit/CraftBukkit/pull/173
