### PR TITLE
Implementation of weather-related events

### DIFF
--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -103,7 +103,12 @@ public abstract class Event implements Serializable {
         LIVING_ENTITY,
 
         /**
-         * Represents Vehicle-based events
+         * Represents Weather-based events
+         */
+        WEATHER,
+
+        /**
+         * Vehicle-based events
          */
         VEHICLE,
 
@@ -568,6 +573,45 @@ public abstract class Event implements Serializable {
          * @see org.bukkit.event.entity.EntityInteractEvent
          */
         ENTITY_INTERACT (Category.LIVING_ENTITY),
+
+        /**
+         * Called when a creeper gains or loses a power shell
+         *
+         * @see org.bukkit.event.entity.CreeperPowerEvent
+         */
+        CREEPER_POWER (Category.LIVING_ENTITY),
+
+        /**
+         * Called when a pig is zapped, zombifying it
+         *
+         * @see org.bukkit.event.entity.PigZapEvent
+         */
+        PIG_ZAP (Category.LIVING_ENTITY),
+
+        /**
+         * WEATHER EVENTS
+         */
+
+        /**
+         * Called when a lightning entity strikes somewhere
+         *
+         * @see org.bukkit.event.weather.LightningStrikeEvent
+         */
+        LIGHTNING_STRIKE (Category.WEATHER),
+
+        /**
+         * Called when the weather in a world changes
+         *
+         * @see org.bukkit.event.weather.WeatherChangeEvent
+         */
+        WEATHER_CHANGE (Category.WEATHER),
+
+        /**
+         * Called when the thunder state in a world changes
+         *
+         * @see org.bukkit.event.weather.ThunderChangeEvent
+         */
+        THUNDER_CHANGE (Category.WEATHER),
 
         /**
          * VEHICLE EVENTS

--- a/src/main/java/org/bukkit/event/entity/CreeperPowerEvent.java
+++ b/src/main/java/org/bukkit/event/entity/CreeperPowerEvent.java
@@ -1,0 +1,89 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Cancellable;
+
+/**
+ * Stores data for creepers being (un)powered
+ */
+public class CreeperPowerEvent extends EntityEvent implements Cancellable {
+
+    private boolean canceled;
+    private Entity creeper;
+    private PowerCause cause;
+    private Entity bolt;
+
+    public CreeperPowerEvent(Entity creeper, Entity bolt, PowerCause cause) {
+        super(Type.CREEPER_POWER, creeper);
+        this.creeper = creeper;
+        this.bolt = bolt;
+        this.cause = cause;
+    }
+
+    public CreeperPowerEvent(Entity creeper, PowerCause cause) {
+        super(Type.CREEPER_POWER, creeper);
+        this.creeper = creeper;
+        this.cause = cause;
+        this.bolt = null;
+    }
+
+    /**
+     * Gets the cancellation state of this event. A canceled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @return true if this event is canceled
+     */
+    public boolean isCancelled() {
+        return canceled;
+    }
+
+    /**
+     * Sets the cancellation state of this event. A canceled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @param cancel true if you wish to cancel this event
+     */
+    public void setCancelled(boolean cancel) {
+        canceled = cancel;
+    }
+
+    /**
+     * Gets the bolt which is striking the creeper.
+     *
+     * @return lightning entity
+     */
+    public Entity getLightning() {
+        return bolt;
+    }
+
+   /**
+    * Gets the cause of the creeper being (un)powered.
+    * @return A PowerCause value detailing the cause of change in power.
+    */
+    public PowerCause getCause() {
+        return cause;
+    }
+
+   /**
+    * An enum to specify the cause of the change in power
+    */
+     public enum PowerCause {
+         /**
+          * Power change caused by a lightning bolt
+          * Powered state: true
+          */
+         LIGHTNING,
+
+         /**
+          * Power change caused by something else (probably a plugin)
+          * Powered state: true
+          */
+         SET_ON,
+
+         /**
+          * Power change caused by something else (probably a plugin)
+          * Powered state: false
+          */
+         SET_OFF
+     }
+}

--- a/src/main/java/org/bukkit/event/entity/EntityListener.java
+++ b/src/main/java/org/bukkit/event/entity/EntityListener.java
@@ -32,4 +32,11 @@ public class EntityListener implements Listener {
     
     public void onEntityInteract(EntityInteractEvent event) {
     }
+
+    public void onPigZap(PigZapEvent event) {
+    }
+
+    public void onCreeperPower(CreeperPowerEvent event) {
+    }
+
 }

--- a/src/main/java/org/bukkit/event/entity/PigZapEvent.java
+++ b/src/main/java/org/bukkit/event/entity/PigZapEvent.java
@@ -1,0 +1,61 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Cancellable;
+
+/**
+ * Stores data for pigs being zapped
+ */
+public class PigZapEvent extends EntityEvent implements Cancellable {
+
+    private boolean canceled;
+    private Entity pig;
+    private Entity pigzombie;
+    private Entity bolt;
+
+    public PigZapEvent(Entity pig, Entity bolt, Entity pigzombie) {
+        super(Type.PIG_ZAP, pig);
+        this.pig = pig;
+        this.bolt = bolt;
+        this.pigzombie = pigzombie;
+    }
+
+    /**
+     * Gets the cancellation state of this event. A canceled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @return true if this event is canceled
+     */
+    public boolean isCancelled() {
+        return canceled;
+    }
+
+    /**
+     * Sets the cancellation state of this event. A canceled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @param cancel true if you wish to cancel this event
+     */
+    public void setCancelled(boolean cancel) {
+        canceled = cancel;
+    }
+
+    /**
+     * Gets the bolt which is striking the pig.
+     *
+     * @return lightning entity
+     */
+    public Entity getLightning() {
+        return bolt;
+    }
+
+    /**
+     * Gets the zombie pig that will replace the pig,
+     * provided the event is not cancelled first.
+     *
+     * @return resulting entity
+     */
+    public Entity getPigZombie() {
+        return pigzombie;
+    }
+}

--- a/src/main/java/org/bukkit/event/weather/LightningStrikeEvent.java
+++ b/src/main/java/org/bukkit/event/weather/LightningStrikeEvent.java
@@ -1,0 +1,51 @@
+package org.bukkit.event.weather;
+
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Cancellable;
+
+/**
+ * Stores data for lightning striking
+ */
+public class LightningStrikeEvent extends WeatherEvent implements Cancellable {
+
+    private boolean canceled;
+    private Entity bolt;
+    private World world;
+
+    public LightningStrikeEvent(World world, Entity bolt) {
+        super(Type.LIGHTNING_STRIKE, world);
+        this.bolt = bolt;
+        this.world = world;
+    }
+
+    /**
+     * Gets the cancellation state of this event. A canceled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @return true if this event is canceled
+     */
+    public boolean isCancelled() {
+        return canceled;
+    }
+
+    /**
+     * Sets the cancellation state of this event. A canceled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @param cancel true if you wish to cancel this event
+     */
+    public void setCancelled(boolean cancel) {
+        canceled = cancel;
+    }
+
+    /**
+     * Gets the bolt which is striking the earth.
+     *
+     * @return lightning entity
+     */
+    public Entity getLightning() {
+        return bolt;
+    }
+
+}

--- a/src/main/java/org/bukkit/event/weather/ThunderChangeEvent.java
+++ b/src/main/java/org/bukkit/event/weather/ThunderChangeEvent.java
@@ -1,0 +1,50 @@
+package org.bukkit.event.weather;
+
+import org.bukkit.World;
+import org.bukkit.event.Cancellable;
+
+/**
+ * Stores data for thudner state changing in a world
+ */
+public class ThunderChangeEvent extends WeatherEvent implements Cancellable {
+
+    private boolean canceled;
+    private boolean to;
+    private World world;
+
+    public ThunderChangeEvent(World world, boolean to) {
+        super(Type.THUNDER_CHANGE, world);
+        this.world = world;
+        this.to = to;
+    }
+
+    /**
+     * Gets the cancellation state of this event. A canceled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @return true if this event is canceled
+     */
+    public boolean isCancelled() {
+        return canceled;
+    }
+
+    /**
+     * Sets the cancellation state of this event. A canceled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @param cancel true if you wish to cancel this event
+     */
+    public void setCancelled(boolean cancel) {
+        canceled = cancel;
+    }
+
+    /**
+     * Gets the state of thunder that the world is being set to
+     *
+     * @return true if the weather is being set to thundering, false otherwise
+     */
+    public boolean toThunderState() {
+        return to;
+    }
+
+}

--- a/src/main/java/org/bukkit/event/weather/WeatherChangeEvent.java
+++ b/src/main/java/org/bukkit/event/weather/WeatherChangeEvent.java
@@ -1,0 +1,50 @@
+package org.bukkit.event.weather;
+
+import org.bukkit.World;
+import org.bukkit.event.Cancellable;
+
+/**
+ * Stores data for weather changing in a world
+ */
+public class WeatherChangeEvent extends WeatherEvent implements Cancellable {
+
+    private boolean canceled;
+    private boolean to;
+    private World world;
+
+    public WeatherChangeEvent(World world, boolean to) {
+        super(Type.WEATHER_CHANGE, world);
+        this.world = world;
+        this.to = to;
+    }
+
+    /**
+     * Gets the cancellation state of this event. A canceled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @return true if this event is canceled
+     */
+    public boolean isCancelled() {
+        return canceled;
+    }
+
+    /**
+     * Sets the cancellation state of this event. A canceled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @param cancel true if you wish to cancel this event
+     */
+    public void setCancelled(boolean cancel) {
+        canceled = cancel;
+    }
+
+    /**
+     * Gets the state of weather that the world is being set to
+     *
+     * @return true if the weather is being set to raining, false otherwise
+     */
+    public boolean toWeatherState() {
+        return to;
+    }
+
+}

--- a/src/main/java/org/bukkit/event/weather/WeatherEvent.java
+++ b/src/main/java/org/bukkit/event/weather/WeatherEvent.java
@@ -1,0 +1,24 @@
+package org.bukkit.event.weather;
+
+import org.bukkit.World;
+import org.bukkit.event.Event;
+
+/**
+ * Represents an Weather-related event
+ */
+public class WeatherEvent extends Event {
+    protected World world;
+
+    public WeatherEvent(final Event.Type type, final World where) {
+        super(type);
+        world = where;
+    }
+
+    /**
+     * Returns the World where this event is occuring
+     * @return World this event is occuring in
+     */
+    public final World getWorld() {
+        return world;
+    }
+}

--- a/src/main/java/org/bukkit/event/weather/WeatherListener.java
+++ b/src/main/java/org/bukkit/event/weather/WeatherListener.java
@@ -1,0 +1,21 @@
+package org.bukkit.event.weather;
+
+import org.bukkit.event.Listener;
+
+/**
+ * Handles all events fired in relation to weather
+ */
+public class WeatherListener implements Listener {
+    public WeatherListener() {
+    }
+
+    public void onWeatherChange(WeatherChangeEvent event) {
+    }
+    
+    public void onThunderChange(ThunderChangeEvent event) {
+    }    
+
+    public void onLightningStrike(LightningStrikeEvent event) {
+    }
+
+}

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -24,6 +24,7 @@ import org.bukkit.event.player.*;
 import org.bukkit.event.server.*;
 import org.bukkit.event.vehicle.*;
 import org.bukkit.event.world.*;
+import org.bukkit.event.weather.*;
 import org.bukkit.plugin.*;
 import org.yaml.snakeyaml.error.YAMLException;
 
@@ -500,6 +501,18 @@ public final class JavaPluginLoader implements PluginLoader {
                     ((EntityListener) listener).onCreatureSpawn((CreatureSpawnEvent) event);
                 }
             };
+        case PIG_ZAP:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((EntityListener) listener).onPigZap((PigZapEvent) event);
+                }
+            };
+        case CREEPER_POWER:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((EntityListener) listener).onCreeperPower((CreeperPowerEvent) event);
+                }
+            };
 
         // Vehicle Events
         case VEHICLE_CREATE:
