### PR TITLE
Regenerate chunk method (also includes refresh chunk method)

### DIFF
--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -201,6 +201,24 @@ public interface World {
     public boolean unloadChunkRequest(int x, int z, boolean safe);
 
     /**
+     * Regenerates the {@link Chunk} at the specified coordinates
+     *
+     * @param x X-coordinate of the chunk
+     * @param z Z-coordinate of the chunk
+     * @return Whether the chunk was actually regenerated
+     */
+    public boolean regenerateChunk(int x, int z);
+
+    /**
+     * Resends the {@link Chunk} to all clients
+     *
+     * @param x X-coordinate of the chunk
+     * @param z Z-coordinate of the chunk
+     * @return Whether the chunk was actually refreshed
+     */
+    public boolean refreshChunk(int x, int z);
+
+    /**
      * Drops an item at the specified {@link Location}
      *
      * @param location Location to drop the item


### PR DESCRIPTION
This pull adds a method that allows chunks to be regenerated.

The process is
- unload the chunk
- generate new chunk
- load the chunk (this also "decorates" the chunk)
- refresh the chunk (sends updated chunk to players)

The pull also includes a refreshChunk() method, since it is required to make the refresh chunk system work.

There is a corresponding CraftBukkit pull request with most of the code.
https://github.com/Bukkit/CraftBukkit/pull/180
