### PR TITLE
Makes Configuration files make sure that all node keys are Strings

### DIFF
--- a/src/main/java/org/bukkit/util/config/Configuration.java
+++ b/src/main/java/org/bukkit/util/config/Configuration.java
@@ -5,8 +5,10 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
@@ -54,7 +56,7 @@ import org.yaml.snakeyaml.representer.Representer;
  *
  */
 public class Configuration extends ConfigurationNode {
-    private Yaml yaml;
+    protected Yaml yaml;
     private File file;
     private String header = null;
 
@@ -175,10 +177,24 @@ public class Configuration extends ConfigurationNode {
                 root = new HashMap<String, Object>();
             } else {
                 root = (Map<String, Object>) input;
+                root = (Map<String, Object>) recursiveCast(root);
             }
         } catch (ClassCastException e) {
             throw new ConfigurationException("Root document must be an key-value structure");
         }
+    }
+    
+    private Map recursiveCast(Map map) {
+        ArrayList<Map.Entry> entries = new ArrayList<Map.Entry>(map.entrySet());
+        HashMap returnMap = new HashMap();
+        for (Entry entry : entries) {
+            Object o = entry.getKey();
+            if(o instanceof String) continue;
+            if(o instanceof Map) o = recursiveCast((Map)o);
+            else o = o.toString();
+            returnMap.put(o, entry.getValue());
+        }
+        return returnMap;
     }
 
     /**


### PR DESCRIPTION
Makes sure that all YML files loaded via Configuration use actual String keys. Due to type erasure, it was possible for the `Map<String, Object>` to actually have Integer (and possibly other type) node names. This is outlined in [this Bukkit+ post](http://forums.bukkit.org/threads/yaml-and-integer-keys.30198/).

I also changed the yaml property of Configuration to be `protected` rather than `private` to allow for subclassing.
