### PR TITLE
New INTERNAL_MESSAGE event

### DIFF
--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -418,6 +418,13 @@ public abstract class Event implements Serializable {
          * @see org.bukkit.event.server.PluginEvent
          */
         SERVER_COMMAND (Category.SERVER),
+        
+        /**
+         * Called when a message is sent to the terminal/console
+         *
+         * @see org.bukkit.event.server.PluginEvent
+         */
+        INTERNAL_MESSAGE (Category.SERVER),
 
         /**
          * WORLD EVENTS

--- a/src/main/java/org/bukkit/event/server/InternalMessageEvent.java
+++ b/src/main/java/org/bukkit/event/server/InternalMessageEvent.java
@@ -1,0 +1,64 @@
+package org.bukkit.event.server;
+
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+
+/**
+ * Server Command events
+ */
+public class InternalMessageEvent extends Event implements Cancellable {
+    
+    private boolean cancel = false;
+    private MessageType type;
+    private long thread_time = 0;
+    
+    public enum MessageType {
+        /**
+         * "Can't keep up! Did the system time change, or is the server overloaded?"
+         */
+        TOO_SLOW,
+        
+        /**
+         * "Time ran backwards! Did the system time change?"
+         */
+        TOO_FAST,
+    }
+    
+    public InternalMessageEvent( MessageType type ) {
+        super(Type.INTERNAL_MESSAGE);
+        this.type = type;
+    }
+    
+    /**
+     * Gets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @return true if this event is cancelled
+     */
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    /**
+     * Sets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @param cancel true if you wish to cancel this event
+     */
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+    
+    public MessageType getMessageType() {
+	return type;
+    }
+
+    public long getThreadTime() {
+        return thread_time;
+    }
+
+    public void setThreadTime(long thread_time) {
+        this.thread_time = thread_time;
+    }
+    
+}

--- a/src/main/java/org/bukkit/event/server/ServerListener.java
+++ b/src/main/java/org/bukkit/event/server/ServerListener.java
@@ -30,6 +30,14 @@ public class ServerListener implements Listener {
      */
     public void onServerCommand(ServerCommandEvent event) {
     }
+    
+    /**
+     * Called when a message is sent to the terminal/console
+     *
+     * @param event Relevant event details
+     */
+    public void onInternalMessage(InternalMessageEvent event) {
+    }
 
     // Prevent compilation of old signatures TODO: Remove after 1.4
     @Deprecated public final void onPluginDisable(PluginEvent event) {}

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -362,6 +362,12 @@ public final class JavaPluginLoader implements PluginLoader {
                     ((ServerListener) listener).onServerCommand((ServerCommandEvent) event);
                 }
             };
+        case INTERNAL_MESSAGE:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((ServerListener) listener).onInternalMessage((InternalMessageEvent) event);
+                }
+            };
 
         // World Events
         case CHUNK_LOAD:


### PR DESCRIPTION
I have written an event that is used to notify serverlisteners that the server sent an internal message. Right now, it only captures the "Can't keep up" and "Time ran backwards" messages. When those messages are sent, the event is fired, and a plugin can react to it. If the event is cancelled, the message will go away. 

This was written for a plugin that I am writing that will hide the "Can't keep up" messages and instead write them to a separate log. I have made a pull request in the other repo. Link: https://github.com/Bukkit/CraftBukkit/pull/221
