### PR TITLE
public constructor for ConfigurationNode, and setNode method

### DIFF
--- a/src/main/java/org/bukkit/util/config/ConfigurationNode.java
+++ b/src/main/java/org/bukkit/util/config/ConfigurationNode.java
@@ -465,6 +465,17 @@ public class ConfigurationNode {
     }
 
     /**
+     * Set a configuration node at a path. This will override existing
+     * configuration data to have it conform to key/value mappings.
+     *
+     * @param path
+     * @param node
+     */
+    public void setNode(String path, ConfigurationNode node){
+        setProperty(path, node.root);
+    }
+
+    /**
      * Get a list of nodes at a location. If the map at the particular location
      * does not exist or it is not a map, null will be returned.
      *

--- a/src/main/java/org/bukkit/util/config/ConfigurationNode.java
+++ b/src/main/java/org/bukkit/util/config/ConfigurationNode.java
@@ -18,6 +18,13 @@ public class ConfigurationNode {
     }
 
     /**
+     * Constructor for a blank node.
+     */
+    public ConfigurationNode(){
+        this.root = new HashMap<String, Object>();
+    }
+
+    /**
      * Gets all of the cofiguration values within the Node as
      * a key value pair, with the key being the full path and the
      * value being the Object that is at the path.


### PR DESCRIPTION
I think programmers should be able to instantiate ConfigurationNode's. ConfigurationNode's would be useful to compartmentalize YAML generation.

Furthermore, a setNode method would allow programmers to add nodes to the main tree. Implementing a setNode is easy because it is basically just a call to setProperty with the argument node's root.

Making these changes enables the following behavior:

ConfigurationNode somethingYaml = something.toYaml();
config.setNode("something", somethingYaml);
