### PR TITLE
Adds support for soft dependencies

### DIFF
--- a/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
+++ b/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
@@ -18,6 +18,7 @@ public final class PluginDescriptionFile {
     private String name = null;
     private String main = null;
     private ArrayList<String> depend = null;
+    private ArrayList<String> softDepend = null;
     private String version = null;
     private Object commands = null;
     private String description = null;
@@ -104,6 +105,10 @@ public final class PluginDescriptionFile {
         return depend;
     }
 
+    public Object getSoftDepend() {
+        return softDepend;
+    }
+
     /**
      * Gets the description of this plugin
      *
@@ -177,6 +182,14 @@ public final class PluginDescriptionFile {
             }
         }
 
+        if (map.containsKey("softdepend")) {
+            try {
+                softDepend = (ArrayList<String>)map.get("softdepend");
+            } catch (ClassCastException ex) {
+                throw new InvalidDescriptionException(ex, "softdepend is of wrong type");
+            }
+        }
+
         if (map.containsKey("database")) {
             try {
                 database = (Boolean)map.get("database");
@@ -229,6 +242,7 @@ public final class PluginDescriptionFile {
 
         if (commands != null) map.put("command", commands);
         if (depend != null) map.put("depend", depend);
+        if (softDepend != null) map.put("softdepend", softDepend);
         if (website != null) map.put("website", website);
         if (description != null) map.put("description", description);
 

--- a/src/main/java/org/bukkit/plugin/PluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/PluginLoader.java
@@ -23,6 +23,17 @@ public interface PluginLoader {
     public Plugin loadPlugin(File file) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException;
 
     /**
+     * Loads the plugin contained in the specified file
+     *
+     * @param file File to attempt to load
+     * @param ignoreSoftDependencies Loader will ignore soft dependencies if this flag is set to true
+     * @return Plugin that was contained in the specified file, or null if
+     * unsuccessful
+     * @throws InvalidPluginException Thrown when the specified file is not a plugin
+     */
+    public Plugin loadPlugin(File file, boolean ignoreSoftDependencies) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException;
+
+    /**
      * Returns a list of all filename filters expected by this PluginLoader
      */
     public Pattern[] getPluginFileFilters();

--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -105,7 +105,7 @@ public final class SimplePluginManager implements PluginManager {
                 Plugin plugin = null;
 
                 try {
-                    plugin = loadPlugin(file);
+                    plugin = loadPlugin(file, finalPass);
                     itr.remove();
                 } catch (UnknownDependencyException ex) {
                     if(finalPass) {
@@ -125,6 +125,7 @@ public final class SimplePluginManager implements PluginManager {
                 if (plugin != null) {
                     result.add(plugin);
                     allFailed = false;
+                    finalPass = false;
                 }
             }
             if(finalPass) {
@@ -148,6 +149,21 @@ public final class SimplePluginManager implements PluginManager {
      * @throws InvalidDescriptionException Thrown when the specified file contains an invalid description
      */
     public synchronized Plugin loadPlugin(File file) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException {
+        return loadPlugin(file, true);
+    }
+
+    /**
+     * Loads the plugin in the specified file
+     *
+     * File must be valid according to the current enabled Plugin interfaces
+     *
+     * @param file File containing the plugin to load
+     * @param ignoreSoftDependencies Loader will ignore soft dependencies if this flag is set to true
+     * @return The Plugin loaded, or null if it was invalid
+     * @throws InvalidPluginException Thrown when the specified file is not a valid plugin
+     * @throws InvalidDescriptionException Thrown when the specified file contains an invalid description
+     */
+    public synchronized Plugin loadPlugin(File file, boolean ignoreSoftDependencies) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException {
         Set<Pattern> filters = fileAssociations.keySet();
         Plugin result = null;
 
@@ -157,7 +173,7 @@ public final class SimplePluginManager implements PluginManager {
 
             if (match.find()) {
                 PluginLoader loader = fileAssociations.get(filter);
-                result = loader.loadPlugin(file);
+                result = loader.loadPlugin(file, ignoreSoftDependencies);
             }
         }
 

--- a/src/main/java/org/bukkit/plugin/UnknownSoftDependencyException.java
+++ b/src/main/java/org/bukkit/plugin/UnknownSoftDependencyException.java
@@ -1,0 +1,46 @@
+
+package org.bukkit.plugin;
+
+/**
+ * Thrown when attempting to load an invalid Plugin file
+ */
+public class UnknownSoftDependencyException extends UnknownDependencyException {
+
+    private static final long serialVersionUID = 5721389371901775899L;
+
+    /**
+     * Constructs a new UnknownSoftDependencyException based on the given Exception
+     *
+     * @param throwable Exception that triggered this Exception
+     */
+    public UnknownSoftDependencyException(Throwable throwable) {
+        this(throwable, "Unknown soft dependency");
+    }
+
+    /**
+     * Constructs a new UnknownSoftDependencyException with the given message
+     *
+     * @param message Brief message explaining the cause of the exception
+     */
+    public UnknownSoftDependencyException(final String message) {
+        this(null, message);
+    }
+
+    /**
+     * Constructs a new UnknownSoftDependencyException based on the given Exception
+     *
+     * @param message Brief message explaining the cause of the exception
+     * @param throwable Exception that triggered this Exception
+     */
+    public UnknownSoftDependencyException(final Throwable throwable, final String message) {
+        super(throwable, message);
+    }
+
+    /**
+     * Constructs a new UnknownSoftDependencyException
+     */
+    public UnknownSoftDependencyException() {
+        this(null, "Unknown dependency");
+    }
+
+}

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -45,6 +45,10 @@ public final class JavaPluginLoader implements PluginLoader {
     }
 
     public Plugin loadPlugin(File file) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException {
+        return loadPlugin(file, false);
+    }
+
+    public Plugin loadPlugin(File file, boolean ignoreSoftDependencies) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException {
         JavaPlugin result = null;
         PluginDescriptionFile description = null;
 
@@ -123,6 +127,28 @@ public final class JavaPluginLoader implements PluginLoader {
             PluginClassLoader current = loaders.get(pluginName);
             if(current == null) {
                 throw new UnknownDependencyException(pluginName);
+            }
+        }
+
+        if(!ignoreSoftDependencies) {
+            ArrayList<String> softDepend;
+            try {
+                softDepend = (ArrayList)description.getSoftDepend();
+                if(softDepend == null) {
+                    softDepend = new ArrayList<String>();
+                }
+            } catch (ClassCastException ex) {
+                 throw new InvalidPluginException(ex);
+            }
+
+            for(String pluginName : softDepend) {
+                if(loaders == null) {
+                    throw new UnknownSoftDependencyException(pluginName);
+                }
+                PluginClassLoader current = loaders.get(pluginName);
+                if(current == null) {
+                    throw new UnknownSoftDependencyException(pluginName);
+                }
             }
         }
 


### PR DESCRIPTION
Added support for soft dependencies.  

Plugins will be loaded after dependencies which they have set as soft dependencies.  However, if the requested plugin is not present, then the plugin will still load without throwing an unknown dependency exception.
