### PR TITLE
Implementing onShutdown() and onStartup() methods

### DIFF
--- a/src/main/java/org/bukkit/fillr/Getter.java
+++ b/src/main/java/org/bukkit/fillr/Getter.java
@@ -39,7 +39,7 @@ public class Getter {
         //TODO again with the implicit jar support...
         File plugin = new File(DIRECTORY, name + ".jar");
         try {
-            server.getPluginManager().loadPlugin(plugin);
+            server.getPluginManager().loadPlugin(plugin, false);
         } catch (UnknownDependencyException ex) {
             server.getLogger().log(Level.SEVERE, null, ex);
         } catch (InvalidPluginException ex) {

--- a/src/main/java/org/bukkit/fillr/Updater.java
+++ b/src/main/java/org/bukkit/fillr/Updater.java
@@ -96,7 +96,7 @@ public class Updater {
         //TODO again with the implicit jar support...
         File plugin = new File(DIRECTORY, name + ".jar");
         try {
-            server.getPluginManager().loadPlugin(plugin);
+            server.getPluginManager().loadPlugin(plugin, false);
         } catch (UnknownDependencyException ex) {
             server.getLogger().log(Level.SEVERE, null, ex);
         } catch (InvalidPluginException ex) {
@@ -109,6 +109,6 @@ public class Updater {
     private void disablePlugin(FillReader update) {
         String name = update.getName();
         Plugin plugin = server.getPluginManager().getPlugin(name);
-        server.getPluginManager().disablePlugin(plugin);
+        server.getPluginManager().disablePlugin(plugin, false);
     }
 }

--- a/src/main/java/org/bukkit/plugin/Plugin.java
+++ b/src/main/java/org/bukkit/plugin/Plugin.java
@@ -57,6 +57,11 @@ public interface Plugin extends CommandExecutor {
      * Called when this plugin is disabled
      */
     public void onDisable();
+    
+    /**
+     * Called when the server shuts down
+     */
+    public void onShutdown();
 
     /**
      * Called after a plugin is loaded but before it has been enabled.
@@ -68,4 +73,9 @@ public interface Plugin extends CommandExecutor {
      * Called when this plugin is enabled
      */
     public void onEnable();
+    
+    /**
+     * Called when the server starts
+     */
+    public void onStartup();
 }

--- a/src/main/java/org/bukkit/plugin/PluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/PluginLoader.java
@@ -16,11 +16,12 @@ public interface PluginLoader {
      * Loads the plugin contained in the specified file
      *
      * @param file File to attempt to load
+     * @param boolean Whether or not this is the startup of the server
      * @return Plugin that was contained in the specified file, or null if
      * unsuccessful
      * @throws InvalidPluginException Thrown when the specified file is not a plugin
      */
-    public Plugin loadPlugin(File file) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException;
+    public Plugin loadPlugin(File file, boolean startup) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException;
 
     /**
      * Returns a list of all filename filters expected by this PluginLoader
@@ -41,8 +42,9 @@ public interface PluginLoader {
      * Attempting to enable a plugin that is already enabled will have no effect
      *
      * @param plugin Plugin to enable
+     * @param boolean Whether or not this is the startup of the server
      */
-    public void enablePlugin(Plugin plugin);
+    public void enablePlugin(Plugin plugin, boolean startup);
 
     /**
      * Disables the specified plugin
@@ -50,6 +52,7 @@ public interface PluginLoader {
      * Attempting to disable a plugin that is not enabled will have no effect
      *
      * @param plugin Plugin to disable
+     * @param boolean Whether or not this is the shutdown of the server
      */
-    public void disablePlugin(Plugin plugin);
+    public void disablePlugin(Plugin plugin, boolean shutdown);
 }

--- a/src/main/java/org/bukkit/plugin/PluginManager.java
+++ b/src/main/java/org/bukkit/plugin/PluginManager.java
@@ -61,29 +61,33 @@ public interface PluginManager {
      * File must be valid according to the current enabled Plugin interfaces
      *
      * @param file File containing the plugin to load
+     * @param boolean Whether or not this is the shutdown of the server
      * @return The Plugin loaded, or null if it was invalid
      * @throws InvalidPluginException Thrown when the specified file is not a valid plugin
      * @throws InvalidDescriptionException Thrown when the specified file contains an invalid description
      */
-    public Plugin loadPlugin(File file) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException;
+    public Plugin loadPlugin(File file, boolean startup) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException;
 
     /**
      * Loads the plugins contained within the specified directory
      *
      * @param directory Directory to check for plugins
+     * @param boolean Whether or not this is the startup of the server
      * @return A list of all plugins loaded
      */
-    public Plugin[] loadPlugins(File directory);
+    public Plugin[] loadPlugins(File directory, boolean startup );
 
     /**
      * Disables all the loaded plugins
+     * @param boolean Whether or not this is the shutting down of the server
      */
-    public void disablePlugins();
+    public void disablePlugins( boolean shutdown );
 
     /**
      * Disables and removes all plugins
+     * @param boolean Whether or not this is the shutting down of the server
      */
-    public void clearPlugins();
+    public void clearPlugins( boolean shutdown );
 
     /**
      * Calls a player related event with the given details
@@ -120,8 +124,9 @@ public interface PluginManager {
      * Attempting to enable a plugin that is already enabled will have no effect
      *
      * @param plugin Plugin to enable
+     * @param boolean Whether or not this is the starting of the server
      */
-    public void enablePlugin(Plugin plugin);
+    public void enablePlugin(Plugin plugin, boolean startup);
 
     /**
      * Disables the specified plugin
@@ -129,6 +134,7 @@ public interface PluginManager {
      * Attempting to disable a plugin that is not enabled will have no effect
      *
      * @param plugin Plugin to disable
+     * @param boolean Whether or not this is the shutting down of the server
      */
-    public void disablePlugin(Plugin plugin);
+    public void disablePlugin(Plugin plugin, boolean shutdown);
 }

--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
@@ -108,15 +108,22 @@ public abstract class JavaPlugin implements Plugin {
      * Sets the enabled state of this plugin
      *
      * @param enabled true if enabled, otherwise false
+     * @param boolean Whether or not this is the startup/shutdown of the server
      */
-    protected void setEnabled(final boolean enabled) {
+    protected void setEnabled(final boolean enabled, boolean startup) {
         if (isEnabled != enabled) {
             isEnabled = enabled;
 
             if (isEnabled) {
                 onEnable();
+                if( startup ) {
+                    onStartup();
+                }
             }  else {
                 onDisable();
+                if( startup ) {
+                    onShutdown();
+                }
             }
         }
     }
@@ -188,5 +195,13 @@ public abstract class JavaPlugin implements Plugin {
 
     public void onLoad() {
         // Empty!
+    }
+    
+    public void onStartup() {
+	// Empty!
+    }
+    
+    public void onShutdown() {
+	// Empty!
     }
 }

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -39,8 +39,11 @@ public final class JavaPluginLoader implements PluginLoader {
     public JavaPluginLoader(Server instance) {
         server = instance;
     }
-
+    
     public Plugin loadPlugin(File file) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException {
+	return loadPlugin( file, false );
+    }
+    public Plugin loadPlugin(File file, boolean startup) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException {
         JavaPlugin result = null;
         PluginDescriptionFile description = null;
 
@@ -495,7 +498,10 @@ public final class JavaPluginLoader implements PluginLoader {
         throw new IllegalArgumentException( "Event " + type + " is not supported" );
     }
 
-    public void enablePlugin(final Plugin plugin) {
+    public void enablePlugin(Plugin plugin) {
+	enablePlugin( plugin, false );
+    }
+    public void enablePlugin(final Plugin plugin, boolean startup) {
         if (!(plugin instanceof JavaPlugin)) {
             throw new IllegalArgumentException("Plugin is not associated with this PluginLoader");
         }
@@ -508,12 +514,15 @@ public final class JavaPluginLoader implements PluginLoader {
                 loaders.put(pluginName, (PluginClassLoader)jPlugin.getClassLoader());
             }
 
-            jPlugin.setEnabled(true);
+            jPlugin.setEnabled(true, startup);
             server.getPluginManager().callEvent(new PluginEnableEvent(plugin));
         }
     }
 
     public void disablePlugin(Plugin plugin) {
+	disablePlugin( plugin, false );
+    }
+    public void disablePlugin(Plugin plugin, boolean shutdown) {
         if (!(plugin instanceof JavaPlugin)) {
             throw new IllegalArgumentException("Plugin is not associated with this PluginLoader");
         }
@@ -522,7 +531,7 @@ public final class JavaPluginLoader implements PluginLoader {
             JavaPlugin jPlugin = (JavaPlugin)plugin;
             ClassLoader cloader = jPlugin.getClassLoader();
 
-            jPlugin.setEnabled(false);
+            jPlugin.setEnabled(false, shutdown);
 
             server.getPluginManager().callEvent(new PluginDisableEvent(plugin));
 


### PR DESCRIPTION
I've implemented onShutdown() and onStartup() methods, which are only run (surprise surprise) when the server is started or stopped. This is as opposed to onEnable() and onDisable(), which run when the plugins are reloaded, manually disabled, etc. I've filed a pull request for both repos. Link to first request: https://github.com/Bukkit/CraftBukkit/pull/217
