### PR TITLE
Enhance chunk snapshot support to include options for biome and raw biome temp/rainfall data

### DIFF
--- a/src/main/java/org/bukkit/Chunk.java
+++ b/src/main/java/org/bukkit/Chunk.java
@@ -45,6 +45,16 @@ public interface Chunk {
      * @return ChunkSnapshot
      */
     ChunkSnapshot getChunkSnapshot();
+ 
+    /**
+     * Capture thread-safe read-only snapshot of chunk data
+     * @param include_maxblocky - if true, snapshot includes per-coordinate maximum Y values
+     * @param include_biome - if true, snapshot includes per-coordinate biome type
+     * @param include_biome_temp_rain - if true, snapshot includes per-coordinate raw biome temperature and rainfall
+     * @return ChunkSnapshot
+     */
+    ChunkSnapshot getChunkSnapshot(boolean include_maxblocky, boolean include_biome,
+            boolean include_biome_temp_rain);
 
     Entity[] getEntities();
 

--- a/src/main/java/org/bukkit/Chunk.java
+++ b/src/main/java/org/bukkit/Chunk.java
@@ -48,13 +48,13 @@ public interface Chunk {
  
     /**
      * Capture thread-safe read-only snapshot of chunk data
-     * @param include_maxblocky - if true, snapshot includes per-coordinate maximum Y values
-     * @param include_biome - if true, snapshot includes per-coordinate biome type
-     * @param include_biome_temp_rain - if true, snapshot includes per-coordinate raw biome temperature and rainfall
+     * @param includeMaxblocky - if true, snapshot includes per-coordinate maximum Y values
+     * @param includeBiome - if true, snapshot includes per-coordinate biome type
+     * @param includeBiomeTempRain - if true, snapshot includes per-coordinate raw biome temperature and rainfall
      * @return ChunkSnapshot
      */
-    ChunkSnapshot getChunkSnapshot(boolean include_maxblocky, boolean include_biome,
-            boolean include_biome_temp_rain);
+    ChunkSnapshot getChunkSnapshot(boolean includeMaxblocky, boolean includeBiome,
+            boolean includeBiomeTempRain);
 
     Entity[] getEntities();
 

--- a/src/main/java/org/bukkit/ChunkSnapshot.java
+++ b/src/main/java/org/bukkit/ChunkSnapshot.java
@@ -1,5 +1,6 @@
 package org.bukkit;
 
+import org.bukkit.block.Biome;
 /**
  * Represents a static, thread-safe snapshot of chunk of blocks
  * Purpose is to allow clean, efficient copy of a chunk data to be made, and then handed off for processing in another thread (e.g. map rendering)
@@ -75,6 +76,33 @@ public interface ChunkSnapshot {
      * @return Y-coordinate of the highest non-air block
      */
     int getHighestBlockYAt(int x, int z);
+
+    /**
+     * Get biome at given coordinates
+     * 
+     * @param x X-coordinate
+     * @param z Z-coordinate
+     * @return Biome at given coordinate
+     */
+    Biome getBiome(int x, int z);
+    
+    /**
+     * Get raw biome temperature (0.0-1.0) at given coordinate
+     * 
+     * @param x X-coordinate
+     * @param z Z-coordinate
+     * @return temperature at given coordinate
+     */
+    double getRawBiomeTemperature(int x, int z);
+    
+    /**
+     * Get raw biome rainfall (0.0-1.0) at given coordinate
+     * 
+     * @param x X-coordinate
+     * @param z Z-coordinate
+     * @return rainfall at given coordinate
+     */
+    double getRawBiomeRainfall(int x, int z);
 
     /**
      * Get world full time when chunk snapshot was captured

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -567,6 +567,16 @@ public interface World {
     public void playEffect(Location location, Effect effect, int data, int radius);
 
     /**
+     * Get empty chunk snapshot (equivalent to all air blocks), optionally including valid biome
+     * data.  Used for representing an ungenerated chunk, or for fetching only biome data without loading a chunk.
+     * @param x - chunk x coordinate
+     * @param z - chunk z coordinate
+     * @param includeBiome - if true, snapshot includes per-coordinate biome type
+     * @param includeBiomeTempRain - if true, snapshot includes per-coordinate raw biome temperature and rainfall
+     */
+    public ChunkSnapshot getEmptyChunkSnapshot(int x, int z, boolean includeBiome, boolean includeBiomeTempRain);
+    
+    /**
      * Represents various map environment types that a world may be
      */
     public enum Environment {


### PR DESCRIPTION
This allows the chunk snapshot mechanism to include additional chunk data - specifically, the biome type of each X-Z coordinate, as well as the raw temperature and rainfall data generated during biome calculation (which is both used to produce the biome mapping, and can be used for deriving color mapping information for grass and leaves). As with the other snapshot data, the option of capturing this data for later processing and use on non-server threads has appeal for mapping applications, such as dynmap. Making the data collection optional is attractive, as the calculation of the biome data is done on demand, and can be computationally non-trivial, but is also deterministic and invariant for a given set of coordinates on a given world derived from a given seed (so mods could request the data once, cache it themselves, and never need to request it again).

This pull has a corresponding CraftBukkit request - https://github.com/Bukkit/CraftBukkit/pull/340
