### PR TITLE
retiring EntityDamageByProjectileEvent in favor of EntityDamageEvent

### DIFF
--- a/src/main/java/org/bukkit/entity/Projectile.java
+++ b/src/main/java/org/bukkit/entity/Projectile.java
@@ -20,4 +20,19 @@ public interface Projectile extends Entity {
      *            the {@link LivingEntity} that shot this projectile
      */
     public void setShooter(LivingEntity shooter);
+
+    /**
+     * Determine if this projectile should bounce or not when it hits.
+     * 
+     * @return true if it should bounce.
+     */
+    public boolean doesBounce();
+
+    /**
+     * Set whether or not this projectile should bounce or not when it hits something.
+     * 
+     * @param doesBounce
+     *            whether or not it should bounce.
+     */
+    public void setBounce(boolean doesBounce);
 }

--- a/src/main/java/org/bukkit/event/entity/EntityDamageByProjectileEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDamageByProjectileEvent.java
@@ -1,28 +1,25 @@
 package org.bukkit.event.entity;
 
-import java.util.Random;
-
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Projectile;
 
 /**
  * Called when an entity is damaged by a projectile
+ * 
+ * @deprecated use {@link EntityDamageByEntityEvent} instead, where {@link EntityDamageByEntityEvent#getDamager()} will return the {@link Projectile}
  */
+@Deprecated
 public class EntityDamageByProjectileEvent extends EntityDamageByEntityEvent {
 
     private Projectile projectile;
-    private boolean bounce;
 
     public EntityDamageByProjectileEvent(Entity damagee, Projectile projectile, DamageCause cause, int damage) {
         this(projectile.getShooter(), damagee, projectile, cause, damage);
     }
 
     public EntityDamageByProjectileEvent(Entity damager, Entity damagee, Projectile projectile, DamageCause cause, int damage) {
-        super(damager, damagee, cause, damage);
+        super(damager, projectile, DamageCause.PROJECTILE, damage);
         this.projectile = projectile;
-        Random random = new Random();
-
-        this.bounce = random.nextBoolean();
     }
 
     /**
@@ -35,10 +32,10 @@ public class EntityDamageByProjectileEvent extends EntityDamageByEntityEvent {
     }
 
     public void setBounce(boolean bounce) {
-        this.bounce = bounce;
+        projectile.setBounce(bounce);
     }
 
     public boolean getBounce() {
-        return bounce;
+        return projectile.doesBounce();
     }
 }

--- a/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
@@ -78,8 +78,14 @@ public class EntityDamageEvent extends EntityEvent implements Cancellable {
          */
         ENTITY_ATTACK,
         /**
+         * Damage caused when attacked by a projectile.
+         * 
+         * Damage: variable
+         */
+        PROJECTILE,
+        /**
          * Damage caused by being put in a block
-         *
+         * 
          * Damage: 1
          */
         SUFFOCATION,


### PR DESCRIPTION
This commit deprecates EDBPE and moves the support for setting whether or not a projectile bounces into the Projectile interface.

Implemented in https://github.com/Bukkit/CraftBukkit/pull/401
