### PR TITLE
PRE_ITEM_SPAWN event (Bukkit)

### DIFF
--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -515,6 +515,12 @@ public abstract class Event implements Serializable {
          */
         CHUNK_POPULATED (Category.WORLD),
         /**
+         * Called when a block spawns an ItemEntity of itself in the world
+         * 
+         * @see org.bukkit.event.block.PreItemSpawnEvent
+         */
+        PRE_ITEM_SPAWN(Category.ENTITY),
+        /**
          * Called when an ItemEntity spawns in the world
          *
          * @see org.bukkit.event.entity.ItemSpawnEvent

--- a/src/main/java/org/bukkit/event/entity/EntityListener.java
+++ b/src/main/java/org/bukkit/event/entity/EntityListener.java
@@ -20,6 +20,13 @@ public class EntityListener implements Listener {
     public void onCreatureSpawn(CreatureSpawnEvent event) {}
 
     /**
+     * Called when a block spawns an item of itself into a world
+     *
+     * @param event Relevant event details
+     */
+    public void onPreItemSpawn(PreItemSpawnEvent event) {}
+
+    /**
      * Called when an item is spawned into a world
      *
      * @param event Relevant event details

--- a/src/main/java/org/bukkit/event/entity/PreItemSpawnEvent.java
+++ b/src/main/java/org/bukkit/event/entity/PreItemSpawnEvent.java
@@ -1,0 +1,71 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.inventory.ItemStack;
+
+public class PreItemSpawnEvent extends Event implements Cancellable {
+
+    private boolean cancelled = false;
+    private Block block;
+    private ItemStack item;
+    private Location location;
+
+    public PreItemSpawnEvent(Block block, ItemStack item, Location location) {
+        super(Type.PRE_ITEM_SPAWN);
+        this.block = block;
+        this.item = item;
+        this.location = location;
+    }
+
+    /**
+     * Gets the block that is spawning an item of itself. The block may already 
+     * be destroyed when this event is called.
+     * 
+     * @return the block that is spawning an item
+     */
+    public Block getBlock() {
+        return block;
+    }
+
+    /**
+     * Gets the item that is being dispensed. Modifying the returned item
+     * will have no effect.
+     *
+     * @return an ItemStack for the item being dispensed
+     */
+    public ItemStack getItem() {
+        return item.clone();
+    }
+
+    /**
+     * Gets the location at which the item is spawning.
+     * 
+     * @return The location at which the item is spawning
+     */
+    public Location getLocation() {
+        return location;
+    }
+
+    /**
+     * Gets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @return true if this event is cancelled
+     */
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    /**
+     * Sets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @param cancel true if you wish to cancel this event
+     */
+    public void setCancelled(boolean cancel) {
+        cancelled = cancel;
+    }
+}

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -512,7 +512,6 @@ public final class JavaPluginLoader implements PluginLoader {
                 }
             };
 
-
         case BLOCK_FADE:
             return new EventExecutor() {
                 public void execute(Listener listener, Event event) {
@@ -703,6 +702,13 @@ public final class JavaPluginLoader implements PluginLoader {
             return new EventExecutor() {
                 public void execute(Listener listener, Event event) {
                     ((EntityListener) listener).onCreatureSpawn((CreatureSpawnEvent) event);
+                }
+            };
+
+        case PRE_ITEM_SPAWN:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((EntityListener) listener).onPreItemSpawn((PreItemSpawnEvent) event);
                 }
             };
 


### PR DESCRIPTION
### Usage

Extremely useful to prevent duplication tricks, because it will also be called when when you destroy a block with a Redstone torch attached to it.

See also: https://github.com/Bukkit/CraftBukkit/pull/368
### Example code

```
    public void onPreItemSpawn(PreItemSpawnEvent event) {
        Material type = event.getItem().getType();
        Bukkit.getServer().broadcastMessage(type.name());

        if( type == Material.REDSTONE_TORCH_ON || 
                type == Material.SIGN ||
                type == Material.TORCH) 
        {
            if(locations.contains(event.getBlock().getLocation()))
            {
                event.setCancelled(true);

                locations.remove(event.getBlock().getLocation());

                Bukkit.getServer().broadcastMessage("Unregistered position, disallowing pickup");
            }
        }
    }
```
