### PR TITLE
fixed PlayerCommandPreprocessEvent to assume the correct Event.Type

### DIFF
--- a/src/main/java/org/bukkit/event/player/PlayerChatEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerChatEvent.java
@@ -4,6 +4,7 @@ package org.bukkit.event.player;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 
@@ -17,10 +18,13 @@ public class PlayerChatEvent extends PlayerEvent implements Cancellable {
     private final Set<Player> recipients;
 
     public PlayerChatEvent(final Player player, final String message) {
-        super(Type.PLAYER_CHAT, player);
-        this.message = message;
-
+        this(Type.PLAYER_CHAT, player, message);
+    }
+    
+    protected PlayerChatEvent(final Type type, final Player player, final String message) {
+        super(type, player);
         recipients = new HashSet<Player>(Arrays.asList(player.getServer().getOnlinePlayers()));
+        this.message = message;
     }
 
     /**

--- a/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java
@@ -3,7 +3,7 @@ package org.bukkit.event.player;
 import org.bukkit.entity.Player;
 
 public class PlayerCommandPreprocessEvent extends PlayerChatEvent {
-    public PlayerCommandPreprocessEvent(Player player, String message) {
-        super(player, message);
+    public PlayerCommandPreprocessEvent(final Player player, final String message) {
+        super(Type.PLAYER_COMMAND_PREPROCESS, player, message);
     }
 }


### PR DESCRIPTION
The inheritance from PlayerChatEvent caused PlayerCommandPreprocessEvent to be processed as a PlayerChatEvent and onCommandPreprocess would never be called.
