### PR TITLE
Added setRecipients() to PlayerChatEvent

### DIFF
--- a/src/main/java/org/bukkit/event/player/PlayerChatEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerChatEvent.java
@@ -14,7 +14,7 @@ public class PlayerChatEvent extends PlayerEvent implements Cancellable {
     private boolean cancel = false;
     private String message;
     private String format = "<%1$s> %2$s";
-    private final Set<Player> recipients;
+    private Set<Player> recipients;
 
     public PlayerChatEvent(final Player player, final String message) {
         this(Type.PLAYER_CHAT, player, message);
@@ -107,5 +107,14 @@ public class PlayerChatEvent extends PlayerEvent implements Cancellable {
      */
     public Set<Player> getRecipients() {
         return recipients;
+    }
+    
+    /**
+     * Sets the players this chat message will be displayed to
+     * 
+     * @param players Set of players to display message to
+     */
+    public void setRecipients(Set<Player> recipients) {
+    	this.recipients = recipients;
     }
 }


### PR DESCRIPTION
Implemented a setRecipients() method to PlayerChatEvent. This will solve the issue that people have at the moment of plugins like HeroChat (that implement chat rooms) just cancelling the PlayerChatEvent when they only want to send a message to a few people.

The issue with this is obviously that other plugins can't edit the message either. So if, say factions, wanted to add the faction of the player in, it woulnd't be able to because the event is cancelled.

By using setRecipients and setMessage there will be no need to cancel the event anymore and other plugins can then add in their own stuff whilst chat plugins can still manipulate the player list so rooms are possible. 
