### PR TITLE
Added SnowFormEvent to handle blocks being snowed upon

### DIFF
--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -392,6 +392,13 @@ public abstract class Event implements Serializable {
          * @see org.bukkit.event.block.BlockBreakEvent
          */
         BLOCK_BREAK (Category.BLOCK),
+        
+        /**
+         * Called when world attempts to place a snow block during a snowfall
+         * 
+         * @see org.bukkit.event.block.SnowFormEvent
+         */
+        SNOW_FORM (Category.BLOCK),
 
         /**
          * INVENTORY EVENTS

--- a/src/main/java/org/bukkit/event/block/BlockListener.java
+++ b/src/main/java/org/bukkit/event/block/BlockListener.java
@@ -108,4 +108,12 @@ public class BlockListener implements Listener {
      */
     public void onBlockBreak(BlockBreakEvent event) {
     }
+    
+    /**
+     * Called when a world is attempting to place a block during a snowfall
+     *
+     * @param event Relevant event details
+     */
+    public void onSnowForm(SnowFormEvent event) {
+    }
 }

--- a/src/main/java/org/bukkit/event/block/SnowFormEvent.java
+++ b/src/main/java/org/bukkit/event/block/SnowFormEvent.java
@@ -1,0 +1,78 @@
+package org.bukkit.event.block;
+
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.event.Cancellable;
+
+/**
+ * 
+ * @author aPunch
+ */
+public class SnowFormEvent extends BlockEvent implements Cancellable {
+
+    private Material material;
+    private byte data;
+    private boolean cancel;
+
+    public SnowFormEvent(Material material, Block block) {
+        super(Type.SNOW_FORM, block);
+        this.material = material;
+        this.cancel = false;
+    }
+    
+    /**
+     * Gets the material being placed on a block during snowfall
+     *
+     * @return the material being placed by a snowfall
+     */
+    public Material getMaterial(){
+        return material;
+    }
+	
+    /**
+     * Sets the material to be placed on a block during a snowfall
+     *
+     * @param material the material to be placed during a snowfall
+     */
+    public void setMaterial(Material material){
+        this.material = material;
+    }
+	
+    /**
+     * Gets the block data of a block involved in a snowfall
+     *
+     * @return the data of the block being placed by a snowfall
+     */
+    public byte getData(){
+        return data;
+    }
+	
+    /**
+     * Sets the block data of a block involved in a snowfall
+     *
+     * @param data
+     */
+    public void setData(byte data){
+        this.data = data;
+    }
+	
+    /**
+     * Gets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @return true if this event is cancelled
+     */
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    /**
+     * Sets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @param cancel true if you wish to cancel snow from forming during a snowfall
+     */
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+}

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -400,6 +400,12 @@ public final class JavaPluginLoader implements PluginLoader {
                     ((BlockListener) listener).onBlockBreak((BlockBreakEvent) event);
                 }
             };
+        case SNOW_FORM:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((BlockListener) listener).onSnowForm((SnowFormEvent) event);
+                }
+            };
 
         // Server Events
         case PLUGIN_ENABLE:


### PR DESCRIPTION
This pull request is to add a new block event that handles blocks that are being snowed upon. It is called when a world is attempting to place a snow block during a snowfall. With it, plugins can change what block is formed when it is snowing. Hooks for this request can be found with its pairing CraftBukkit pull request.

CraftBukkit - https://github.com/Bukkit/CraftBukkit/pull/273
