### PR TITLE
added whodunnit to EntityDeathEvent

### DIFF
--- a/src/main/java/org/bukkit/event/entity/EntityDeathEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDeathEvent.java
@@ -10,10 +10,28 @@ import org.bukkit.inventory.ItemStack;
  */
 public class EntityDeathEvent extends EntityEvent {
     private List<ItemStack> drops;
+    private Entity killer;
 
-    public EntityDeathEvent(final Entity what, final List<ItemStack> drops) {
-        super(Type.ENTITY_DEATH, what);
+    /**
+     * Construct an EntityDeathEvent for a victim with an unknown causing entity
+     * @param victim the entity who died
+     * @param drops the items left behind by the dead entity
+     */
+    public EntityDeathEvent(final Entity victim, final List<ItemStack> drops) {
+        super(Type.ENTITY_DEATH, victim);
         this.drops = drops;
+        this.killer = null;
+    }
+    
+    /**
+     * Construct and EntityDeathEvent for a victim with a known causing entity
+     * @param victim the entity who died
+     * @param killer the entity causing the death
+     * @param drops the items left behind by the dead entity
+     */
+    public EntityDeathEvent(final Entity victim, final Entity killer, final List<ItemStack> drops) {
+        this(victim, drops);
+        this.killer = killer;
     }
 
     /**
@@ -23,5 +41,21 @@ public class EntityDeathEvent extends EntityEvent {
      */
     public List<ItemStack> getDrops() {
         return drops;
+    }
+    
+    /**
+     * Set the items that will be dropped after the entity's death
+     * @param drops a {@link List} of {@link ItemStack} to be dropped
+     */
+    public void setDrops(List<ItemStack> drops) {
+        this.drops = drops;
+    }
+    
+    /**
+     * Retrieve the entity that caused the death, if known.
+     * @return the entity that caused the death or null if it's not known
+     */
+    public Entity getKiller() {
+        return killer;
     }
 }


### PR DESCRIPTION
This commits adds a constructor and getter for the death causing entity to EntityDeathEvent. The event now also contains a setter to allow the items to be dropped to be changed.

Use is made of the new constructor in the pull request at https://github.com/Bukkit/CraftBukkit/pull/244
