### PR TITLE
Added Interface for MaximumLogoutDelayTicks and LogoutDelayTicks

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -99,6 +99,28 @@ public interface Player extends HumanEntity, CommandSender {
     public void setSneaking(boolean sneak);
 
     /**
+     * Gets the number of ticks that a player will remain in the world after logging out
+     */
+    public int getMaximumLogoutDelayTicks();
+
+    /**
+     * Sets the number of ticks that a player will remain in the world after logging out
+     * @param delay the number of ticks
+     */
+    public void setMaximumLogoutDelayTicks(int delay);
+
+    /**
+     * Gets the number of ticks remaining before the player is removed from the world, after logout. If still online will return 0.
+     */
+    public int getLogoutDelayTicks();
+
+    /**
+     * Sets the number of ticks remaining before the player is removed, after logout. This can only be set after the player goes offline.
+     * @param delay the number of ticks
+     */
+    public void setLogoutDelayTicks(int delay);
+
+    /**
      * Forces an update of the player's entire inventory.
      *
      * @return


### PR DESCRIPTION
Interface of MaximumLogoutDelayTicks and LogoutDelayTicks. When MaximumLogoutDelayTicks is set to a value above zero, and a player logs out, their "ghost" will remain in game for the set number of ticks, and can be attacked and even killed. If the player logs back in while their ghost is still on, the player get's updated to the latest settings of the ghost, and the ghost dies. (The switch is seamless). Otherwise, once the tick counter has expired, the ghost disappears.

CraftBukkit Pull Request: https://github.com/Bukkit/CraftBukkit/pull/239
