### PR TITLE
Add a VEHICLE_DESTROY event

### DIFF
--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -546,6 +546,13 @@ public abstract class Event implements Serializable {
         VEHICLE_CREATE (Category.VEHICLE),
 
         /**
+         * Called when a vehicle is destroyed
+         *
+         * @see org.bukkit.event.vehicle.VehicleDestroyEvent
+         */
+        VEHICLE_DESTROY (Category.VEHICLE),
+
+        /**
          * Called when a vehicle is damaged by a LivingEntity
          *
          * @see org.bukkit.event.vehicle.VehicleDamageEvent

--- a/src/main/java/org/bukkit/event/vehicle/VehicleDestroyEvent.java
+++ b/src/main/java/org/bukkit/event/vehicle/VehicleDestroyEvent.java
@@ -1,0 +1,33 @@
+package org.bukkit.event.vehicle;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Vehicle;
+import org.bukkit.event.Cancellable;
+
+/**
+ * Raised when a vehicle is destroyed
+ *
+ * @author sk89q, cyklo
+ */
+public class VehicleDestroyEvent extends VehicleEvent implements Cancellable {
+    private Entity attacker;
+    private boolean cancelled;
+    
+    public VehicleDestroyEvent(Type type, Vehicle vehicle, Entity attacker) {
+        super(type, vehicle);
+        this.attacker = attacker;
+    }
+    
+    public Entity getAttacker() {
+        return attacker;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+}

--- a/src/main/java/org/bukkit/event/vehicle/VehicleListener.java
+++ b/src/main/java/org/bukkit/event/vehicle/VehicleListener.java
@@ -27,6 +27,14 @@ public class VehicleListener implements Listener {
      */
     public void onVehicleDamage(VehicleDamageEvent event) {
     }
+
+    /**
+     * Called when a vehicle is destroyed.
+     *
+     * @param event
+     */
+    public void onVehicleDestroy(VehicleDestroyEvent event) {
+    }
     
     /**
      * Called when a vehicle collides with a block.

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -398,6 +398,11 @@ public final class JavaPluginLoader implements PluginLoader {
                     ((VehicleListener)listener).onVehicleDamage( (VehicleDamageEvent)event );
                 }
             };
+        case VEHICLE_DESTROY:
+            return new EventExecutor() { public void execute( Listener listener, Event event ) {
+                    ((VehicleListener)listener).onVehicleDestroy( (VehicleDestroyEvent)event );
+                }
+            };
         case VEHICLE_COLLISION_BLOCK:
             return new EventExecutor() { public void execute( Listener listener, Event event ) {
                     ((VehicleListener)listener).onVehicleBlockCollision( (VehicleBlockCollisionEvent)event );


### PR DESCRIPTION
There is a corresponding CraftBukkit pull request: https://github.com/Bukkit/CraftBukkit/pull/213 (CHANGED!)

This fixes the issue raised in Redmine Issue 241 - http://redmine.bukkit.org/issues/241

This adds a VEHICLE_DESTROY hook, equivalent to a BLOCK_BREAK hook. It has all the same methods as VEHICLE_DAMAGE, with the exception of the damage quantity.

In the Redmine thread it was mentioned that you had decided on an overall "entity gone" event. However, so long as VEHICLE_CREATE exists, there should be an analagous destruction event.
