### PR TITLE
Added various utility methods to make chunk handling easier.

### DIFF
--- a/src/main/java/org/bukkit/Chunk.java
+++ b/src/main/java/org/bukkit/Chunk.java
@@ -44,4 +44,50 @@ public interface Chunk {
     Entity[] getEntities();
     
     BlockState[] getTileEntities();
+    
+    /**
+     * Checks if the chunk is loaded.
+     * 
+     * @return
+     */
+    boolean isLoaded();
+    
+    /**
+     * Loads the chunk.
+     * 
+     * @param generate Whether or not to generate a chunk if it doesn't already exist
+     * @return true if the chunk has loaded successfully, otherwise false
+     */
+    boolean load(boolean generate);
+    
+    /**
+     * Loads the chunk.
+     * 
+     * @return true if the chunk has loaded successfully, otherwise false
+     */
+    boolean load();
+    
+    /**
+     * Unloads and optionally saves the Chunk
+     * 
+     * @param save Controls whether the chunk is saved
+     * @param safe Controls whether to unload the chunk when players are nearby
+     * @return true if the chunk has unloaded successfully, otherwise false
+     */
+    boolean unload(boolean save, boolean safe);
+    
+    /**
+     * Unloads and optionally saves the Chunk
+     * 
+     * @param save Controls whether the chunk is saved
+     * @return true if the chunk has unloaded successfully, otherwise false
+     */
+    boolean unload(boolean save);
+    
+    /**
+     * Unloads and optionally saves the Chunk
+     * 
+     * @return true if the chunk has unloaded successfully, otherwise false
+     */
+    boolean unload();
 }

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -144,7 +144,17 @@ public interface World {
      * @return true if the chunk has loaded successfully, otherwise false
      */
     public boolean loadChunk(int x, int z, boolean generate);
-
+    
+    /**
+     * Safely unloads and saves the {@link Chunk} at the specified coordinates
+     *
+     * This method is analogous to {@link #unloadChunk(int, int, boolean, boolean)} where safe and saveis true
+     *
+     * @param chunk the chunk to unload
+     * @return true if the chunk has unloaded successfully, otherwise false
+     */
+    public boolean unloadChunk(Chunk chunk);
+    
     /**
      * Safely unloads and saves the {@link Chunk} at the specified coordinates
      *


### PR DESCRIPTION
This seems a bit redundant but makes allot of code nicer.
chunk.unload();
is allot nicer then
getworld().unloadChunk(chunk);

CraftBukkit pull request: https://github.com/Bukkit/CraftBukkit/pull/287
