### PR TITLE
added get/setLastDamageCause to Entity interface

### DIFF
--- a/src/main/java/org/bukkit/entity/Entity.java
+++ b/src/main/java/org/bukkit/entity/Entity.java
@@ -4,6 +4,7 @@ package org.bukkit.entity;
 import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.World;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.util.Vector;
 
 import java.util.List;
@@ -168,5 +169,17 @@ public interface Entity {
      * @param distance 
      */
     public void setFallDistance(float distance);
+    
+    /**
+     * Record the last {@link EntityDamageEvent} inflicted on this entity
+     * @param event a {@link EntityDamageEvent}
+     */
+    public void setLastDamageCause(EntityDamageEvent event);
+    
+    /**
+     * Retrieve the last {@link EntityDamageEvent} inflicted on this entity. This event may have been cancelled.
+     * @return the last known {@link EntityDamageEvent} or null if hithero unharmed
+     */
+    public EntityDamageEvent getLastDamageCause();
 
 }

--- a/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
@@ -13,18 +13,16 @@ public class EntityDamageEvent extends EntityEvent implements Cancellable {
     private boolean cancelled;
     private DamageCause cause;
 
-    public EntityDamageEvent(Entity damagee, DamageCause cause, int damage)
-    {
-        super(Event.Type.ENTITY_DAMAGE, damagee);
-        this.cause = cause;
-        this.damage = damage;
+    public EntityDamageEvent(Entity damagee, DamageCause cause, int damage) {
+        this(Event.Type.ENTITY_DAMAGE, damagee, cause, damage);
     }
 
-    protected EntityDamageEvent(Event.Type type, Entity damagee, DamageCause cause, int damage)
-    {
+    protected EntityDamageEvent(Event.Type type, Entity damagee, DamageCause cause, int damage) {
         super(type, damagee);
         this.cause = cause;
         this.damage = damage;
+        
+        damagee.setLastDamageCause(this);
     }
 
     /**


### PR DESCRIPTION
this is an alternative to https://github.com/Bukkit/Bukkit/pull/195 . The method is called in the EntityDamageEvent constructor and implemented in CraftEntity for all entities here: https://github.com/Bukkit/CraftBukkit/pull/246
