### PR TITLE
Adds a method to ban a player

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -78,6 +78,12 @@ public interface Player extends HumanEntity, CommandSender {
     public void kickPlayer(String message);
 
     /**
+     * Bans a player with a custom kick message
+     * @param message The kick message
+     */
+    public void banPlayer(String message);
+
+    /**
      * Says a message (or runs a command).
      *
      * @param msg message to print


### PR DESCRIPTION
I can't seem to get the diff to work nicely on this. Sorry!

This adds to the API to allow banning of a player (I will be using it in my plugin, DefaultCommands, unless someone else has a request approved, of course)

CraftBukkit: https://github.com/Bukkit/CraftBukkit/pull/380
