### PR TITLE
Add ability to make entities invisible.

### DIFF
--- a/src/main/java/org/bukkit/entity/Entity.java
+++ b/src/main/java/org/bukkit/entity/Entity.java
@@ -109,4 +109,18 @@ public interface Entity {
      * @return Server instance running this Entity
      */
     public Server getServer();
+
+    /**
+     * Gets whether this entity is invisible
+     *
+     * @return Whether this entity is invisible
+     */
+    public boolean isInvisible();
+
+    /**
+     * Sets whether this entity is invisible
+     *
+     * @param invisible Whether this entity is invisible
+     */
+    public void setInvisible(boolean visible);
 }

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -99,4 +99,20 @@ public interface Player extends HumanEntity, CommandSender {
      * @deprecated This method should not be relied upon as it is a temporary work-around for a larger, more complicated issue.
      */
     public void updateInventory();
+
+    /**
+     * Gets whether another entity is invisible to just this player
+     *
+     * @param entity The other entity
+     * @return Whether the other entity is invisible
+     */
+    public boolean isEntityInvisible(Entity entity);
+
+    /**
+     * Sets whether another entity is invisible to just this player
+     *
+     * @param entity The other entity
+     * @param visible Whether the other entity is invisible
+     */
+    public void setEntityInvisible(Entity entity, boolean visible);
 }


### PR DESCRIPTION
This commit adds methods to make entities globally invisible, or make entities invisible to specific players.

The way this is set up now, it's not possible to make entities _visible only_ to specific players. I wasn't sure if that's desirable, but if it is, I can make the adjustment. Something like `Player#setEntityVisibility`, but it'd need an enum (effectively tristate) to be able to set it to inherit the global visibility.

Accompanying CraftBukkit pull: https://github.com/Bukkit/CraftBukkit/pull/197
