### PR TITLE
Implementation of BlockFallEvents. (Sand / Gravel)

### DIFF
--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -396,6 +396,12 @@ public abstract class Event implements Serializable {
          * @see org.bukkit.event.block.BlockFadeEvent
          */
         BLOCK_FADE (Category.BLOCK),
+        /**
+         * Called when a block attempts to fall
+         *
+         * @see org.bukkit.event.block.BlockFallEvent
+         */
+        BLOCK_FALL (Category.BLOCK),
 
         /**
          * INVENTORY EVENTS

--- a/src/main/java/org/bukkit/event/block/BlockFallEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockFallEvent.java
@@ -1,0 +1,40 @@
+package org.bukkit.event.block;
+
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+
+/**
+ * Called when a block attempts to fall
+ *
+ * @author Xolsom
+ */
+public class BlockFallEvent extends BlockEvent {
+    private final Entity fallingEntity;
+
+    protected boolean instantFall;
+
+    public BlockFallEvent(Block block, Entity fallingEntity, boolean instantFall) {
+        super(Type.BLOCK_FALL, block);
+
+        this.fallingEntity = fallingEntity;
+        this.instantFall = instantFall;
+    }
+
+    /**
+     * Get the instant fall flag of the falling block
+     *
+     * @return Whether the block would fall instantly
+     */
+    public boolean getInstantFall() {
+        return this.instantFall;
+    }
+
+    /**
+     * Get the entity into which the falling block would turn to.
+     *
+     * @return The entity into which the falling block would turn to
+     */
+    public Entity getFallingEntity() {
+        return this.fallingEntity;
+    }
+}

--- a/src/main/java/org/bukkit/event/block/BlockFallStartEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockFallStartEvent.java
@@ -1,0 +1,47 @@
+package org.bukkit.event.block;
+
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Cancellable;
+
+/**
+ * @author Xolsom
+ */
+public class BlockFallStartEvent extends BlockFallEvent implements Cancellable {
+    private boolean cancelled;
+
+    public BlockFallStartEvent(Block block, Entity fallingEntity, boolean instantFall) {
+        super(block, fallingEntity, instantFall);
+
+        this.cancelled = false;
+    }
+
+    /**
+     * Gets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @return true if this event is cancelled
+     */
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    /**
+     * Setting the cancellation state of this event. This determines whether
+     * the block should turn into an entity and fall or not
+     *
+     * @param cancelled True to prevent the block from falling
+     */
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    /**
+     * Set the instant fall flag of the falling block
+     *
+     * @param instantFall Whether the block should fall instantly
+     */
+    public void setInstantFall(boolean instantFall) {
+        this.instantFall = instantFall;
+    }
+}

--- a/src/main/java/org/bukkit/event/block/BlockFallStopEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockFallStopEvent.java
@@ -1,0 +1,82 @@
+package org.bukkit.event.block;
+
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+
+/**
+ * @author Xolsom
+ */
+public class BlockFallStopEvent extends BlockFallEvent {
+    private final StopCause stopCause;
+
+    private boolean droppable;
+    private boolean transformable;
+
+    public BlockFallStopEvent(Block block, Entity fallingEntity, boolean instantFall, StopCause stopCause, boolean transformable, boolean droppable) {
+        super(block, fallingEntity, instantFall);
+
+        this.stopCause = stopCause;
+        this.droppable = droppable;
+        this.transformable = transformable;
+    }
+
+    /**
+     * Get the cause that stopped the entity from falling
+     *
+     * @return The stop cause
+     */
+    public StopCause getStopCause() {
+        return this.stopCause;
+    }
+
+    /**
+     * Returns whether the falling entity can be transformed into a block
+     *
+     * @return Whether the entity can be transformed into a block
+     */
+    public boolean isTransformable() {
+        return this.transformable;
+    }
+
+    /**
+     * Set whether the falling entity should be able to be transformed into a block.
+     * Setting this with a timeout cause will not have any effect
+     *
+     * @param transformable Whether the falling entity should be transformable
+     */
+    public void setTransformable(boolean transformable) {
+        this.transformable = transformable;
+    }
+
+    /**
+     * Returns whether the falling entity can be dropped as a block item
+     *
+     * @return Whether the entity can be dropped as a block item
+     */
+    public boolean isDroppable() {
+        return this.droppable;
+    }
+
+    /**
+     * Set whether the falling entity should be able to be dropped as a block item
+     *
+     * @param droppable  Whether the falling entity should be droppable
+     */
+    public void setDroppable(boolean droppable) {
+        this.droppable = droppable;
+    }
+
+    /**
+     * Determines the cause that stopped the entity from falling
+     */
+    public enum StopCause {
+        /**
+         * The entity touched the ground
+         */
+        GROUND,
+        /**
+         * The fall duration was too long
+         */
+        TIMEOUT;
+    }
+}

--- a/src/main/java/org/bukkit/event/block/BlockListener.java
+++ b/src/main/java/org/bukkit/event/block/BlockListener.java
@@ -135,4 +135,11 @@ public class BlockListener implements Listener {
      * @param event Relevant event details
      */
     public void onBlockDispense(BlockDispenseEvent event) {}
+
+    /**
+     * Called when a block attempts to fall
+     *
+     * @param event Relevant event details
+     */
+    public void onBlockFall(BlockFallEvent event) {}
 }

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -520,6 +520,13 @@ public final class JavaPluginLoader implements PluginLoader {
                 }
             };
 
+        case BLOCK_FALL:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((BlockListener) listener).onBlockFall((BlockFallEvent) event);
+                }
+            };
+
         // Server Events
         case PLUGIN_ENABLE:
             return new EventExecutor() {


### PR DESCRIPTION
Two events that handle the start and stop of block falls. This allows plugins to have blocks not fall at all or handle the stop differently. (I.e. only allow drops / block transforms)
This also adds a possibility to control those blocks when they would fall into regions of any sort.

Corresponding CraftBukkit pull request: https://github.com/Bukkit/CraftBukkit/pull/353
