### PR TITLE
Allows PlayerArmAnimation to be cancelled.

### DIFF
--- a/src/main/java/org/bukkit/event/player/PlayerAnimationEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerAnimationEvent.java
@@ -34,7 +34,12 @@ public class PlayerAnimationEvent extends PlayerEvent implements Cancellable{
     public boolean isCancelled() {
         return cancel;
     }
-
+    
+    /**
+     * Animation is not seen by all surrounding players if cancelled    
+     *
+     * @param cancel boolean determining if event is cancelled
+     */
     public void setCancelled(boolean cancel) {
         this.cancel = cancel;
     }

--- a/src/main/java/org/bukkit/event/player/PlayerAnimationEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerAnimationEvent.java
@@ -36,9 +36,11 @@ public class PlayerAnimationEvent extends PlayerEvent implements Cancellable{
     }
     
     /**
-     * Animation is not seen by all surrounding players if cancelled    
-     *
-     * @param cancel boolean determining if event is cancelled
+     * Sets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins.
+     * Animation is not seen by all surrounding players if cancelled      
+     * 
+     * @param cancel true if you wish to cancel this event     
      */
     public void setCancelled(boolean cancel) {
         this.cancel = cancel;

--- a/src/main/java/org/bukkit/event/player/PlayerAnimationEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerAnimationEvent.java
@@ -1,12 +1,13 @@
 package org.bukkit.event.player;
 
 import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
 
 /**
  * Represents a player animation event
  */
-public class PlayerAnimationEvent extends PlayerEvent {
-
+public class PlayerAnimationEvent extends PlayerEvent implements Cancellable{
+	private boolean cancel = false;
     private PlayerAnimationType animationType;
 
     /**
@@ -29,4 +30,13 @@ public class PlayerAnimationEvent extends PlayerEvent {
     public PlayerAnimationType getAnimationType() {
         return animationType;
     }
+
+	public boolean isCancelled() {
+        return cancel;
+	}
+
+	public void setCancelled(boolean cancel) {
+		this.cancel = cancel;
+		
+	}
 }

--- a/src/main/java/org/bukkit/event/player/PlayerAnimationEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerAnimationEvent.java
@@ -7,7 +7,7 @@ import org.bukkit.event.Cancellable;
  * Represents a player animation event
  */
 public class PlayerAnimationEvent extends PlayerEvent implements Cancellable{
-	private boolean cancel = false;
+    private boolean cancel = false;
     private PlayerAnimationType animationType;
 
     /**
@@ -31,12 +31,11 @@ public class PlayerAnimationEvent extends PlayerEvent implements Cancellable{
         return animationType;
     }
 
-	public boolean isCancelled() {
+    public boolean isCancelled() {
         return cancel;
-	}
+    }
 
-	public void setCancelled(boolean cancel) {
-		this.cancel = cancel;
-		
-	}
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
 }


### PR DESCRIPTION
Makes PlayerArmAnimation event implement cancellable.

CraftBukkit pull: https://github.com/Bukkit/CraftBukkit/pull/402
