### PR TITLE
Safe "Live" .jar file updating (auto-copies from Update On Load directory)

### DIFF
--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -24,6 +24,8 @@ import org.bukkit.event.Event;
 import org.bukkit.event.Event.Priority;
 import org.bukkit.event.Listener;
 
+import org.bukkit.util.FileUtil;
+
 /**
  * Handles all plugin management from the Server
  */
@@ -164,6 +166,20 @@ public final class SimplePluginManager implements PluginManager {
      * @throws InvalidDescriptionException Thrown when the specified file contains an invalid description
      */
     public synchronized Plugin loadPlugin(File file, boolean ignoreSoftDependencies) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException {
+         File parentDirectory = file.getParentFile();
+         File updateDirectory = null;
+         File updateFile = null;
+ 
+         if (parentDirectory != null && !(updateDirectory = new File(parentDirectory, "Update On Load")).exists()) {
+             updateDirectory.mkdirs();
+         }
+ 
+         if (updateDirectory != null && updateDirectory.isDirectory() && (updateFile = new File(updateDirectory, file.getName())).isFile()) {
+             if (FileUtil.copy(updateFile, file)) {
+                 updateFile.delete();
+             }
+        }
+
         Set<Pattern> filters = fileAssociations.keySet();
         Plugin result = null;
 

--- a/src/main/java/org/bukkit/util/FileUtil.java
+++ b/src/main/java/org/bukkit/util/FileUtil.java
@@ -1,0 +1,61 @@
+package org.bukkit.util;
+
+import java.nio.channels.FileChannel;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+/**
+ * Class containing file utilities
+ *
+ * @author raphfrk
+ */
+
+public class FileUtil {
+
+    /**
+     * This method copies one file to another location
+     *
+     * @param inFile the source filename
+     * @param outFile the target filename
+     * @return true on success
+     */
+
+    public static boolean copy(File inFile, File outFile) {
+        if (!inFile.exists()) {
+            return false;
+        }
+
+        FileChannel in = null;
+        FileChannel out = null;
+
+        try {
+            in = new FileInputStream(inFile).getChannel();
+            out = new FileOutputStream(outFile).getChannel();
+
+            long pos = 0;
+            long size = in.size();
+
+            while (pos < size) {
+                 pos += in.transferTo(pos, 10*1024*1024, out);
+            }
+        } catch (IOException ioe) {
+            return false;
+        } finally {
+            try {
+                if (in != null) {
+                    in.close();
+                }
+                if (out != null) {
+                    out.close();
+                }
+            } catch (IOException ioe) {
+                return false;
+            }
+        } 
+
+        return true;
+
+    }
+}


### PR DESCRIPTION
This pull allows .jar files to be safely updated "live"

The admin would place the new .jar file in the Update On Load sub-directory of the plugins folder.

When a reload happens, any files in that folder are copied into the main plugins folder.  This means that the over-write happens at a safe time, when all plugins have been disabled.

This should eliminate problems with classes not being found when reloading, since the file changed.
