### PR TITLE
Adds CHUNK_GENERATED and CHUNK_DECORATED events

### DIFF
--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -435,7 +435,7 @@ public abstract class Event implements Serializable {
          * Called when a chunk is loaded
          *
          * If a new chunk is being generated for loading, it will call
-         * Type.CHUNK_GENERATION and then Type.CHUNK_LOADED upon completion
+         * Type.CHUNK_GENERATED and then Type.CHUNK_LOADED upon completion
          *
          * @see org.bukkit.event.world.ChunkLoadEvent
          */
@@ -453,7 +453,14 @@ public abstract class Event implements Serializable {
          *
          * @todo: add javadoc see comment
          */
-        CHUNK_GENERATION (Category.WORLD),
+        CHUNK_GENERATED (Category.WORLD),
+
+        /**
+         * Called when a chunk needs to be decorated
+         *
+         * @todo: add javadoc see comment
+         */
+        CHUNK_DECORATED (Category.WORLD),
 
         /**
          * Called when an ItemEntity spawns in the world

--- a/src/main/java/org/bukkit/event/world/ChunkDecoratedEvent.java
+++ b/src/main/java/org/bukkit/event/world/ChunkDecoratedEvent.java
@@ -1,0 +1,37 @@
+
+package org.bukkit.event.world;
+
+import org.bukkit.Chunk;
+import org.bukkit.event.Cancellable;
+
+/**
+ * Called when a chunk is generated
+ */
+public class ChunkDecoratedEvent extends ChunkLoadEvent implements Cancellable {
+    private boolean cancel = false;
+
+    public ChunkDecoratedEvent(final Type type, final Chunk chunk) {
+        super(type, chunk);
+    }
+
+    /**
+     * Gets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @return true if this event is cancelled
+     */
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    /**
+     * Sets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @param cancel true if you wish to cancel this event
+     */
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+
+}

--- a/src/main/java/org/bukkit/event/world/ChunkGeneratedEvent.java
+++ b/src/main/java/org/bukkit/event/world/ChunkGeneratedEvent.java
@@ -1,0 +1,54 @@
+
+package org.bukkit.event.world;
+
+import org.bukkit.Chunk;
+
+/**
+ * Called when a chunk is generated
+ */
+public class ChunkGeneratedEvent extends WorldEvent {
+    private final Chunk chunk;
+    private byte[] typeId = null;
+
+    public ChunkGeneratedEvent(final Type type, final Chunk chunk) {
+        super(type, chunk.getWorld());
+
+        this.chunk = chunk;
+
+        this.typeId = typeId;
+    }
+
+    /**
+     * Gets the chunk being loaded/unloaded
+     *
+     * @return Chunk that triggered this event
+     */
+    public Chunk getChunk() {
+        return chunk;
+    }
+
+    /**
+     * Sets the byte array and sets override to true.  The byte array must be 32768 bytes long.
+     *
+     * @param typeId Array containing byte data
+     * @return Returns true if the byte array is accepted
+     */
+    public boolean setTypeIdArray(byte[] typeId) {
+        if(typeId.length == 32768) {
+            this.typeId = typeId;
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Sets the byte array and sets override to true.  The byte array must be 32768 bytes long.
+     *
+     * @return Returns the byte array
+     */
+    public byte[] getTypeIdArray() {
+        return this.typeId;
+    }
+
+}

--- a/src/main/java/org/bukkit/event/world/WorldListener.java
+++ b/src/main/java/org/bukkit/event/world/WorldListener.java
@@ -23,7 +23,25 @@ public class WorldListener implements Listener {
     public void onChunkUnloaded(ChunkUnloadEvent event) {
     }
 
-    /**
+   /**
+     * Called when a chunk is generated
+     *
+     * @param event Relevant event details
+     */
+    public void onChunkGenerated(ChunkGeneratedEvent event) {
+    }
+
+   /**
+     * Called when a chunk is decorated
+     * This occurs shortly after the chunk is generated
+     * It is guaranteed that the 3 neighbouring chunks (x+1, z), (x+1, z+1), (x, z+1) will be loaded
+     *
+     * @param event Relevant event details
+     */
+    public void onChunkDecorated(ChunkDecoratedEvent event) {
+    }
+
+   /**
     * Called when a world is saved
     *
     * param event Relevant event details

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -25,6 +25,8 @@ import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.event.world.ChunkUnloadEvent;
 import org.bukkit.event.world.WorldEvent;
 import org.bukkit.event.world.WorldListener;
+import org.bukkit.event.world.ChunkGeneratedEvent;
+import org.bukkit.event.world.ChunkDecoratedEvent;
 import org.bukkit.plugin.*;
 
 /**
@@ -300,6 +302,16 @@ public final class JavaPluginLoader implements PluginLoader {
         case CHUNK_UNLOADED:
             return new EventExecutor() { public void execute( Listener listener, Event event ) {
                     ((WorldListener)listener).onChunkUnloaded( (ChunkUnloadEvent)event );
+                }
+            };
+        case CHUNK_GENERATED:
+            return new EventExecutor() { public void execute( Listener listener, Event event ) {
+                    ((WorldListener)listener).onChunkGenerated( (ChunkGeneratedEvent)event );
+                }
+            };
+        case CHUNK_DECORATED:
+            return new EventExecutor() { public void execute( Listener listener, Event event ) {
+                    ((WorldListener)listener).onChunkDecorated( (ChunkDecoratedEvent)event );
                 }
             };
         case WORLD_SAVED:


### PR DESCRIPTION
There is a corresponding CraftBukkit pull:
https://github.com/Bukkit/CraftBukkit/pull/181

This pull adds adds code for 2 events

CHUNK_GENERATED (was CHUNK_GENERATION)
CHUNK_DECORATED

The generated event occurs when the chunk is being generated.  The event allows a plugin to provide an alternative byte array for the chunk to be initialised with.

The decorated event occurs when the chunk is being decorated (adding ores/trees etc).  A plugin can cancel this event if it doesn't want the chunk to be decorated.

The theory is that this system can be used with the regenerate chunk from the previous pull.  When a new world is started, a plugin could register these events and then regenerate the spawn area chunks using the method in the other pull.
