### PR TITLE
Fix for basic plugin dependencies

### DIFF
--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -39,7 +39,7 @@ public final class JavaPluginLoader implements PluginLoader {
             Pattern.compile("\\.jar$"),
     };
     private final Map<String, Class<?>> classes = new HashMap<String, Class<?>>();
-    private final Map<String, File> files = new HashMap<String, File>();
+    private final Map<String, PluginClassLoader> loaders = new HashMap<String, PluginClassLoader>();
 
     public JavaPluginLoader(Server instance) {
         server = instance;
@@ -81,27 +81,21 @@ public final class JavaPluginLoader implements PluginLoader {
              throw new InvalidPluginException(ex);
         }
 
-        ArrayList<File> dependFiles = new ArrayList<File>();
-
         for(String pluginName : depend) {
-            if(files == null) {
+            if(loaders == null) {
                 throw new UnknownDependencyException(pluginName);
             }
-            File current = files.get(pluginName);
+            PluginClassLoader current = loaders.get(pluginName);
             if(current == null) {
                 throw new UnknownDependencyException(pluginName);
             }
-            dependFiles.add(current);
         }
 
+        PluginClassLoader loader = null;
         try {
-            URL[] urls = new URL[dependFiles.size() + 1];
+            URL[] urls = new URL[1];
             urls[0] = file.toURI().toURL();
-            int cnt = 1;
-            for(File f : dependFiles) {
-                urls[cnt++] = f.toURI().toURL();
-            }
-            ClassLoader loader = new PluginClassLoader(this, urls, getClass().getClassLoader());
+            loader = new PluginClassLoader(this, urls, getClass().getClassLoader());
             Class<?> jarClass = Class.forName(description.getMain(), true, loader);
             Class<? extends JavaPlugin> plugin = jarClass.asSubclass(JavaPlugin.class);
 
@@ -113,7 +107,7 @@ public final class JavaPluginLoader implements PluginLoader {
             throw new InvalidPluginException(ex);
         }
 
-        files.put(description.getName(), file);
+        loaders.put(description.getName(), (PluginClassLoader)loader);
 
         return (Plugin)result;
     }
@@ -143,7 +137,22 @@ public final class JavaPluginLoader implements PluginLoader {
     }
 
     public Class<?> getClassByName(final String name) {
-        return classes.get(name);
+        Class<?> cachedClass = classes.get(name);
+        if(cachedClass != null) {
+            return cachedClass;
+        } else {
+            for(String current : loaders.keySet()) {
+                PluginClassLoader loader = loaders.get(current);
+                try {
+                    cachedClass = loader.findClass(name, false);
+                } catch (ClassNotFoundException cnfe) {
+                }
+                if(cachedClass != null) {
+                    return cachedClass;
+                }
+            }
+        }
+        return null;
     }
 
     public void setClass(final String name, final Class<?> clazz) {
@@ -448,6 +457,11 @@ public final class JavaPluginLoader implements PluginLoader {
         if (!plugin.isEnabled()) {
             JavaPlugin jPlugin = (JavaPlugin)plugin;
 
+            String pluginName = jPlugin.getDescription().getName();
+            if(!loaders.containsKey(pluginName)) {
+                loaders.put(pluginName, (PluginClassLoader)jPlugin.getClassLoader());
+            }
+
             jPlugin.setEnabled(true);
             server.getPluginManager().callEvent(new PluginEvent(Event.Type.PLUGIN_ENABLE, plugin));
         }
@@ -466,7 +480,7 @@ public final class JavaPluginLoader implements PluginLoader {
 
             server.getPluginManager().callEvent(new PluginEvent(Event.Type.PLUGIN_DISABLE, plugin));
 
-            files.remove(jPlugin.getDescription().getName());
+            loaders.remove(jPlugin.getDescription().getName());
 
             if (cloader instanceof PluginClassLoader) {
                 PluginClassLoader loader = (PluginClassLoader)cloader;

--- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
@@ -21,10 +21,16 @@ public class PluginClassLoader extends URLClassLoader {
 
     @Override
     protected Class<?> findClass(String name) throws ClassNotFoundException {
+        return findClass(name, true);
+    }
+
+    protected Class<?> findClass(String name, boolean checkGlobal) throws ClassNotFoundException {
         Class<?> result = classes.get(name);
 
         if (result == null) {
-            result = loader.getClassByName(name);
+            if(checkGlobal) {
+                result = loader.getClassByName(name);
+            }
 
             if (result == null) {
                 result = super.findClass(name);


### PR DESCRIPTION
This should fix the problems with the last dependency pull.

The "depend" field in the yml file is now only used to decide plugin load ordering.  It no longer causes the .jar file of any dependencies to be included in the class loader for a plugin.

The class scan has been expanded.  If a class cannot be found in the global cache (checked first) or the local .jar file, then all other .jar files are scanned.
