### PR TITLE
Fixed PlayerTeleportEvent so getType() returns Type.PLAYER_TELEPORT

### DIFF
--- a/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
@@ -4,9 +4,10 @@ package org.bukkit.event.player;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
 
 /**
- * Holds information for player movement and teleportation events
+ * Holds information for player movement events
  */
 public class PlayerMoveEvent extends PlayerEvent implements Cancellable {
     private boolean cancel = false;
@@ -15,6 +16,12 @@ public class PlayerMoveEvent extends PlayerEvent implements Cancellable {
 
     public PlayerMoveEvent(final Player player, final Location from, final Location to) {
         super(Type.PLAYER_MOVE, player);
+        this.from = from;
+        this.to = to;
+    }
+
+    PlayerMoveEvent(final Event.Type type, final Player player, final Location from, final Location to) {
+        super(type, player);
         this.from = from;
         this.to = to;
     }

--- a/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
@@ -3,8 +3,11 @@ package org.bukkit.event.player;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
+/**
+ * Holds information for player teleport events
+ */
 public class PlayerTeleportEvent extends PlayerMoveEvent {
     public PlayerTeleportEvent(Player player, Location from, Location to) {
-        super(player, from, to);
+        super(Type.PLAYER_TELEPORT, player, from, to);
     }
 }


### PR DESCRIPTION
Fixed PlayerTeleportEvent so events actually get dispatched. Instances were returning Type.PLAYER_MOVE for their type so the wrong event got fired.
