### PR TITLE
Finally fixes Material.java

### DIFF
--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -227,7 +227,7 @@ public enum Material {
     }
 
     private Material(final int id, final int stack, final Class<? extends MaterialData> data) {
-        this(id, -1, stack, data);
+        this(id, stack, -1, data);
     }
 
     private Material(final int id, final int stack, final int durability, final Class<? extends MaterialData> data) {


### PR DESCRIPTION
Commit 601afef to fix the mix-up between durabilities and stack sizes was incomplete; it simply moved the error from one constructor to another. This patch now fixes it.
