### PR TITLE
Add PlayerVelocityEvent

### DIFF
--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -198,6 +198,13 @@ public abstract class Event implements Serializable {
          */
         PLAYER_MOVE (Category.PLAYER),
         /**
+         * Called before a player gets a velocity vector sent, which will instruct him to 
+         * get "pushed" into a specific direction, e.g. after an explosion
+         *
+         * @see org.bukkit.event.player.PlayerVelocityEvent
+         */
+        PLAYER_VELOCITY (Category.PLAYER),
+        /**
          * Called when a player undergoes an animation (Arm Swing is the only animation currently supported)
          *
          * @see org.bukkit.event.player.PlayerAnimationEvent

--- a/src/main/java/org/bukkit/event/player/PlayerListener.java
+++ b/src/main/java/org/bukkit/event/player/PlayerListener.java
@@ -52,6 +52,14 @@ public class PlayerListener implements Listener {
     public void onPlayerMove(PlayerMoveEvent event) {}
 
     /**
+     * Called before a player gets a velocity vector sent, which will "push"
+     * the player in a certain direction
+     *
+     * @param event Relevant event details
+     */
+    public void onPlayerVelocity(PlayerVelocityEvent event) {}
+
+    /**
      * Called when a player attempts to teleport to a new location in a world
      *
      * @param event Relevant event details

--- a/src/main/java/org/bukkit/event/player/PlayerVelocityEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerVelocityEvent.java
@@ -1,0 +1,63 @@
+package org.bukkit.event.player;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.util.Vector;
+
+public class PlayerVelocityEvent extends PlayerEvent implements Cancellable {
+
+	/**
+	 * Holds information for player velocity events
+	 */
+	private boolean cancel = false;
+	private Vector velocity;
+
+	public PlayerVelocityEvent(final Player player, final Vector velocity) {
+		super(Type.PLAYER_VELOCITY, player);
+		this.velocity = velocity;
+	}
+
+	PlayerVelocityEvent(final Event.Type type, final Player player, final Vector velocity) {
+		super(type, player);
+		this.velocity = velocity;
+	}
+
+	/**
+	 * Gets the cancellation state of this event. A cancelled event will not
+	 * be executed in the server, but will still pass to other plugins
+	 *
+	 * @return true if this event is cancelled
+	 */
+	public boolean isCancelled() {
+		return cancel;
+	}
+
+	/**
+	 * Sets the cancellation state of this event. A cancelled event will not
+	 * be executed in the server, but will still pass to other plugins
+	 *
+	 * @param cancel true if you wish to cancel this event
+	 */
+	public void setCancelled(boolean cancel) {
+		this.cancel = cancel;
+	}
+
+	/**
+	 * Gets the velocity vector that will be sent to the player
+	 *
+	 * @return Vector the player will get
+	 */
+	public Vector getVelocity() {
+		return velocity;
+	}
+
+	/**
+	 * Sets the velocity vector that will be sent to the player
+	 *
+	 * @param velocity The velocity vector that will be sent to the player
+	 */
+	public void setVelocity(Vector velocity) {
+		this.velocity = velocity;
+	}
+}

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -287,6 +287,13 @@ public final class JavaPluginLoader implements PluginLoader {
                 }
             };
 
+        case PLAYER_VELOCITY:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((PlayerListener) listener).onPlayerVelocity((PlayerVelocityEvent) event);
+                }
+            };
+
         case PLAYER_TELEPORT:
             return new EventExecutor() {
                 public void execute(Listener listener, Event event) {


### PR DESCRIPTION
This adds a PlayerVelocityEvent, which will fire before a "PacketVelocity" is sent to the player.

"PacketVelocity" is used by Minecraft to temporarily take away control and instruct the player to move in a specific direction on the client side, e.g. after getting hit by an enemy, an explosion, ...

I need the ability to read this information for my Plugin "NoCheat", to be able to predict that the specific player will move very fast in that specific direction very soon. But I also added the option to change the velocity vector (e.g. increase or reduce the effect of such "pushes" by the environment) or completely cancel the event (make a player immune to such effects, like a Juggernaut) for other plugin developers.

This is only the Bukkit-part of the feature.
