### PR TITLE
Advanced onpluginenable

### DIFF
--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -219,25 +219,26 @@ public final class SimplePluginManager implements PluginManager {
             plugin.getPluginLoader().enablePlugin(plugin);
             
             this.callEvent(new PluginEvent(Event.Type.PLUGIN_ENABLE, plugin));
-            // Calls the new enabled plugin the enable listener for each plugin previously enabled
+            // Calls the new enabled plugin the enable listener for each plugin
+            // previously enabled
             RegisteredListener listener = this.getListener(plugin, Type.PLUGIN_ENABLE);
-            
+
             for (Plugin otherPlugin : this.plugins) {
-				if (otherPlugin != plugin) {
-					listener.callEvent(new PluginEvent(Event.Type.PLUGIN_ENABLE, otherPlugin));
-				}
+                if (otherPlugin != plugin) {
+                    listener.callEvent(new PluginEvent(Event.Type.PLUGIN_ENABLE, otherPlugin));
+                }
             }
         }
     }
-    
+
     public RegisteredListener getListener(Plugin plugin, Type type) {
-    	SortedSet<RegisteredListener> eventListeners = this.listeners.get(Event.Type.PLUGIN_ENABLE);
+        SortedSet<RegisteredListener> eventListeners = this.listeners.get(Event.Type.PLUGIN_ENABLE);
         if (eventListeners != null) {
-        	for (RegisteredListener registeredListener : eventListeners) {
-				if (registeredListener.getPlugin() == plugin) {
-					return registeredListener;
-				}
-			}
+            for (RegisteredListener registeredListener : eventListeners) {
+                if (registeredListener.getPlugin() == plugin) {
+                    return registeredListener;
+                }
+            }
         }
         return null;
     }

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -449,7 +449,6 @@ public final class JavaPluginLoader implements PluginLoader {
             JavaPlugin jPlugin = (JavaPlugin)plugin;
 
             jPlugin.setEnabled(true);
-            server.getPluginManager().callEvent(new PluginEvent(Event.Type.PLUGIN_ENABLE, plugin));
         }
     }
 


### PR DESCRIPTION
I [posted](http://forums.bukkit.org/threads/making-your-plugin-accessible-to-other-plugins.6897/#post-110101) in the forum, an idea to avoid, that a plugin has to check the listener and at least one time in onEnabled() if a dependency plugin is enabled.

I also moved the listener call (that a plugin was enabled) to the plugin manager, because each PluginLoader should call this.

Fabian
