### PR TITLE
Adding an entity right clicked event.

### DIFF
--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -214,6 +214,13 @@ public abstract class Event implements Serializable {
          * @see org.bukkit.event.player.PlayerItemEvent
          */
         PLAYER_INTERACT (Category.PLAYER),
+        
+        /**
+         * Called when a player right clicks an entity
+         *
+         * @see org.bukkit.event.player.PlayerInteractEntityEvent
+         */
+        PLAYER_INTERACT_ENTITY (Category.PLAYER),
 
         /**
          * Called when a player throws an egg and it might hatch

--- a/src/main/java/org/bukkit/event/player/PlayerInteractEntityEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerInteractEntityEvent.java
@@ -1,0 +1,49 @@
+package org.bukkit.event.player;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+
+/**
+ * 
+ * @author fullwall
+ * 
+ */
+public class PlayerInteractEntityEvent extends PlayerEvent implements Cancellable {
+	protected Entity clickedEntity;
+	boolean cancelled = false;
+
+	public PlayerInteractEntityEvent(Player who, Entity clickedEntity) {
+		super(Type.PLAYER_INTERACT_ENTITY, who);
+		this.clickedEntity = clickedEntity;
+	}
+
+	/**
+     * Gets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @return true if this event is cancelled
+     */
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    /**
+     * Sets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins.
+     *
+     * @param cancel true if you wish to cancel this event
+     */
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+    
+    /**
+     * Gets the entity that was rightclicked by the player.
+     * 
+     * @return entity right clicked by player
+     */
+    public Entity getRightClicked() {
+    	return this.clickedEntity;
+    }
+}

--- a/src/main/java/org/bukkit/event/player/PlayerListener.java
+++ b/src/main/java/org/bukkit/event/player/PlayerListener.java
@@ -91,6 +91,14 @@ public class PlayerListener implements Listener {
      */
     public void onPlayerInteract(PlayerInteractEvent event) {
     }
+    
+    /**
+     * Called when a player right clicks an entity.
+     *
+     * @param event Relevant event details
+     */
+    public void onPlayerInteractEntity(PlayerInteractEntityEvent event) {
+    }
 
     /**
      * Called when a player attempts to log in to the server

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -252,6 +252,12 @@ public final class JavaPluginLoader implements PluginLoader {
                     ((PlayerListener) listener).onPlayerInteract((PlayerInteractEvent) event);
                 }
             };
+        case PLAYER_INTERACT_ENTITY:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((PlayerListener) listener).onPlayerInteractEntity((PlayerInteractEntityEvent) event);
+                }
+            };
         case PLAYER_LOGIN:
             return new EventExecutor() {
                 public void execute(Listener listener, Event event) {


### PR DESCRIPTION
This pull request is to add the Bukkit API for the new entity right clicked event, called 'PlayerInteractEntityEvent'. It is called whenever the player right clicks an entity (the hooks for this are in the craftbukkit pull request).
