### PR TITLE
Use instanceof instead of getClass() in equals() methods!

### DIFF
--- a/src/main/java/org/bukkit/Location.java
+++ b/src/main/java/org/bukkit/Location.java
@@ -218,7 +218,7 @@ public class Location implements Cloneable {
         if (obj == null) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
+        if (!(obj instanceof Location)) {
             return false;
         }
         final Location other = (Location) obj;

--- a/src/main/java/org/bukkit/util/Vector.java
+++ b/src/main/java/org/bukkit/util/Vector.java
@@ -522,7 +522,7 @@ public class Vector implements Cloneable {
 
         return Math.abs(x - other.x) < epsilon
                 && Math.abs(y - other.y) < epsilon
-                && Math.abs(z - other.z) < epsilon && (this.getClass().equals(obj.getClass()));
+                && Math.abs(z - other.z) < epsilon;
     }
 
     /**


### PR DESCRIPTION
This is a fix to allow subclasses of Location and Vector classes to work with the built-in equals() methods.
This way, subclasses don't have to implement their own completely copied equals() method and don't violate the equals() contract.
Please read [this short article](http://www.artima.com/intv/bloch17.html) to understand why it is bad to use getClass.equals(obj.getClass()) for equality checks!
