### PR TITLE
Provide API for efficient, thread-safe snapshots of chunk data

### DIFF
--- a/src/main/java/org/bukkit/Chunk.java
+++ b/src/main/java/org/bukkit/Chunk.java
@@ -40,6 +40,12 @@ public interface Chunk {
      */
     Block getBlock(int x, int y, int z);
 
+    /**
+     * Capture thread-safe read-only snapshot of chunk data
+     * @return ChunkSnapshot 
+     */
+    ChunkSnapshot	getChunkSnapshot();
+
     Entity[] getEntities();
 
     BlockState[] getTileEntities();

--- a/src/main/java/org/bukkit/ChunkSnapshot.java
+++ b/src/main/java/org/bukkit/ChunkSnapshot.java
@@ -1,0 +1,85 @@
+
+package org.bukkit;
+
+/**
+ * Represents a static, thread-safe snapshot of chunk of blocks
+ * Purpose is to allow clean, efficient copy of a chunk data to be made, and then handed off for processing in another thread (e.g. map rendering)
+ */
+public interface ChunkSnapshot {
+
+	/**
+     * Gets the X-coordinate of this chunk
+     *
+     * @return X-coordinate
+     */
+    int getX();
+
+    /**
+     * Gets the Z-coordinate of this chunk
+     *
+     * @return Z-coordinate
+     */
+    int getZ();
+
+    /**
+     * Gets name of the world containing this chunk
+     *
+     * @return Parent World Name
+     */
+    String getWorldName();
+
+    /**
+     * Get block type for block at corresponding coordinate in the chunk
+     * 
+     * @param x 0-15
+     * @param y 0-127
+     * @param z 0-15
+     * @return 0-255
+     */
+    int getBlockTypeId(int x, int y, int z);
+
+    /**
+     * Get block data for block at corresponding coordinate in the chunk
+     * 
+     * @param x 0-15
+     * @param y 0-127
+     * @param z 0-15
+     * @return 0-15
+     */
+    int getBlockData(int x, int y, int z);
+
+    /**
+     * Get sky light level for block at corresponding coordinate in the chunk
+     * 
+     * @param x 0-15
+     * @param y 0-127
+     * @param z 0-15
+     * @return 0-15
+     */
+    int getBlockSkyLight(int x, int y, int z);
+
+    /**
+     * Get light level emitted by block at corresponding coordinate in the chunk
+     * 
+     * @param x 0-15
+     * @param y 0-127
+     * @param z 0-15
+     * @return 0-15
+     */
+    int getBlockEmittedLight(int x, int y, int z);
+
+    /**
+     * Gets the highest non-air coordinate at the given coordinates
+     *
+     * @param x X-coordinate of the blocks
+     * @param z Z-coordinate of the blocks
+     * @return Y-coordinate of the highest non-air block
+     */
+    int getHighestBlockYAt(int x, int z);
+
+    /**
+     * Get world full time when chunk snapshot was captured
+     * @return time in ticks
+     */
+    long getCaptureFullTime();
+}


### PR DESCRIPTION
The purpose of this is to exploit an existing obfuscated server API to allow efficient creation of stable, thread-safe snapshots of chunk data (including some chunk data, such as sky-light and emitted-light, that are not otherwise available). This is specifically intended to aid applications that require process-intensive use of chunk data, such as mapping applications like dynmap, by allowing them to quickly grab stable copies of chunks that can then be farmed off for processing on other threads without needing to keep the original chunks loaded or active, and without imposing a high processing load on the server thread.

There is a corresponding CraftBukkit pull request for the supporting components (https://github.com/Bukkit/CraftBukkit/pull/309)
