### PR TITLE
SpawnChangeEvent (WorldEvent) for when a world's spawn changes

### DIFF
--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -455,6 +455,13 @@ public abstract class Event implements Serializable {
         ITEM_SPAWN (Category.WORLD),
 
         /**
+         * Called when a World's spawn is changed
+         *
+         * @see org.bukkit.event.world.SpawnChangeEvent
+         */
+        SPAWN_CHANGE (Category.WORLD),
+
+        /**
          * Called when a world is saved
          * 
          */

--- a/src/main/java/org/bukkit/event/world/SpawnChangeEvent.java
+++ b/src/main/java/org/bukkit/event/world/SpawnChangeEvent.java
@@ -1,0 +1,28 @@
+package org.bukkit.event.world;
+
+import org.bukkit.World;
+import org.bukkit.Location;
+
+/**
+ * An event that is called when a world's spawn changes. The
+ * world's previous spawn location is included.
+ *
+ * @author willurd
+ */
+public class SpawnChangeEvent extends WorldEvent {
+    private Location previousLocation;
+
+    public SpawnChangeEvent(World world, Location previousLocation) {
+        super(Type.SPAWN_CHANGE, world);
+        this.previousLocation = previousLocation;
+    }
+
+    /**
+     * Gets the previous spawn location
+     *
+     * @return Location that used to be spawn
+     */
+    public Location getPreviousLocation() {
+        return previousLocation;
+    }
+}

--- a/src/main/java/org/bukkit/event/world/WorldListener.java
+++ b/src/main/java/org/bukkit/event/world/WorldListener.java
@@ -24,6 +24,14 @@ public class WorldListener implements Listener {
     }
 
     /**
+     * Called when a World's spawn is changed
+     *
+     * @param event Relevant event details
+     */
+    public void onSpawnChange(SpawnChangeEvent event) {
+    }
+
+    /**
     * Called when a world is saved
     *
     * @param event Relevant event details

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -376,6 +376,12 @@ public final class JavaPluginLoader implements PluginLoader {
                     ((WorldListener) listener).onChunkUnload((ChunkUnloadEvent) event);
                 }
             };
+        case SPAWN_CHANGE:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((WorldListener) listener).onSpawnChange((SpawnChangeEvent) event);
+                }
+            };
         case WORLD_SAVE:
             return new EventExecutor() {
                 public void execute(Listener listener, Event event) {


### PR DESCRIPTION
Added the SPAWN_CHANGE event, which occurs when a world's spawn is changed.

(Note: this has a corresponding commit in CraftBukkit which implements the SPAWN_CHANGE event in CraftWorld.setSpawnLocation(): https://github.com/Bukkit/CraftBukkit/pull/218)

This event includes the world whose spawn changed and its previous spawn location.

To listen for this event:
    PluginManager pm = getServer().getPluginManager();
    YourWorldListener worldListener = new YourWorldListener(this);
    pm.registerEvent(Event.Type.SPAWN_CHANGE, worldListener, Priority.Normal, this);

To use this event:
    public class YourWorldListener extends WorldListener {
        @Override
        public void onSpawnChange(SpawnChangeEvent event) {
            World world = event.getWorld();
            Location previousLocation = event.getPreviousLocation();
        }
    }

I tested this thoroughly before committing. It's a pretty simple addition, but it's also my first contribution to Bukkit. Please let me know if I didn't do something correctly or in line with Bukkit coding standards or vision or whatever.

Thanks!
