### PR TITLE
Added a unqiue id to entities

### DIFF
--- a/src/main/java/org/bukkit/entity/Entity.java
+++ b/src/main/java/org/bukkit/entity/Entity.java
@@ -182,7 +182,7 @@ public interface Entity {
      * @return the last known {@link EntityDamageEvent} or null if hitherto unharmed
      */
     public EntityDamageEvent getLastDamageCause();
-    
+
     /**
      * Returns a unique and persistent id for this entity
      * @return unique id

--- a/src/main/java/org/bukkit/entity/Entity.java
+++ b/src/main/java/org/bukkit/entity/Entity.java
@@ -7,6 +7,7 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.util.Vector;
 
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Represents a base entity in the world
@@ -181,5 +182,11 @@ public interface Entity {
      * @return the last known {@link EntityDamageEvent} or null if hitherto unharmed
      */
     public EntityDamageEvent getLastDamageCause();
+    
+    /**
+     * Returns a unique and persistent id for this entity
+     * @return unique id
+     */
+    public UUID getUniqueId();
 
 }


### PR DESCRIPTION
Adds a unique id to each entity, that is persistent between server starts. Necessary to keep track of non-player entities between server starts.

CraftBukkit Pull: https://github.com/Bukkit/CraftBukkit/pull/297
