### PR TITLE
onBlockPush & onBlockPull events (Piston Events)

### DIFF
--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -404,6 +404,12 @@ public abstract class Event implements Serializable {
          * @see org.bukkit.event.block.BlockFadeEvent
          */
         BLOCK_FADE (Category.BLOCK),
+        /**
+         * Called when a block is about to get pushed by a piston
+         *
+         * @see org.bukkit.event.block.BlockPushEvent
+         */
+        BLOCK_PUSH (Category.BLOCK),
 
         /**
          * INVENTORY EVENTS

--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -405,11 +405,17 @@ public abstract class Event implements Serializable {
          */
         BLOCK_FADE (Category.BLOCK),
         /**
+         * Called when a block is getting pulled by a piston
+         *
+         * @see org.bukkit.event.block.BlockPushEvent
+         */
+        BLOCK_PULL (Category.BLOCK),
+        /**
          * Called when a block is about to get pushed by a piston
          *
          * @see org.bukkit.event.block.BlockPushEvent
          */
-        BLOCK_PUSH (Category.BLOCK),
+        PISTON_PUSH (Category.BLOCK),
 
         /**
          * INVENTORY EVENTS

--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -415,7 +415,7 @@ public abstract class Event implements Serializable {
          *
          * @see org.bukkit.event.block.BlockPushEvent
          */
-        PISTON_PUSH (Category.BLOCK),
+        BLOCK_PUSH (Category.BLOCK),
 
         /**
          * INVENTORY EVENTS

--- a/src/main/java/org/bukkit/event/block/BlockListener.java
+++ b/src/main/java/org/bukkit/event/block/BlockListener.java
@@ -132,7 +132,7 @@ public class BlockListener implements Listener {
      *
      * @param event Relevant event details
      */
-    public void onPistonPush(PistonPushEvent event) {}
+    public void onBlockPush(BlockPushEvent event) {}
     
     /**
      * Called when a block is pulled by a piston

--- a/src/main/java/org/bukkit/event/block/BlockListener.java
+++ b/src/main/java/org/bukkit/event/block/BlockListener.java
@@ -128,9 +128,16 @@ public class BlockListener implements Listener {
     public void onBlockDispense(BlockDispenseEvent event) {}
     
     /**
-     * Called when a block is pushed by a piston
+     * Called when a piston pushes blocks
      *
      * @param event Relevant event details
      */
-    public void onBlockPush(BlockPushEvent event) {}
+    public void onPistonPush(PistonPushEvent event) {}
+    
+    /**
+     * Called when a block is pulled by a piston
+     *
+     * @param event Relevant event details
+     */
+    public void onBlockPull(BlockPullEvent event) {}
 }

--- a/src/main/java/org/bukkit/event/block/BlockListener.java
+++ b/src/main/java/org/bukkit/event/block/BlockListener.java
@@ -126,4 +126,11 @@ public class BlockListener implements Listener {
      * @param event Relevant event details
      */
     public void onBlockDispense(BlockDispenseEvent event) {}
+    
+    /**
+     * Called when a block is pushed by a piston
+     *
+     * @param event Relevant event details
+     */
+    public void onBlockPush(BlockPushEvent event) {}
 }

--- a/src/main/java/org/bukkit/event/block/BlockPullEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockPullEvent.java
@@ -1,0 +1,59 @@
+package org.bukkit.event.block;
+
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.event.Cancellable;
+
+/**
+ * Holds information for events with a block that is being pulled
+ */
+public class BlockPullEvent extends BlockEvent implements Cancellable {
+    protected BlockFace face;
+    protected Block source;
+    protected boolean cancel;
+
+    public BlockPullEvent(final Block block, final Block source, final BlockFace face) {
+        super(Type.BLOCK_PULL, block);
+        this.face = face;
+        this.source = source;
+        this.cancel = false;
+    }
+
+    /**
+     * Gets the location this block is pulled from
+     *
+     * @return Block the block is event originated from
+     */
+    public BlockFace getFace() {
+        return face;
+    }
+    
+    /**
+     * Gets the source of the blockpull
+     *
+     * @return the block where event originated from
+     */
+    public Block getSource(){
+        return source;
+    }
+
+     /**
+     * Gets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @return true if this event is cancelled
+     */
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    /**
+     * Sets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @param cancel true if you wish to cancel this event
+     */
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+}

