### PR TITLE
Added the ability to set the quit message

### DIFF
--- a/src/main/java/org/bukkit/event/player/PlayerQuitEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerQuitEvent.java
@@ -3,7 +3,34 @@ package org.bukkit.event.player;
 import org.bukkit.entity.Player;
 
 public class PlayerQuitEvent extends PlayerEvent {
+
+    private String quitMessage;
+
     public PlayerQuitEvent(Player who) {
-        super(Type.PLAYER_QUIT, who);
+        this(who, "\u00A7e" + who.getName() + " left the game.");
     }
+
+    public PlayerQuitEvent(Player who, String quitMessage) {
+        super(Type.PLAYER_QUIT, who);
+        this.quitMessage = quitMessage;
+    }
+
+    /**
+     * Gets the quit message to send to all online players
+     *
+     * @return string quit message
+     */
+    public String getQuitMessage() {
+        return quitMessage;
+    }
+
+    /**
+     * Sets the quit message to send to all online players
+     *
+     * @param quitMessage quit message
+     */
+    public void setQuitMessage(String quitMessage) {
+        this.quitMessage = quitMessage;
+    }
+
 }


### PR DESCRIPTION
This pull adds the ability to set the leave message sent to other players when a player disconnects.

This is to match the previous pull that adds the function for messages when a player joins and leaves due to a kick.

There is a matching CraftBukkit pull.
https://github.com/Bukkit/CraftBukkit/pull/230
