### PR TITLE
Line of sight with callbacks

### DIFF
--- a/src/main/java/org/bukkit/entity/LivingEntity.java
+++ b/src/main/java/org/bukkit/entity/LivingEntity.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.bukkit.Location;
 import org.bukkit.block.Block;
+import org.bukkit.util.Callback;
 
 /**
  * Represents a living entity, such as a monster or player
@@ -46,6 +47,34 @@ public interface LivingEntity extends Entity {
      * @return a Location at the eyes of the LivingEntity.
      */
     public Location getEyeLocation();
+
+    /**
+     * Gets all blocks along the player's line of sight
+     * List iterates from player's position to target inclusive
+     *
+     * @param callback Through every iteration it will call {@link Callback#call(Block)}. If set to/returns <code>null</code> only air is considered transparent.
+     * @param maxDistance This is the maximum distance to scan. This may be further limited by the server, but never to less than 100 blocks.
+     * @return List containing all blocks along the player's line of sight
+     */
+    public List<Block> getLineOfSightCallbacked(Callback<Boolean, Block> callback, int maxDistance);
+
+    /**
+     * Gets the block that the player has targeted
+     *
+     * @param callback Through every iteration it will call {@link Callback#call(Block)}. If set to/returns <code>null</code> only air is considered transparent.
+     * @param maxDistance This is the maximum distance to scan. This may be further limited by the server, but never to less than 100 blocks.
+     * @return Block that the player has targeted
+     */
+    public Block getTargetBlockCallbacked(Callback<Boolean, Block> callback, int maxDistance);
+
+    /**
+     * Gets the block that the player has targeted
+     *
+     * @param callback Through every iteration it will call {@link Callback#call(Block)}. If set to/returns <code>null</code> only air is considered transparent. 
+     * @param int This is the maximum distance to scan. This may be further limited by the server, but never to less than 100 blocks.
+     * @return Block that the player has targeted
+     */
+    public List<Block> getLastTwoTargetBlocksCallbacked(Callback<Boolean, Block> callback, int maxDistance);
 
     /**
      * Gets all blocks along the player's line of sight

--- a/src/main/java/org/bukkit/util/Callback.java
+++ b/src/main/java/org/bukkit/util/Callback.java
@@ -1,0 +1,19 @@
+package org.bukkit.util;
+
+/**
+ * Primitive callback class, to allow specific callback handling. For example to determine if a block in sight is invisible.
+ *
+ * @param <Result> This is the type it will return.
+ * @param <Parameter> This is the type it has as parameter.
+ */
+public interface Callback<Result, Parameter> {
+
+    /**
+     * This method will be called on each step.
+     *
+     * @param parameter The parameter of this step.
+     * @return The result of the step.
+     */
+    public Result call(Parameter parameter);
+
+}

--- a/src/main/java/org/bukkit/util/TransparentCallback.java
+++ b/src/main/java/org/bukkit/util/TransparentCallback.java
@@ -1,0 +1,34 @@
+package org.bukkit.util;
+
+import java.util.Set;
+
+import org.bukkit.block.Block;
+
+/**
+ * Default transparent call back. This class as callback acts like the normal
+ * line of sight methods.
+ * 
+ * To implement own handler override {@link TransparentCallback#call(Block)} and
+ * call it via super.
+ */
+public class TransparentCallback implements Callback<Boolean, Block> {
+
+    private final Set<Byte> transparent;
+
+    /**
+     * Creates a new callback class which returns by default for every block in
+     * the transparent list true. Otherwise false. Could be expanded by override
+     * the {@link Callback#call(Block)} method.
+     *
+     * @param transparent
+     *            The list of transparent blocks.
+     */
+    public TransparentCallback(Set<Byte> transparent) {
+        this.transparent = transparent;
+    }
+
+    public Boolean call(Block parameter) {
+        return this.transparent.contains((byte) parameter.getTypeId());
+    }
+
+}


### PR DESCRIPTION
Add methods to allow a callback in the line of sight. So instead of define a transparent byte set, this methods will call a callback on every iteration. Their the callback can define, if this block is “transparent”.

I didn't removed the old line of sight methods, to prevent API breakage, and because I think the classic way is faster.

Fabian

→ [CraftBukkit Pull Request](https://github.com/Bukkit/CraftBukkit/pull/290)
