### PR TITLE
Material constructor fix

### DIFF
--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -227,7 +227,7 @@ public enum Material {
     }
 
     private Material(final int id, final int stack, final Class<? extends MaterialData> data) {
-        this(id, -1, stack, data);
+        this(id, stack, -1, data);
     }
 
     private Material(final int id, final int stack, final int durability, final Class<? extends MaterialData> data) {


### PR DESCRIPTION
Simple one line fix for the Material constructor mixup. Material.getMaxStackSize() and Material.getMaxDurability() now work properly.
