### PR TITLE
Interface for opening inventory windows

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -4,6 +4,7 @@ package org.bukkit.entity;
 import java.net.InetSocketAddress;
 import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
+import org.bukkit.inventory.CustomInventory;
 import org.bukkit.inventory.Inventory;
 
 /**
@@ -110,6 +111,13 @@ public interface Player extends HumanEntity, CommandSender {
      * @param inventory to use in the dialog GUI
      */
     public void openInventoryWindow(Inventory inventory);
+
+    /**
+     * Opens a custom inventory dialog to the player, with the given inventory displayed in the upper pane, and the player's inventory in the lower pane;
+     * 
+     * @param inventory to use in the dialog GUI
+     */
+    public void openInventoryWindow(CustomInventory inv);
 
     /**
      * Opens an workbench dialog to the player, using the workbench at the given location

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -125,18 +125,6 @@ public interface Player extends HumanEntity, CommandSender {
      * @param location of the workbench to use. Must be a valid workbench.
      */
     public void openWorkbenchWindow(Location location);
-    
-    /**
-     * Saves the players current location, health, inventory, motion, and other information into the username.dat file, in the world/player folder
-     */
-    public void savePlayerData();
-    
-    /**
-     * Loads the players current location, health, inventory, motion, and other information from the username.dat file, in the world/player folder
-     * 
-     * Note: This will overwrite the players current inventory, health, motion, etc, with the state from the saved dat file.
-     */
-    public void loadPlayerData();
 
     /**
      * Forces an update of the player's entire inventory.

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -4,6 +4,7 @@ package org.bukkit.entity;
 import java.net.InetSocketAddress;
 import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
+import org.bukkit.inventory.Inventory;
 
 /**
  * Represents a player, connected or not
@@ -97,6 +98,37 @@ public interface Player extends HumanEntity, CommandSender {
      * @param sneak true if player should appear sneaking
      */
     public void setSneaking(boolean sneak);
+
+    /**
+     * Closes any dialog windows the client may have open at the time. If no windows are open, it does nothing
+     */
+    public void closeWindow();
+
+    /**
+     * Opens an inventory dialog to the player, with the given inventory displayed in the upper pane, and the player's inventory in the lower pane;
+     * 
+     * @param inventory to use in the dialog GUI
+     */
+    public void openInventoryWindow(Inventory inventory);
+
+    /**
+     * Opens an workbench dialog to the player, using the workbench at the given location
+     * 
+     * @param location of the workbench to use. Must be a valid workbench.
+     */
+    public void openWorkbenchWindow(Location location);
+    
+    /**
+     * Saves the players current location, health, inventory, motion, and other information into the username.dat file, in the world/player folder
+     */
+    public void savePlayerData();
+    
+    /**
+     * Loads the players current location, health, inventory, motion, and other information from the username.dat file, in the world/player folder
+     * 
+     * Note: This will overwrite the players current inventory, health, motion, etc, with the state from the saved dat file.
+     */
+    public void loadPlayerData();
 
     /**
      * Forces an update of the player's entire inventory.

--- a/src/main/java/org/bukkit/inventory/CustomInventory.java
+++ b/src/main/java/org/bukkit/inventory/CustomInventory.java
@@ -1,0 +1,86 @@
+package org.bukkit.inventory;
+
+import java.util.HashMap;
+
+import org.bukkit.inventory.ItemStack;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+
+/**
+ * An interface to implement for custom inventory windows.
+ * 
+ * @author Celtic Minstrel
+ */
+public interface CustomInventory {
+
+    /**
+     * Get the number of rows in this inventory window (up to 6, with nine slots per row).
+     * 
+     * @return The number of rows
+     */
+    int getRows();
+
+    /**
+     * Get the title of this inventory window.
+     * 
+     * @return The window title
+     */
+    String getTitle();
+
+    /**
+     * Get the maximum stack size of items in this window.
+     * 
+     * @return The maximum stack size
+     */
+    int getMaxStack();
+
+    /**
+     * Split a stack from this window into two stacks and return one of them.
+     * 
+     * @param slot The slot to split
+     * @param amount How much of the item to return
+     * @return An item stack
+     */
+    ItemStack takeSomeFrom(int slot, int amount);
+
+    /**
+     * Set one of the items in this window.
+     * 
+     * @param slot The slot to set
+     * @param stack The new item stack
+     */
+    void setItem(int slot, ItemStack stack);
+
+    /**
+     * Get one of the items in this window.
+     * 
+     * @param slot The slot to fetch from
+     * @return The item in the slot
+     */
+    ItemStack getItem(int slot);
+
+    /**
+     * Check whether the object that this window belongs to is still available.
+     * For example, if the object no longer exists, it would return false.
+     * 
+     * @return Whether the object is available
+     */
+    boolean isAvailable();
+
+    /**
+     * Get the location of the object that this window belongs to.
+     * 
+     * @return The location
+     */
+    Location getLocation();
+
+    /**
+     * Get the range from which the player can use the object.
+     * 
+     * @return The range
+     */
+    double getUseRange();
+
+
+}

--- a/src/main/java/org/bukkit/inventory/Inventory.java
+++ b/src/main/java/org/bukkit/inventory/Inventory.java
@@ -214,4 +214,11 @@ public interface Inventory {
      * Clear out the whole index
      */
     public void clear();
+    
+    /**
+     * Get the custom window, if any.
+     * 
+     * @return The custom window, or null if it's a built-in window
+     */
+    public CustomInventory getCustomWindow();
 }


### PR DESCRIPTION
Replaces [this](https://github.com/Bukkit/Bukkit/pull/185) and adds a mechanism for customized windows.

This does not rely on having a proper inventory hook system, but it would be complemented by one, and a few things that are currently glitchy (such as changing maximum stack size) would benefit from it.

[Corresponding CraftBukkit request](https://github.com/Bukkit/CraftBukkit/pull/237)
