### PR TITLE
Per World PVP Settings

### DIFF
--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -497,6 +497,18 @@ public interface World {
     public long getSeed();
 
     /**
+     * Gets the current PVP setting for this world.
+     * @return
+     */
+    public boolean getPVP();
+
+    /**
+     * Sets the PVP setting for this world.
+     * @param pvp True/False whether PVP should be Enabled.
+     */
+    public void setPVP(boolean pvp);
+
+    /**
      * Saves world to disk
      */
     public void save();


### PR DESCRIPTION
Per world PVP Settings, when a world initially loads it is set to the same setting as the value in server.properties.

CraftBukkit - https://github.com/Bukkit/CraftBukkit/pull/272
