### PR TITLE
Comparing MaterialData instances

### DIFF
--- a/src/main/java/org/bukkit/material/MaterialData.java
+++ b/src/main/java/org/bukkit/material/MaterialData.java
@@ -85,4 +85,19 @@ public class MaterialData {
     public String toString() {
         return getItemType() + "(" + getData() + ")";
     }
+
+    @Override
+    public int hashCode() {
+        return ((getItemTypeId() << 8) ^ getData());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(obj != null && obj instanceof MaterialData) {
+            MaterialData md = (MaterialData)obj;
+            return (md.getItemTypeId() == getItemTypeId() && md.getData() == getData());
+        } else {
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
This commit makes it possible to compare instances of MaterialData using the .equals() function.
