### PR TITLE
Improved ConfigurationNode

### DIFF
--- a/src/main/java/org/bukkit/util/cast/BooleanCaster.java
+++ b/src/main/java/org/bukkit/util/cast/BooleanCaster.java
@@ -1,0 +1,24 @@
+package org.bukkit.util.cast;
+
+/**
+ * Casts the object to a boolean, if the object is one, otherwise null.
+ */
+public final class BooleanCaster implements Caster<Boolean> {
+    
+    public static final BooleanCaster INSTANCE = new BooleanCaster();
+    
+    private BooleanCaster() {};
+    
+    /**
+     * Casts the object to a boolean, if the object is one, otherwise null.
+     */
+    public Boolean cast(Object o) {
+        if (o == null) {
+            return null;
+        } else if (o instanceof Boolean) {
+            return (Boolean) o;
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/bukkit/util/cast/Caster.java
+++ b/src/main/java/org/bukkit/util/cast/Caster.java
@@ -1,0 +1,14 @@
+package org.bukkit.util.cast;
+
+/**
+ * Tries to cast the given object into another one.
+ */
+public interface Caster<T> {
+
+    /**
+     * Casts the object to the type <code>t</code>. If unable, it will return null.
+     * @param o This object will be casted.
+     * @return If o is <code>null</code> or it is impossible to cast it will return <code>null</code>. Otherwise the casted object.
+     */
+    T cast(Object o);
+}

--- a/src/main/java/org/bukkit/util/cast/DoubleCaster.java
+++ b/src/main/java/org/bukkit/util/cast/DoubleCaster.java
@@ -1,0 +1,22 @@
+package org.bukkit.util.cast;
+
+
+public final class DoubleCaster implements Caster<Double> {
+    
+    public static final DoubleCaster INSTANCE = new DoubleCaster();
+    
+    private DoubleCaster() {};
+    
+    /**
+     * Casts the object to a double, if the object is a Number, otherwise null.
+     */
+    public Double cast(Object o) {
+        if (o == null) {
+            return null;
+        } else if (o instanceof Number) {
+            return ((Number) o).doubleValue();
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/bukkit/util/cast/IntCaster.java
+++ b/src/main/java/org/bukkit/util/cast/IntCaster.java
@@ -1,0 +1,24 @@
+package org.bukkit.util.cast;
+
+/**
+ * Casts the object to an Integer, if the object is a Number, otherwise null.
+ */
+public final class IntCaster implements Caster<Integer> {
+    
+    public static final IntCaster INSTANCE = new IntCaster();
+    
+    private IntCaster() {};
+    
+    /**
+     * Casts the object to an Integer, if the object is a Number, otherwise null.
+     */
+    public Integer cast(Object o) {
+        if (o == null) {
+            return null;
+        } else if (o instanceof Number) {
+            return ((Number) o).intValue();
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/bukkit/util/cast/LongCaster.java
+++ b/src/main/java/org/bukkit/util/cast/LongCaster.java
@@ -1,0 +1,24 @@
+package org.bukkit.util.cast;
+
+/**
+ * Casts the object to a long, if the object is a Number, otherwise null.
+ */
+public final class LongCaster implements Caster<Long> {
+    
+    public static final LongCaster INSTANCE = new LongCaster();
+    
+    private LongCaster() {};
+    
+    /**
+     * Casts the object to a long, if the object is a Number, otherwise null.
+     */
+    public Long cast(Object o) {
+        if (o == null) {
+            return null;
+        } else if (o instanceof Number) {
+            return ((Number) o).longValue();
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/bukkit/util/cast/MapCaster.java
+++ b/src/main/java/org/bukkit/util/cast/MapCaster.java
@@ -1,0 +1,26 @@
+package org.bukkit.util.cast;
+
+import java.util.Map;
+
+/**
+ * Casts the object to a map, if the object is one, otherwise null.
+ */
+public class MapCaster<K, V> implements Caster<Map<K, V>> {
+
+    public static final MapCaster<String, Object> STRING_OBJECT_INSTANCE = new MapCaster<String, Object>(); 
+    
+    /**
+     * Casts the object to a map, if the object is one, otherwise null.
+     */
+    @SuppressWarnings("unchecked")
+    public Map<K, V> cast(Object o) {
+        if (o == null) {
+            return null;
+        } else if (o instanceof Map) {
+            return (Map<K, V>) o;
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/org/bukkit/util/cast/StringCaster.java
+++ b/src/main/java/org/bukkit/util/cast/StringCaster.java
@@ -1,0 +1,21 @@
+package org.bukkit.util.cast;
+
+/**
+ * Casts the object to a string, if the object isn't null. It will call the
+ * {@link Object#toString()} method.
+ */
+public final class StringCaster implements Caster<String> {
+
+    public static final StringCaster INSTANCE = new StringCaster();
+
+    private StringCaster() {
+    };
+
+    /**
+     * Casts the object to a string, if the object isn't null. It will call the
+     * {@link Object#toString()} method.
+     */
+    public String cast(Object o) {
+        return o == null ? null : o.toString();
+    }
+}


### PR DESCRIPTION
Hello, I improved the ConfigurationNode class:
1. There were various copy&waste errors in the javadocs for getting a list of any kind.
2. Added native long support (list and single value)
3. Getters for int/double/long/boolean without a default value. It is “only” getProperty and a cast. So you could test, if the property exists.
4. There was many code duplication in the getters. With the new casters (see below), I was able to remove this duplications.

I also added various casters which casts an object to an specified sub class. So instead of `ConfigurationNode.castInt(Object)` there is a singleton `IntCaster` which has a cast method. Because all casters now implements the `interface Caster<T>` I was able to simplify the getters for the lists and single values, because there is now a method `T ConfigurationNode.getProperty(String, T, Caster<T>)` and `List<T> ConfigurationNode.getList(String, List<T>, Caster<T>)` which generically make the stuff. The “old” getters are only special implementations. For example now the `ConfigurationNode.getStringList(String, List<String>)`:

``` java
    public List<String> getStringList(String path, List<String> def) {
        return this.getList(path, def, StringCaster.INSTANCE);
    }
```

I decided to make the casters public, to allow the plugin developers to use them. They are singletons and final.

Fabian
