### PR TITLE
Added KICK_WHITELIST

### DIFF
--- a/src/main/java/org/bukkit/event/player/PlayerLoginEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerLoginEvent.java
@@ -95,7 +95,12 @@ public class PlayerLoginEvent extends PlayerEvent {
          * The player is not allowed to log in, due to them being banned
          */
         KICK_BANNED,
-
+        
+        /**
+         * The player is not allowed to log in, due to them not being on the white list
+         */
+        KICK_WHITELIST,
+        
         /**
          * The player is not allowed to log in, for reasons undefined
          */


### PR DESCRIPTION
Added a new Result for Kicks resulting from not being on the whitelist. I didn't see the point of craftbukkit throwing KICK_BANNED when the player gets disconnected from a server because he/she wasn't on the whitelist.

CraftBukkit Pull request: https://github.com/Bukkit/CraftBukkit/pull/203
