### PR TITLE
EntityExplodeEvent ignore block and/or associated drop (Bukkit)

### DIFF
--- a/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java
@@ -1,5 +1,6 @@
 package org.bukkit.event.entity;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
@@ -13,6 +14,8 @@ public class EntityExplodeEvent extends EntityEvent implements Cancellable {
     private boolean cancel;
     private Location location;
     private List<Block> blocks;
+    private List<Location> ignoreBlocks;
+    private List<Location> ignoreDropBlocks;
     private float yield = 0.3F;
 
     public EntityExplodeEvent(Entity what, Location location, List<Block> blocks) {
@@ -20,6 +23,8 @@ public class EntityExplodeEvent extends EntityEvent implements Cancellable {
         this.location = location;
         this.cancel = false;
         this.blocks = blocks;
+        this.ignoreBlocks = new ArrayList<Location>();
+        this.ignoreDropBlocks = new ArrayList<Location>();
     }
 
     /**
@@ -48,6 +53,28 @@ public class EntityExplodeEvent extends EntityEvent implements Cancellable {
      */
     public List<Block> blockList() {
         return blocks;
+    }
+    
+    public List<Location> ignoreBlockList() {
+        return ignoreBlocks;
+    }
+    
+    public List<Location> ignoreDropBlockList() {
+        return ignoreDropBlocks;
+    }
+    
+    public void addIgnoreBlock(Block block) {
+    	if(!blocks.contains(block))
+    		return;
+    	
+    	ignoreBlocks.add(block.getLocation());
+    }
+    
+    public void addIgnoreDropBlock(Block block) {
+    	if(!blocks.contains(block))
+    		return;
+    	
+    	ignoreDropBlocks.add(block.getLocation());
     }
 
     /**

--- a/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java
@@ -54,27 +54,47 @@ public class EntityExplodeEvent extends EntityEvent implements Cancellable {
     public List<Block> blockList() {
         return blocks;
     }
-    
+
+    /**
+     * Returns the list of blocks which should not be destroyed during the
+     * explosion event.
+     */
     public List<Location> ignoreBlockList() {
         return ignoreBlocks;
     }
-    
+
+    /**
+     * Returns the list of blocks which should not drop an item after
+     * being destroyed.
+     */
     public List<Location> ignoreDropBlockList() {
         return ignoreDropBlocks;
     }
-    
+
+    /**
+     * Add a block to the list of blocks which should not be destroyed
+     * during the explosion event. 
+     * 
+     * @param block Block you wish to ignore
+     */
     public void addIgnoreBlock(Block block) {
-    	if(!blocks.contains(block))
-    		return;
-    	
-    	ignoreBlocks.add(block.getLocation());
+        if(!blocks.contains(block))
+            return;
+
+        ignoreBlocks.add(block.getLocation());
     }
-    
+
+    /**
+     * Add a block to the list of blocks which should not drop an item
+     * after being destroyed.
+     * 
+     * @param block
+     */
     public void addIgnoreDropBlock(Block block) {
-    	if(!blocks.contains(block))
-    		return;
-    	
-    	ignoreDropBlocks.add(block.getLocation());
+        if(!blocks.contains(block))
+            return;
+
+        ignoreDropBlocks.add(block.getLocation());
     }
 
     /**


### PR DESCRIPTION
### Commit message

Adds two additional ArrayLists to the EntityExplodeEvent, which allows you to ignore blocks and/or their associated drops.
### Associated commit message (fork: Bukkit)

Implements the two additional ArrayLists from the EntityExplosionEvent in CraftBukkit, which will allow you to ignore blocks and/or their associated drops.
### Usage

Extremely useful to prevent duplication tricks, because you won't have to remember to kind of block you encountered in order to cancel the drop on ITEM_SPAWN event.
### Example code

```
    public void onEntityExplode(EntityExplodeEvent event) {
        for(Block block : event.blockList())
        {
            Material type = block.getType();

            if( type == Material.REDSTONE_TORCH_ON || 
                type == Material.SIGN_POST ||
                type == Material.WALL_SIGN ||
                type == Material.TORCH) 
            {
                Bukkit.getServer().broadcastMessage("Explosion destroys " + type + " at location " + block.getLocation());

                if(locations.contains(block.getLocation()))
                {
                    locations.remove(block.getLocation());

                    event.addIgnoreDropBlock(block);

                    Bukkit.getServer().broadcastMessage("Unregistered position, disallowing pickup");
                }
            }
            else if(type == Material.SAND) {
                event.addIgnoreBlock(block);
            }
        }
    }
```
