### PR TITLE
Filled out interface for ServerCommandEvent

### DIFF
--- a/src/main/java/org/bukkit/event/server/ServerCommandEvent.java
+++ b/src/main/java/org/bukkit/event/server/ServerCommandEvent.java
@@ -1,5 +1,7 @@
 package org.bukkit.event.server;
 
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.event.Cancellable;
 
 /**
@@ -7,10 +9,12 @@ import org.bukkit.event.Cancellable;
  */
 public class ServerCommandEvent extends ServerEvent implements Cancellable {
     private boolean cancelled = false;
-    String command;
-    public ServerCommandEvent(String message) {
+    private String command;
+    private CommandSender sender;
+    public ServerCommandEvent(ConsoleCommandSender console, String message) {
         super(Type.SERVER_COMMAND);
         command = message;
+        sender = console;
     }
 
     /**
@@ -49,5 +53,12 @@ public class ServerCommandEvent extends ServerEvent implements Cancellable {
      */
     public void setCommand(String message) {
         this.command = message;
+    }
+    
+    /**
+     * Get the command sender.
+     */
+    public CommandSender getSender() {
+        return sender;
     }
 }

--- a/src/main/java/org/bukkit/event/server/ServerCommandEvent.java
+++ b/src/main/java/org/bukkit/event/server/ServerCommandEvent.java
@@ -1,12 +1,53 @@
 package org.bukkit.event.server;
 
-import org.bukkit.event.Event;
+import org.bukkit.event.Cancellable;
 
 /**
  * Server Command events
  */
-public class ServerCommandEvent extends Event {
-    public ServerCommandEvent() {
+public class ServerCommandEvent extends ServerEvent implements Cancellable {
+    private boolean cancelled = false;
+    String command;
+    public ServerCommandEvent(String message) {
         super(Type.SERVER_COMMAND);
+        command = message;
+    }
+
+    /**
+     * Gets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @return true if this event is cancelled
+     */
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    /**
+     * Sets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins.
+     *
+     * @param cancel true if you wish to cancel this event
+     */
+    public void setCancelled(boolean cancel) {
+        cancelled = cancel;
+    }
+
+    /**
+     * Gets the command that the user is attempting to execute from the console
+     *
+     * @return Command the user is attempting to execute
+     */
+    public String getCommand() {
+        return command;
+    }
+
+    /**
+     * Sets the command that the server will execute
+     *
+     * @param message New message that the server will execute
+     */
+    public void setCommand(String message) {
+        this.command = message;
     }
 }


### PR DESCRIPTION
The ServerCommandEvent is like PlayerCommandPreprocessEvent except that it triggers as a result of commands from the console rather than from a player. As such it could be used to catch vanilla Minecraft commands and either cancel them or do something extra with them, for example logging them or passing "say" messages through to IRC.
