### PR TITLE
Player teleport event fix - revision 1

### DIFF
--- a/src/main/java/org/bukkit/entity/Entity.java
+++ b/src/main/java/org/bukkit/entity/Entity.java
@@ -42,6 +42,23 @@ public interface Entity {
      * Teleports this entity to the given location
      *
      * @param location New location to teleport this entity to
+     * @return <code>true</code> if the teleport was successful
+     */
+    public boolean teleport(Location location);
+
+    /**
+     * Teleports this entity to the target Entity
+     *
+     * @param destination Entity to teleport this entity to
+     * @return <code>true</code> if the teleport was successful
+     */
+    public boolean teleport(Entity destination);
+
+    /**
+     * Teleports this entity to the given location
+     *
+     * @param location New location to teleport this entity to
+     * @deprecated use {@link #teleport(Location)}
      */
     public void teleportTo(Location location);
 
@@ -49,6 +66,7 @@ public interface Entity {
      * Teleports this entity to the target Entity
      *
      * @param destination Entity to teleport this entity to
+     * @deprecated use {@link #teleport(Entity)}
      */
     public void teleportTo(Entity destination);
 


### PR DESCRIPTION
CraftBukkit pull: https://github.com/Bukkit/CraftBukkit/pull/210

Snipped initial comment below:

Summary of changes:
- new methods: boolean Entity.teleport(...) -- The return value indicates if the teleport was aborted due to a plugin canceling the event.
- deprecated void Entity.teleport(...)

The third commit is a Bukkit API change: void CraftEntity.teleportTo(Location) has been changed to boolean CraftEntity.teleport(Location).
The purpose of this change is to allow plugins to determine if the teleport was canceled or not.  This allows the cross-world teleports to specific locations to continue to work even when the teleport is canceled.  (Referring to the hack where cross-world teleports function only in PlayerMoveEvent handlers, but only if event.setTo() is called with the teleport destination).
CraftEntity.teleport()'s implementation was unchanged since there is no event currently being fired to cancel.  If EntityTeleportEvent is added, the implemetation should be updated to correctly return true if and only if the event is allowed to pass.
