### PR TITLE
Methods to register multiple events at once

### DIFF
--- a/src/main/java/org/bukkit/plugin/PluginManager.java
+++ b/src/main/java/org/bukkit/plugin/PluginManager.java
@@ -119,9 +119,8 @@ public interface PluginManager {
     /**
      * Registers all events of the specified category to the specified listener
      *
-     * @param type EventType to register
+     * @param category The category of events to register
      * @param listener PlayerListener to register
-     * @param executor EventExecutor to register
      * @param priority Priority of this event
      * @param plugin Plugin to register
      */
@@ -130,7 +129,7 @@ public interface PluginManager {
     /**
      * Registers all events of the specified category to the specified listener using a directly passed EventExecutor
      *
-     * @param type EventType to register
+     * @param category The category of events to register
      * @param listener PlayerListener to register
      * @param executor EventExecutor to register
      * @param priority Priority of this event
@@ -138,6 +137,16 @@ public interface PluginManager {
      */
     public void registerEvents(Event.Category category, Listener listener, EventExecutor executor, Priority priority, Plugin plugin);
 
+    /**
+     * Registers all events to the specified listener using a directly passed EventExecutor
+     *
+     * @param listener PlayerListener to register
+     * @param executor EventExecutor to register
+     * @param priority Priority of this event
+     * @param plugin Plugin to register
+     */
+    public void registerAllEvents(Listener listener, EventExecutor executor, Priority priority, Plugin plugin);
+    
     /**
      * Enables the specified plugin
      *

--- a/src/main/java/org/bukkit/plugin/PluginManager.java
+++ b/src/main/java/org/bukkit/plugin/PluginManager.java
@@ -117,6 +117,28 @@ public interface PluginManager {
     public void registerEvent(Event.Type type, Listener listener, EventExecutor executor, Priority priority, Plugin plugin);
 
     /**
+     * Registers all events of the specified category to the specified listener
+     *
+     * @param type EventType to register
+     * @param listener PlayerListener to register
+     * @param executor EventExecutor to register
+     * @param priority Priority of this event
+     * @param plugin Plugin to register
+     */
+    public void registerEvents(Event.Category category, Listener listener, Priority priority, Plugin plugin);
+
+    /**
+     * Registers all events of the specified category to the specified listener using a directly passed EventExecutor
+     *
+     * @param type EventType to register
+     * @param listener PlayerListener to register
+     * @param executor EventExecutor to register
+     * @param priority Priority of this event
+     * @param plugin Plugin to register
+     */
+    public void registerEvents(Event.Category category, Listener listener, EventExecutor executor, Priority priority, Plugin plugin);
+
+    /**
      * Enables the specified plugin
      *
      * Attempting to enable a plugin that is already enabled will have no effect

--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -395,6 +395,70 @@ public final class SimplePluginManager implements PluginManager {
     }
 
     /**
+     * Registers all events of the specified category to the specified listener
+     *
+     * @param type EventType to register
+     * @param listener PlayerListener to register
+     * @param executor EventExecutor to register
+     * @param priority Priority of this event
+     * @param plugin Plugin to register
+     */
+    public void registerEvents(Event.Category category, Listener listener, Priority priority, Plugin plugin) {
+        for (Event.Type type : Event.Type.values()) {
+            if (type.getCategory() == category) {
+                registerEvent(type, listener, priority, plugin);
+            }
+        }
+    }
+
+    /**
+     * Registers all events of the specified category to the specified listener using a directly passed EventExecutor
+     *
+     * @param type EventType to register
+     * @param listener PlayerListener to register
+     * @param executor EventExecutor to register
+     * @param priority Priority of this event
+     * @param plugin Plugin to register
+     */
+    public void registerEvents(Event.Category category, Listener listener, EventExecutor executor, Priority priority, Plugin plugin) {
+        for (Event.Type type : Event.Type.values()) {
+            if (type.getCategory() == category) {
+                registerEvent(type, listener, executor, priority, plugin);
+            }
+        }
+    }
+
+    /**
+     * Registers all events to the specified listener
+     *
+     * @param type EventType to register
+     * @param listener PlayerListener to register
+     * @param executor EventExecutor to register
+     * @param priority Priority of this event
+     * @param plugin Plugin to register
+     */
+    public void registerAllEvents(Listener listener, Priority priority, Plugin plugin) {
+        for (Event.Type type : Event.Type.values()) {
+            registerEvent(type, listener, priority, plugin);
+        }
+    }
+
+    /**
+     * Registers all events to the specified listener using a directly passed EventExecutor
+     *
+     * @param type EventType to register
+     * @param listener PlayerListener to register
+     * @param executor EventExecutor to register
+     * @param priority Priority of this event
+     * @param plugin Plugin to register
+     */
+    public void registerAllEvents(Listener listener, EventExecutor executor, Priority priority, Plugin plugin) {
+        for (Event.Type type : Event.Type.values()) {
+            registerEvent(type, listener, executor, priority, plugin);
+        }
+    }
+
+    /**
      * Returns a SortedSet of RegisteredListener for the specified event type creating a new queue if needed
      *
      * @param type EventType to lookup

--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -397,9 +397,8 @@ public final class SimplePluginManager implements PluginManager {
     /**
      * Registers all events of the specified category to the specified listener
      *
-     * @param type EventType to register
+     * @param category The category of events to register
      * @param listener PlayerListener to register
-     * @param executor EventExecutor to register
      * @param priority Priority of this event
      * @param plugin Plugin to register
      */
@@ -414,7 +413,7 @@ public final class SimplePluginManager implements PluginManager {
     /**
      * Registers all events of the specified category to the specified listener using a directly passed EventExecutor
      *
-     * @param type EventType to register
+     * @param category The category of events to register
      * @param listener PlayerListener to register
      * @param executor EventExecutor to register
      * @param priority Priority of this event
@@ -429,24 +428,8 @@ public final class SimplePluginManager implements PluginManager {
     }
 
     /**
-     * Registers all events to the specified listener
-     *
-     * @param type EventType to register
-     * @param listener PlayerListener to register
-     * @param executor EventExecutor to register
-     * @param priority Priority of this event
-     * @param plugin Plugin to register
-     */
-    public void registerAllEvents(Listener listener, Priority priority, Plugin plugin) {
-        for (Event.Type type : Event.Type.values()) {
-            registerEvent(type, listener, priority, plugin);
-        }
-    }
-
-    /**
      * Registers all events to the specified listener using a directly passed EventExecutor
      *
-     * @param type EventType to register
      * @param listener PlayerListener to register
      * @param executor EventExecutor to register
      * @param priority Priority of this event


### PR DESCRIPTION
Adds methods to register every event to a single listener, and methods to register every event in a given category. Would be useful for plugins that (for example) provide logging functions.