@@ -553,6 +566,26 @@ public final class JavaPluginLoader implements PluginLoader {
             return new EventExecutor() {
                 public void execute(Listener listener, Event event) {
                     ((VehicleListener) listener).onVehicleUpdate((VehicleUpdateEvent) event);
+                }
+            };
+
+        // Weather Events
+        case WEATHER_CHANGE:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((WeatherListener) listener).onWeatherChange((WeatherChangeEvent) event);
+                }
+            };
+        case THUNDER_CHANGE:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((WeatherListener) listener).onThunderChange((ThunderChangeEvent) event);
+                }
+            };
+        case LIGHTNING_STRIKE:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((WeatherListener) listener).onLightningStrike((LightningStrikeEvent) event);
                 }
             };
 


### PR DESCRIPTION
This has events for when lightning strikes, for when the state of weather (or thunder) changes in a world, and also for the two entity related events (creepers and pigs).
I ended up adding a new event category after a consensus in #bukkitdev since weather events didn't really fit anywhere else.
Note that cancelling the entity events will cancel them correctly on the server, but the client still "predicts", so a sighting of a "ghost pig" and several (3-5) zombie pigmen isn't rare when canceling the event, as well as powered creepers that aren't powered at all.

Corresponding CraftBukkit pull: https://github.com/Bukkit/CraftBukkit/pull/265
