### PR TITLE
Cleaned up PlayerMoveEvent and PlayerTeleportEvent.

### DIFF
--- a/src/main/java/org/bukkit/event/player/PlayerChangePositionEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerChangePositionEvent.java
@@ -1,0 +1,96 @@
+
+package org.bukkit.event.player;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+
+/**
+ * Holds information for player events involving movement or teleportation.
+ * This should not be used directly.  Use {@link PlayerMoveEvent} or
+ * {@link PlayerTeleportEvent}.
+ */
+public abstract class PlayerChangePositionEvent extends PlayerEvent implements Cancellable {
+    private boolean cancel = false;
+    private Location from;
+    private Location to;
+
+    /**
+     * Create a new player relocate event.
+     *
+     * @param type the event type for dispatch purposes
+     * @param player the player that's moving
+     * @param from the old location
+     * @param to the new location
+     */
+    public PlayerChangePositionEvent(final Event.Type type, final Player player, final Location from, final Location to) {
+        super(type, player);
+        this.from = from;
+        this.to = to;
+    }
+
+    /**
+     * Gets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * If a move or teleport event is cancelled, the player will be moved or
+     * teleported back to the Location as defined by getFrom(). This will not
+     * fire an event
+     *
+     * @return true if this event is cancelled
+     */
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    /**
+     * Sets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * If a move or teleport event is cancelled, the player will be moved or
+     * teleported back to the Location as defined by getFrom(). This will not
+     * fire an event
+     *
+     * @param cancel true if you wish to cancel this event
+     */
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+
+    /**
+     * Gets the location this player moved from
+     *
+     * @return Location the player moved from
+     */
+    public Location getFrom() {
+        return from;
+    }
+
+    /**
+     * Sets the location to mark as where the player moved from
+     *
+     * @param from New location to mark as the players previous location
+     */
+    public void setFrom(Location from) {
+        this.from = from;
+    }
+
+    /**
+     * Gets the location this player moved to
+     *
+     * @return Location the player moved to
+     */
+    public Location getTo() {
+        return to;
+    }
+
+    /**
+     * Sets the location that this player will move to
+     *
+     * @param to New Location this player will move to
+     */
+    public void setTo(Location to) {
+        this.to = to;
+    }
+}

--- a/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
@@ -1,92 +1,23 @@
-
 package org.bukkit.event.player;
 
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
+import org.bukkit.event.Event.Type;
 
 /**
  * Holds information for player movement events
  */
-public class PlayerMoveEvent extends PlayerEvent implements Cancellable {
-    private boolean cancel = false;
-    private Location from;
-    private Location to;
-
-    public PlayerMoveEvent(final Player player, final Location from, final Location to) {
-        super(Type.PLAYER_MOVE, player);
-        this.from = from;
-        this.to = to;
-    }
-
-    PlayerMoveEvent(final Event.Type type, final Player player, final Location from, final Location to) {
-        super(type, player);
-        this.from = from;
-        this.to = to;
-    }
-
+public class PlayerMoveEvent extends PlayerChangePositionEvent {
     /**
-     * Gets the cancellation state of this event. A cancelled event will not
-     * be executed in the server, but will still pass to other plugins
+     * Create a new player move event.
      *
-     * If a move or teleport event is cancelled, the player will be moved or
-     * teleported back to the Location as defined by getFrom(). This will not
-     * fire an event
-     *
-     * @return true if this event is cancelled
+     * @param player the player that's moving
+     * @param from the old location
+     * @param to the new location
      */
-    public boolean isCancelled() {
-        return cancel;
-    }
-
-    /**
-     * Sets the cancellation state of this event. A cancelled event will not
-     * be executed in the server, but will still pass to other plugins
-     *
-     * If a move or teleport event is cancelled, the player will be moved or
-     * teleported back to the Location as defined by getFrom(). This will not
-     * fire an event
-     *
-     * @param cancel true if you wish to cancel this event
-     */
-    public void setCancelled(boolean cancel) {
-        this.cancel = cancel;
-    }
-
-    /**
-     * Gets the location this player moved from
-     *
-     * @return Location the player moved from
-     */
-    public Location getFrom() {
-        return from;
-    }
-
-    /**
-     * Sets the location to mark as where the player moved from
-     *
-     * @param from New location to mark as the players previous location
-     */
-    public void setFrom(Location from) {
-        this.from = from;
-    }
-
-    /**
-     * Gets the location this player moved to
-     *
-     * @return Location the player moved to
-     */
-    public Location getTo() {
-        return to;
-    }
-
-    /**
-     * Sets the location that this player will move to
-     *
-     * @param to New Location this player will move to
-     */
-    public void setTo(Location to) {
-        this.to = to;
+    public PlayerMoveEvent(Player player, Location from, Location to) {
+        super(Type.PLAYER_MOVE, player, from, to);
     }
 }

--- a/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
@@ -6,7 +6,14 @@ import org.bukkit.entity.Player;
 /**
  * Holds information for player teleport events
  */
-public class PlayerTeleportEvent extends PlayerMoveEvent {
+public class PlayerTeleportEvent extends PlayerChangePositionEvent {
+    /**
+     * Create a new player move event.
+     *
+     * @param player the player that's moving
+     * @param from the old location
+     * @param to the new location
+     */
     public PlayerTeleportEvent(Player player, Location from, Location to) {
         super(Type.PLAYER_TELEPORT, player, from, to);
     }


### PR DESCRIPTION
Cleaned up PlayerMoveEvent and PlayerTeleportEvent.  Now both inherit from a new PlayerChangePositionEvent.

Should have no source visible impact on any other code.