--- a/src/main/java/org/bukkit/event/block/BlockPullEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockPullEvent.java
@@ -8,14 +8,14 @@ import org.bukkit.event.Cancellable;
  * Holds information for events with a block that is being pulled
  */
 public class BlockPullEvent extends BlockEvent implements Cancellable {
+
     protected BlockFace face;
-    protected Block source;
+    protected Block movedBlock;
     protected boolean cancel;
 
-    public BlockPullEvent(final Block block, final Block source, final BlockFace face) {
+    public BlockPullEvent(final Block block, final BlockFace face) {
         super(Type.BLOCK_PULL, block);
         this.face = face;
-        this.source = source;
         this.cancel = false;
     }
 
@@ -27,17 +27,21 @@ public class BlockPullEvent extends BlockEvent implements Cancellable {
     public BlockFace getFace() {
         return face;
     }
-    
+
     /**
-     * Gets the source of the blockpull
+     * Gets the block that is pulled
      *
      * @return the block where event originated from
      */
-    public Block getSource(){
-        return source;
+    public Block getMovedBlock() {
+        if (movedBlock == null) {
+            // Needs to be done twice otherwise will return piston extension!
+            movedBlock = block.getRelative(face.getModX() * 2, face.getModY() * 2, face.getModZ() * 2);
+        }
+        return movedBlock;
     }
 
-     /**
+    /**
      * Gets the cancellation state of this event. A cancelled event will not
      * be executed in the server, but will still pass to other plugins
      *

--- a/src/main/java/org/bukkit/event/block/BlockPushEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockPushEvent.java
@@ -1,5 +1,6 @@
 package org.bukkit.event.block;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -8,15 +9,17 @@ import org.bukkit.event.Cancellable;
 /**
  * Holds information for events with blocks that are pushed by a piston
  */
-public class PistonPushEvent extends BlockEvent implements Cancellable {
-    protected BlockFace face;
-    protected List<Block> blocks;
-    protected boolean cancel;
+public class BlockPushEvent extends BlockEvent implements Cancellable {
 
-    public PistonPushEvent(final Block block, final List<Block> blocks, final BlockFace face) {
-        super(Type.PISTON_PUSH, block);
+    protected BlockFace face;
+    protected Block endBlock;
+    protected boolean cancel;
+    protected List<Block> pushedBlocks;
+
+    public BlockPushEvent(final Block block, final Block endBlock, final BlockFace face) {
+        super(Type.BLOCK_PUSH, block);
         this.face = face;
-        this.blocks = blocks;
+        this.endBlock = endBlock;
         this.cancel = false;
     }
 
@@ -35,10 +38,18 @@ public class PistonPushEvent extends BlockEvent implements Cancellable {
      * @return List of blocks that are getting pushed
      */
     public List<Block> blocklist() {
-        return blocks;
+        if (pushedBlocks == null) {
+            pushedBlocks = new ArrayList<Block>();
+            Block tempblock = block.getRelative(face.getModX(), face.getModY(), face.getModZ());
+            while (tempblock != endBlock) {
+                pushedBlocks.add(tempblock);
+                tempblock = tempblock.getRelative(face.getModX(), face.getModY(), face.getModZ());
+            }
+        }
+        return pushedBlocks;
     }
 
-     /**
+    /**
      * Gets the cancellation state of this event. A cancelled event will not
      * be executed in the server, but will still pass to other plugins
      *

--- a/src/main/java/org/bukkit/event/block/BlockPushEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockPushEvent.java
@@ -1,0 +1,48 @@
+package org.bukkit.event.block;
+
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.event.Cancellable;
+
+/**
+ * Holds information for events with a source block and a destination block
+ */
+public class BlockPushEvent extends BlockEvent implements Cancellable {
+    protected BlockFace face;
+    protected boolean cancel;
+
+    public BlockPushEvent(final Block block, final BlockFace face) {
+        super(Type.BLOCK_PUSH, block);
+        this.face = face;
+        this.cancel = false;
+    }
+
+    /**
+     * Gets the location this block is pushed to
+     *
+     * @return Block the block is event originated from
+     */
+    public BlockFace getFace() {
+        return face;
+    }
+
+     /**
+     * Gets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @return true if this event is cancelled
+     */
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    /**
+     * Sets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @param cancel true if you wish to cancel this event
+     */
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+}

--- a/src/main/java/org/bukkit/event/block/PistonPushEvent.java
+++ b/src/main/java/org/bukkit/event/block/PistonPushEvent.java
@@ -1,29 +1,41 @@
 package org.bukkit.event.block;
 
+import java.util.List;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.event.Cancellable;
 
 /**
- * Holds information for events with a source block and a destination block
+ * Holds information for events with blocks that are pushed by a piston
  */
-public class BlockPushEvent extends BlockEvent implements Cancellable {
+public class PistonPushEvent extends BlockEvent implements Cancellable {
     protected BlockFace face;
+    protected List<Block> blocks;
     protected boolean cancel;
 
-    public BlockPushEvent(final Block block, final BlockFace face) {
-        super(Type.BLOCK_PUSH, block);
+    public PistonPushEvent(final Block block, final List<Block> blocks, final BlockFace face) {
+        super(Type.PISTON_PUSH, block);
         this.face = face;
+        this.blocks = blocks;
         this.cancel = false;
     }
 
     /**
      * Gets the location this block is pushed to
      *
-     * @return Block the block is event originated from
+     * @return Block the block is event moving to
      */
     public BlockFace getFace() {
         return face;
+    }
+
+    /**
+     * Returns the list of blocks that are pushed
+     * 
+     * @return List of blocks that are getting pushed
+     */
+    public List<Block> blocklist() {
+        return blocks;
     }
 
      /**

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -534,10 +534,10 @@ public final class JavaPluginLoader implements PluginLoader {
                 }
             };
             
-        case PISTON_PUSH:
+        case BLOCK_PUSH:
             return new EventExecutor() {
                 public void execute(Listener listener, Event event) {
-                    ((BlockListener) listener).onPistonPush((PistonPushEvent) event);
+                    ((BlockListener) listener).onBlockPush((BlockPushEvent) event);
                 }
             };
 

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -519,18 +519,25 @@ public final class JavaPluginLoader implements PluginLoader {
                     ((BlockListener) listener).onBlockFade((BlockFadeEvent) event);
                 }
             };
-            
-        case BLOCK_PUSH:
-            return new EventExecutor() {
-                public void execute(Listener listener, Event event) {
-                    ((BlockListener) listener).onBlockPush((BlockPushEvent) event);
-                }
-            };
 
         case BLOCK_DISPENSE:
             return new EventExecutor() {
                 public void execute(Listener listener, Event event) {
                     ((BlockListener) listener).onBlockDispense((BlockDispenseEvent) event);
+                }
+            };
+            
+        case BLOCK_PULL:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((BlockListener) listener).onBlockPull((BlockPullEvent) event);
+                }
+            };
+            
+        case PISTON_PUSH:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((BlockListener) listener).onPistonPush((PistonPushEvent) event);
                 }
             };
 

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -519,6 +519,13 @@ public final class JavaPluginLoader implements PluginLoader {
                     ((BlockListener) listener).onBlockFade((BlockFadeEvent) event);
                 }
             };
+            
+        case BLOCK_PUSH:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((BlockListener) listener).onBlockPush((BlockPushEvent) event);
+                }
+            };
 
         case BLOCK_DISPENSE:
             return new EventExecutor() {


### PR DESCRIPTION
For my own server i needed an event that listens to blocks pushed by a piston.

Well, here is the bukkit code for the new event. I send a pull request for CraftBukkit so its actually called when a block is pushed (https://github.com/Bukkit/CraftBukkit/pull/384).

I think this can help a great deal of plugin developers to add new functions.
