### PR TITLE
Entity.isDead returns true if the entity has been marked for removal

### DIFF
--- a/src/main/java/org/bukkit/entity/Entity.java
+++ b/src/main/java/org/bukkit/entity/Entity.java
@@ -104,6 +104,11 @@ public interface Entity {
     public void remove();
 
     /**
+     * Returns true if this entity has been marked for removal.
+     */
+    public boolean isDead();
+
+    /**
      * Gets the {@link Server} that contains this Entity
      *
      * @return Server instance running this Entity


### PR DESCRIPTION
New method that returns true if this entity has been marked for removal. 

Has a matching CraftBukkit Pull: https://github.com/Bukkit/CraftBukkit/pull/227
