### PR TITLE
interface for player.saveData and player.loadData

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -99,6 +99,18 @@ public interface Player extends HumanEntity, CommandSender {
     public void setSneaking(boolean sneak);
 
     /**
+     * Saves the players current location, health, inventory, motion, and other information into the username.dat file, in the world/player folder
+     */
+    public void saveData();
+
+    /**
+     * Loads the players current location, health, inventory, motion, and other information from the username.dat file, in the world/player folder
+     * 
+     * Note: This will overwrite the players current inventory, health, motion, etc, with the state from the saved dat file.
+     */
+    public void loadData();
+
+    /**
      * Forces an update of the player's entire inventory.
      *
      * @return


### PR DESCRIPTION
Adds inteface for player.saveData and player.loadData functions, which force the game to save or load the player state to and from Notch's dat files.

CraftBukkit Pull Request: https://github.com/Bukkit/CraftBukkit/pull/236
