### PR TITLE
(re)implemented painting events, fixed for 1.4 and different event naming

### DIFF
--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -91,7 +91,12 @@ public abstract class Event implements Serializable {
          * @see Category.LIVING_ENTITY
          */
         PLAYER,
-
+        
+        /**
+         * Represents Entity-based events
+         */
+        ENTITY,
+        
         /**
          * Represents Block-based events
          */
@@ -492,6 +497,24 @@ public abstract class Event implements Serializable {
          * Called when a World is loaded
          */
         WORLD_LOAD (Category.WORLD),
+
+        /**
+         * ENTITY EVENTS
+         */
+
+        /**
+         * Called when a painting is placed by player
+         *
+         * @see org.bukkit.event.painting.PaintingCreateEvent
+         */
+        PAINTING_PLACE (Category.ENTITY),
+
+        /**
+         * Called when a painting is removed
+         *
+         * @see org.bukkit.event.painting.PaintingRemoveEvent
+         */
+        PAINTING_BREAK (Category.ENTITY),
 
         /**
          * LIVING_ENTITY EVENTS

--- a/src/main/java/org/bukkit/event/entity/EntityListener.java
+++ b/src/main/java/org/bukkit/event/entity/EntityListener.java
@@ -1,6 +1,8 @@
 package org.bukkit.event.entity;
 
 import org.bukkit.event.Listener;
+import org.bukkit.event.painting.PaintingPlaceEvent;
+import org.bukkit.event.painting.PaintingBreakEvent;
 
 /**
  * Handles all events fired in relation to entities
@@ -29,7 +31,13 @@ public class EntityListener implements Listener {
 
     public void onEntityTarget(EntityTargetEvent event) {
     }
-    
+
     public void onEntityInteract(EntityInteractEvent event) {
+    }
+
+    public void onPaintingPlace(PaintingPlaceEvent event){
+    }
+
+    public void onPaintingBreak(PaintingBreakEvent event){
     }
 }

--- a/src/main/java/org/bukkit/event/painting/PaintingBreakByEntityEvent.java
+++ b/src/main/java/org/bukkit/event/painting/PaintingBreakByEntityEvent.java
@@ -1,0 +1,23 @@
+package org.bukkit.event.painting;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Painting;
+
+/**
+ * Triggered when a painting is removed by an entity
+ *
+ * @author Tanel Suurhans
+ */
+
+public class PaintingBreakByEntityEvent extends PaintingBreakEvent {
+    private Entity remover;
+
+    public PaintingBreakByEntityEvent(final Painting painting, final Entity remover) {
+        super(painting, RemoveCause.ENTITY);
+        this.remover = remover;
+    }
+
+    public Entity getRemover() {
+        return remover;
+    }
+}

--- a/src/main/java/org/bukkit/event/painting/PaintingBreakByWorldEvent.java
+++ b/src/main/java/org/bukkit/event/painting/PaintingBreakByWorldEvent.java
@@ -1,0 +1,15 @@
+package org.bukkit.event.painting;
+
+import org.bukkit.entity.Painting;
+
+/**
+ * Triggered when a painting is removed by the world (water flowing over it, block damaged behind it)
+ *
+ * @author Tanel Suurhans
+ */
+
+public class PaintingBreakByWorldEvent extends PaintingBreakEvent{
+    public PaintingBreakByWorldEvent(final Painting painting) {
+        super(painting, RemoveCause.WORLD);
+    }
+}

--- a/src/main/java/org/bukkit/event/painting/PaintingBreakEvent.java
+++ b/src/main/java/org/bukkit/event/painting/PaintingBreakEvent.java
@@ -1,0 +1,52 @@
+package org.bukkit.event.painting;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Painting;
+import org.bukkit.event.Cancellable;
+
+/**
+ * Triggered when a painting is removed
+ *
+ * @author Tanel Suurhans
+ */
+
+public class PaintingBreakEvent extends PaintingEvent implements Cancellable {
+
+    private boolean cancelled;
+    private RemoveCause cause;
+
+    public PaintingBreakEvent(final Painting painting, RemoveCause cause) {
+        super(Type.PAINTING_BREAK, painting);
+        this.cause = cause;
+    }
+
+    public RemoveCause getCause(){
+        return cause;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    /**
+     * An enum to specify the cause of the removal
+     */
+    public enum RemoveCause {
+
+        /**
+         * Removed by an entity
+         */
+        ENTITY,
+
+        /**
+         * Removed by the world - block destroyed behind, water flowing over etc
+         */
+        WORLD
+
+    }
+
+}

--- a/src/main/java/org/bukkit/event/painting/PaintingEvent.java
+++ b/src/main/java/org/bukkit/event/painting/PaintingEvent.java
@@ -1,0 +1,29 @@
+package org.bukkit.event.painting;
+
+import org.bukkit.entity.Painting;
+import org.bukkit.event.Event;
+
+/**
+ * Represents a painting-related event.
+ *
+ * @author Tanel Suurhans
+ */
+public class PaintingEvent extends Event {
+
+    protected Painting painting;
+
+    protected PaintingEvent(final Type type, final Painting painting) {
+        super(type);
+        this.painting = painting;
+    }
+
+    /**
+     * Get the painting.
+     *
+     * @return the painting
+     */
+    public Painting getPainting() {
+        return painting;
+    }
+
+}

--- a/src/main/java/org/bukkit/event/painting/PaintingPlaceEvent.java
+++ b/src/main/java/org/bukkit/event/painting/PaintingPlaceEvent.java
@@ -1,0 +1,65 @@
+package org.bukkit.event.painting;
+
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Painting;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+
+/**
+ * Triggered when a painting is created in the world
+ *
+ * @author Tanel Suurhans
+ */
+public class PaintingPlaceEvent extends PaintingEvent implements Cancellable {
+
+    private boolean cancelled;
+
+    private Player player;
+    private Block block;
+    private BlockFace blockFace;
+
+    public PaintingPlaceEvent(final Painting painting, final Player player, Block block, BlockFace blockFace) {
+        super(Event.Type.PAINTING_PLACE, painting);
+        this.player = player;
+        this.block = block;
+        this.blockFace = blockFace;
+    }
+
+    /**
+     * Returns the player placing the painting
+     *
+     * @return Entity returns the player placing the painting
+     */
+    public Player getPlayer() {
+        return player;
+    }
+
+    /**
+     * Returns the block painting placed on
+     *
+     * @return Block returns the block painting placed on
+     */
+    public Block getBlock() {
+        return block;
+    }
+
+    /**
+     * Returns the face of the block that the painting was placed on
+     *
+     * @return BlockFace returns the face of the block the painting was placed on
+     */
+    public BlockFace getBlockFace() {
+        return blockFace;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+}

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -19,6 +19,7 @@ import org.bukkit.event.CustomEventListener;
 import org.bukkit.event.Event;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.*;
+import org.bukkit.event.painting.*;
 import org.bukkit.event.entity.*;
 import org.bukkit.event.player.*;
 import org.bukkit.event.server.*;
@@ -442,6 +443,20 @@ public final class JavaPluginLoader implements PluginLoader {
             return new EventExecutor() {
                 public void execute(Listener listener, Event event) {
                     ((WorldListener) listener).onWorldLoad((WorldLoadEvent) event);
+                }
+            };
+
+        //Painting Events
+        case PAINTING_PLACE:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((EntityListener) listener).onPaintingPlace((PaintingPlaceEvent) event);
+                }
+            };
+        case PAINTING_BREAK:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((EntityListener) listener).onPaintingBreak((PaintingBreakEvent) event);
                 }
             };
 


### PR DESCRIPTION
Fixed and implemented the painting events originally designed and implemented by tanelsuurhans in this pull request: https://github.com/Bukkit/Bukkit/pull/131/ -- but since it's several months old, I went ahead and updated it for my personal use, adding it here incase it can get pulled this time around.  

I went ahead and changed the event names to match closer to BlockPlace and BlockBreak (PaintingPlace and PaintingBreak) -- pretty much everything else is the same as what he wrote, except for the updates to make it 1.4 and handle the bukkit changes since then.

Matching CraftBukkit pull request: https://github.com/Bukkit/CraftBukkit/pull/258
