### PR TITLE
* node functionality.

### DIFF
--- a/src/main/java/org/bukkit/permissions/PermissibleBase.java
+++ b/src/main/java/org/bukkit/permissions/PermissibleBase.java
@@ -65,6 +65,21 @@ public class PermissibleBase implements Permissible {
         calculatePermissions();
 
         String name = inName.toLowerCase();
+        
+        if (isPermissionSet("*")) {
+            return permissions.get("*").getValue();
+        }
+        
+        String[] arr = name.split("\\.");
+        String node = "";
+        
+        for (int i = 0; i < arr.length; i++) {
+            node += arr[i];
+            if (isPermissionSet(node + ".*")) {
+                return permissions.get(node + ".*").getValue();
+            }
+            node += ".";
+        }
 
         if (isPermissionSet(name)) {
             return permissions.get(name).getValue();
@@ -87,6 +102,21 @@ public class PermissibleBase implements Permissible {
         calculatePermissions();
 
         String name = perm.getName().toLowerCase();
+        
+        if (isPermissionSet("*")) {
+            return permissions.get("*").getValue();
+        }
+        
+        String[] arr = name.split("\\.");
+        String node = "";
+        
+        for (int i = 0; i < arr.length; i++) {
+            node += arr[i];
+            if (isPermissionSet(node + ".*")) {
+                return permissions.get(node + ".*").getValue();
+            }
+            node += ".";
+        }
 
         if (isPermissionSet(name)) {
             return permissions.get(name).getValue();


### PR DESCRIPTION
This commit allows for a well-sought-after feature, which was present in the Permissions plugins - the usage of a wildcard character. This commit allows a global \* node to be specified (which allows the group or player to have ALL permissions) as well as children \* nodes, which allows the group or player to have all children nodes under a parent node. (foo.\* gives foo.bar, foo.pie etc.)
