### PR TITLE
Added various 1.6 portal events

### DIFF
--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -230,6 +230,12 @@ public abstract class Event implements Serializable {
          */
         PLAYER_TELEPORT (Category.PLAYER),
         /**
+         * Called when a player completes the portaling process by standing in a portal
+         *
+         * @see org.bukkit.event.player.PlayerTeleportEvent
+         */
+        PLAYER_PORTAL (Category.PLAYER),
+        /**
          * Called when a player changes their held item
          *
          * @see org.bukkit.event.player.PlayerItemHeldEvent
@@ -483,6 +489,12 @@ public abstract class Event implements Serializable {
          * Called when a World is unloaded
          */
         WORLD_UNLOAD (Category.WORLD),
+        /**
+         * Called when world attempts to create a matching end to a portal
+         *
+         * @see org.bukkit.event.world.PortalCreateEvent
+         */
+        PORTAL_CREATE (Category.WORLD),
 
         /**
          * ENTITY EVENTS
@@ -500,6 +512,12 @@ public abstract class Event implements Serializable {
          * @see org.bukkit.event.painting.PaintingRemoveEvent
          */
         PAINTING_BREAK (Category.ENTITY),
+        /**
+         * Called when an entity touches a portal block
+         *
+         * @see org.bukkit.event.entity.EntityPortalEnterEvent
+         */
+        ENTITY_PORTAL_ENTER (Category.ENTITY),
 
         /**
          * LIVING_ENTITY EVENTS

--- a/src/main/java/org/bukkit/event/entity/EntityListener.java
+++ b/src/main/java/org/bukkit/event/entity/EntityListener.java
@@ -26,6 +26,8 @@ public class EntityListener implements Listener {
 
     public void onEntityInteract(EntityInteractEvent event) {}
 
+    public void onEntityPortalEnter(EntityPortalEnterEvent event) {}
+
     public void onPaintingPlace(PaintingPlaceEvent event) {}
 
     public void onPaintingBreak(PaintingBreakEvent event) {}

--- a/src/main/java/org/bukkit/event/entity/EntityPortalEnterEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityPortalEnterEvent.java
@@ -1,0 +1,26 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.Location;
+import org.bukkit.event.Cancellable;
+
+/**
+ * Stores data for entities standing inside a portal block
+ */
+public class EntityPortalEnterEvent extends EntityEvent {
+
+    private Location location;
+    
+    public EntityPortalEnterEvent(Entity entity, Location location) {
+        super(Type.ENTITY_PORTAL_ENTER, entity);
+        this.location = location;
+    }
+
+    /*
+     * Gets the portal block the entity is touching
+     * @return The portal block the entity is touching
+     */
+    public Location getLocation() {
+        return location;
+    }
+}

--- a/src/main/java/org/bukkit/event/player/PlayerListener.java
+++ b/src/main/java/org/bukkit/event/player/PlayerListener.java
@@ -183,6 +183,13 @@ public class PlayerListener implements Listener {
      */
     public void onPlayerBedLeave(PlayerBedLeaveEvent event) {}
 
+    /**
+     * Called when a player is teleporting in a portal (after the animation)
+     *
+     * @param event Relevant event details
+     */
+    public void onPlayerPortal(PlayerPortalEvent event) {}
+
     // TODO: Remove after RB
     @Deprecated public void onPlayerQuit(PlayerEvent event) {}
     @Deprecated public void onPlayerCommandPreprocess(PlayerChatEvent event) {}

--- a/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
@@ -1,0 +1,22 @@
+package org.bukkit.event.player;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.block.Block;
+
+/**
+ * Holds information for when a player completes a portal events
+ */
+public class PlayerPortalEvent extends PlayerTeleportEvent {
+    private boolean useTravelAgent = true;
+    public PlayerPortalEvent(Player player, Location from, Location to) {
+        super(Type.PLAYER_PORTAL, player, from, to);
+    }
+
+    public void useTravelAgent(boolean useTravelAgent){
+        this.useTravelAgent = useTravelAgent;
+    }
+    public boolean useTravelAgent(){
+        return useTravelAgent;
+    }
+}

--- a/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
@@ -2,6 +2,7 @@ package org.bukkit.event.player;
 
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
 
 /**
  * Holds information for player teleport events
@@ -9,5 +10,8 @@ import org.bukkit.entity.Player;
 public class PlayerTeleportEvent extends PlayerMoveEvent {
     public PlayerTeleportEvent(Player player, Location from, Location to) {
         super(Type.PLAYER_TELEPORT, player, from, to);
+    }
+    public PlayerTeleportEvent(final Event.Type type, Player player, Location from, Location to) {
+        super(type, player, from, to);
     }
 }

--- a/src/main/java/org/bukkit/event/world/PortalCreateEvent.java
+++ b/src/main/java/org/bukkit/event/world/PortalCreateEvent.java
@@ -1,0 +1,43 @@
+package org.bukkit.event.world;
+
+import org.bukkit.block.Block;
+import org.bukkit.World;
+import org.bukkit.event.Cancellable;
+import java.util.ArrayList;
+
+/**
+ * Called on leaves decaying
+ */
+public class PortalCreateEvent extends WorldEvent implements Cancellable {
+    private boolean cancel = false;
+    private ArrayList<Block> blocks = new ArrayList<Block>(); 
+
+    public PortalCreateEvent(final ArrayList<Block> blocks, final World world) {
+        super(Type.PORTAL_CREATE, world);
+        this.blocks = blocks;
+    }
+
+    public ArrayList<Block> getBlocks(){
+        return this.blocks;
+    }
+    
+    /**
+     * Gets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @return true if this event is cancelled
+     */
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    /**
+     * Sets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @param cancel true if you wish to cancel this event
+     */
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+}

--- a/src/main/java/org/bukkit/event/world/WorldListener.java
+++ b/src/main/java/org/bukkit/event/world/WorldListener.java
@@ -30,6 +30,13 @@ public class WorldListener implements Listener {
     public void onSpawnChange(SpawnChangeEvent event) {}
 
     /**
+     * Called when the world generates a portal end point
+     *
+     * @param event Relevant event details
+     */
+    public void onPortalCreate(PortalCreateEvent event) {}
+
+    /**
      * Called when a world is saved
      *
      * @param event Relevant event details

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -293,6 +293,13 @@ public final class JavaPluginLoader implements PluginLoader {
                 }
             };
 
+        case PLAYER_PORTAL:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((PlayerListener) listener).onPlayerPortal((PlayerPortalEvent) event);
+                }
+            };
+
         case PLAYER_INTERACT:
             return new EventExecutor() {
                 public void execute(Listener listener, Event event) {
@@ -562,6 +569,13 @@ public final class JavaPluginLoader implements PluginLoader {
                 }
             };
 
+        case PORTAL_CREATE:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((WorldListener) listener).onPortalCreate((PortalCreateEvent) event);
+                }
+            };
+
         // Painting Events
         case PAINTING_PLACE:
             return new EventExecutor() {
@@ -626,6 +640,14 @@ public final class JavaPluginLoader implements PluginLoader {
                     ((EntityListener) listener).onEntityInteract((EntityInteractEvent) event);
                 }
             };
+
+        case ENTITY_PORTAL_ENTER:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((EntityListener) listener).onEntityPortalEnter((EntityPortalEnterEvent) event);
+                }
+            };
+            
 
         case CREATURE_SPAWN:
             return new EventExecutor() {


### PR DESCRIPTION
3 portal related events

ENTITY_PORTAL_ENTER is an entity event and fired when any entity touches a portal block which can be used to trigger teleports instantly. Keep in mind this event can spam and plugins should handle it accordingly. Fires once for each block touched per tick.

PLAYER_PORTAL is a player event fired when a player sits in a portal and watches the animation, it fires when a player would normally be teleported to the nether (must be player only because of Notch's checks)

PORTAL_CREATE is a world event fired when a TravelAgent creates a portal in another dimension

CraftBukkit Pull: https://github.com/Bukkit/CraftBukkit/pull/329
