### PR TITLE
EntityExplodeEvent ignore block and/or associated drop (Bukkit)

### DIFF
--- a/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java
@@ -1,6 +1,8 @@
 package org.bukkit.event.entity;
 
+import java.util.ArrayList;
 import java.util.List;
+
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.Location;
@@ -9,13 +11,13 @@ import org.bukkit.event.Cancellable;
 /**
  * Called when an entity explodes
  */
-public class EntityExplodeEvent extends EntityEvent implements Cancellable {
+public class EntityExplodeEvent extends EntityEvent implements Cancellable {   
     private boolean cancel;
     private Location location;
-    private List<Block> blocks;
+    private List<EntityExplodeEventBlock> blocks;
     private float yield = 0.3F;
 
-    public EntityExplodeEvent(Entity what, Location location, List<Block> blocks) {
+    public EntityExplodeEvent(Entity what, Location location, List<EntityExplodeEventBlock> blocks) {
         super(Type.ENTITY_EXPLODE, what);
         this.location = location;
         this.cancel = false;
@@ -32,10 +34,35 @@ public class EntityExplodeEvent extends EntityEvent implements Cancellable {
 
     /**
      * Returns the list of blocks that would have been removed or were
-     * removed from the explosion event.
+     * removed from the explosion event
+     * 
+     * You can modify the blocks in the returned list to control how the
+     * explosion treats them. You could even add or remove blocks from 
+     * the list, although this is not recommended.
+     * 
+     * @see org.bukkit.event.entity.EntityExplodeEventBlock
      */
-    public List<Block> blockList() {
+    public List<EntityExplodeEventBlock> getBlocks() {
         return blocks;
+    }
+
+    /**
+     * Returns the list of blocks that would have been removed or were
+     * removed from the explosion event
+     * 
+     * NOTICE: This method is very memory inefficient!
+     * 
+     * @deprecated Method has been replaced by getBlocks()
+     * @see #getBlocks()
+     */
+    @Deprecated
+    public List<Block> blockList() {
+        List<Block> list = new ArrayList<Block>();
+        for(EntityExplodeEventBlock block : blocks) {
+            list.add(block.getBlock());
+        }
+
+        return list;
     }
 
     /**
@@ -49,8 +76,6 @@ public class EntityExplodeEvent extends EntityEvent implements Cancellable {
 
     /**
      * Returns the percentage of blocks to drop from this explosion
-     *
-     * @return
      */
     public float getYield() {
         return yield;

--- a/src/main/java/org/bukkit/event/entity/EntityExplodeEventBlock.java
+++ b/src/main/java/org/bukkit/event/entity/EntityExplodeEventBlock.java
@@ -1,0 +1,80 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.block.Block;
+
+/**
+ * Class used by EntityExplodeEvent to store per-block settings
+ * 
+ * @see org.bukkit.event.entity.EntityExplodeEvent
+ */
+public class EntityExplodeEventBlock { 
+    private final Block block;
+    private boolean destroyable;
+    private boolean dropable;
+    private float yield;
+
+    public EntityExplodeEventBlock(final Block block) {
+        this.block = block;
+        this.destroyable = true;
+        this.dropable = true;
+        this.yield = -1.0F;
+    }
+
+    /**
+     * Returns the actual block associated with the explosion event
+     */
+    public Block getBlock() {
+        return block;
+    }
+
+    /**
+     * Returns if this block should be destroyed during the explosion
+     */
+    public boolean isDestroyable() {
+        return destroyable;
+    }
+
+    /**
+     * Sets if this block should be destroyed during the explosion
+     * 
+     * @param destroyable True if this block should be destroyed
+     */
+    public void setDestroyable(boolean destroyable) {
+        this.destroyable = destroyable;
+    }
+
+    /**
+     * Returns if this block should drop an item after the explosion
+     */
+    public boolean isDropable() {
+        return dropable;
+    }
+
+    /**
+     * Sets if this block should drop an item after the explosion
+     * 
+     * @param dropable True if this block should drop an item
+     */
+    public void setDropable(boolean dropable) {
+        this.dropable = dropable;
+    }
+
+    /**
+     * Returns the chance this block drops an item after the explosion
+     */
+    public float getYield() {
+        return yield;
+    }
+
+    /**
+     * Sets the chance this block drops and item after the explosion
+     * 
+     * When set to a negative value, the yield-value of the associated 
+     * explosion event will be used instead.
+     * 
+     * @param yield Value between 0.0F and 1.0F
+     */
+    public void setYield(float yield) {
+        this.yield = yield;
+    }
+}


### PR DESCRIPTION
### Usage

Extremely useful to prevent duplication tricks, because you won't have to remember to kind of block you encountered in order to cancel the drop on ITEM_SPAWN event.

See also: https://github.com/Bukkit/CraftBukkit/pull/370
### Example code

```
    public void onEntityExplode(EntityExplodeEvent event) {
        for(EntityExplodeEventBlock explosionBlock : event.getBlocks())
        {
            Block block = explosionBlock.getBlock();
            Material type = block.getType();

            if( type == Material.REDSTONE_TORCH_ON || 
                type == Material.SIGN_POST ||
                type == Material.WALL_SIGN ||
                type == Material.TORCH)
            {
                Bukkit.getServer().broadcastMessage("Explosion destroys " + type + " at location " + block.getLocation());

                if(locations.contains(block.getLocation()))
                {
                    locations.remove(block.getLocation());

                    explosionBlock.setDropable(false);

                    Bukkit.getServer().broadcastMessage("Unregistered position, disabling drop");
                }
            }
            else if(type == Material.SAND) {
                explosionBlock.setDestroyable(false);
            }
            else if(type == Material.GRAVEL) {
                explosionBlock.setDestroyable(false);
                explosionBlock.setDropable(false);
            }
            else if(type == Material.DIRT) {
                explosionBlock.setYield(1.0F);
            }
        }
    }
```
