### PR TITLE
Added PlayerSendChunkEvent

### DIFF
--- a/src/main/java/org/bukkit/ChunkSnapshot.java
+++ b/src/main/java/org/bukkit/ChunkSnapshot.java
@@ -37,6 +37,16 @@ public interface ChunkSnapshot {
      * @return 0-255
      */
     int getBlockTypeId(int x, int y, int z);
+    
+    /**
+     * Set block type for block at corresponding coordinate in the chunk
+     *
+     * @param x 0-15
+     * @param y 0-127
+     * @param z 0-15
+     * @param type 0-255
+     */
+    void setBlockTypeId(int x, int y, int z, int type);
 
     /**
      * Get block data for block at corresponding coordinate in the chunk
@@ -47,6 +57,16 @@ public interface ChunkSnapshot {
      * @return 0-15
      */
     int getBlockData(int x, int y, int z);
+    
+    /**
+     * Set block data for block at corresponding coordinate in the chunk
+     *
+     * @param x 0-15
+     * @param y 0-127
+     * @param z 0-15
+     * @param data 0-15
+     */
+    void setBlockData(int x, int y, int z, int data);
 
     /**
      * Get sky light level for block at corresponding coordinate in the chunk
@@ -109,4 +129,10 @@ public interface ChunkSnapshot {
      * @return time in ticks
      */
     long getCaptureFullTime();
+    
+    /**
+     * Returns the data buffer associated with the chunk snapshot
+     * @return data buffer
+     */
+    public byte[] getData();
 }

--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -150,6 +150,12 @@ public abstract class Event implements Serializable {
          */
         PLAYER_JOIN (Category.PLAYER),
         /**
+         * Called when a chunk is sent to a player
+         *
+         * @see org.bukkit.event.player.PlayerSendChunkEvent
+         */
+        PLAYER_SEND_CHUNK (Category.PLAYER),
+        /**
          * Called when a player is attempting to connect to the server
          *
          * @see org.bukkit.event.player.PlayerLoginEvent

--- a/src/main/java/org/bukkit/event/player/PlayerListener.java
+++ b/src/main/java/org/bukkit/event/player/PlayerListener.java
@@ -14,6 +14,13 @@ public class PlayerListener implements Listener {
      * @param event Relevant event details
      */
     public void onPlayerJoin(PlayerJoinEvent event) {}
+    
+    /**
+     * Called when a chunk is sent to a player
+     *
+     * @param event Relevant event details
+     */
+    public void onPlayerSendChunk(PlayerSendChunkEvent event) {}
 
     /**
      * Called when a player leaves a server

--- a/src/main/java/org/bukkit/event/player/PlayerSendChunkEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerSendChunkEvent.java
@@ -1,0 +1,29 @@
+package org.bukkit.event.player;
+
+import org.bukkit.Chunk;
+import org.bukkit.ChunkSnapshot;
+import org.bukkit.entity.Player;
+
+public class PlayerSendChunkEvent extends PlayerEvent {
+	
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+	protected ChunkSnapshot chunkSnapshot;
+	protected Chunk chunk;
+
+	public PlayerSendChunkEvent(Type type, Player who, ChunkSnapshot chunkSnapshot, Chunk chunk) {
+		super(type, who);
+		this.chunkSnapshot = chunkSnapshot;
+		this.chunk = chunk;
+	}
+	
+	public ChunkSnapshot getChunkSnapshot(){
+		return this.chunkSnapshot;
+	}
+
+	public Chunk getChunk(){
+		return this.chunk;
+	}
+}

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -244,6 +244,13 @@ public final class JavaPluginLoader implements PluginLoader {
                     ((PlayerListener) listener).onPlayerJoin((PlayerJoinEvent) event);
                 }
             };
+            
+        case PLAYER_SEND_CHUNK:
+        	return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((PlayerListener) listener).onPlayerSendChunk((PlayerSendChunkEvent) event);
+                }
+            };
 
         case PLAYER_QUIT:
             return new EventExecutor() {


### PR DESCRIPTION
PlayerSendChunkEvent is triggered for each player when a chunk is sen to them. Plugins can take the chunkSnapshot and modify blocks, making it appear to players that the world is different than it actually is. During testing it ran without any performance problems on my laptop, so it should be good for larger implementations. One major way to implement this would be to make anti-xray plugins that never send hidden ores to clients at all.

The corresponding CraftBukkit pull can be found here:
https://github.com/Bukkit/CraftBukkit/pull/416

Behold its amazing power:
https://github.com/downloads/zonedabone/CraftBukkit/2011-08-05_23.54.27.png
