### PR TITLE
added method to spawn falling sand to world

### DIFF
--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -284,6 +284,15 @@ public interface World {
     public Arrow spawnArrow(Location location, Vector velocity, float speed, float spread);
 
     /**
+     * Creates an {@link FallingSand} entity at the given {@link Location}
+     *
+     * @param location Location to spawn the falling sand at
+     * @param gravel Whether to spawn a falling sand or gravel entity
+     * @return FallingSand entity spawned as a result of this method
+     */
+    public FallingSand spawnFallingSand(Location location, boolean gravel);
+
+    /**
      * Creates a tree at the given {@link Location}
      *
      * @param location Location to spawn the tree


### PR DESCRIPTION
`world.spawn(location, FallingSand.class);`
caused an IllegalArgumentException in net.minecraft.server.EntityTrackerEntry because it expects the "a" field from EntityFallingSand to be either 12 (sand id) or 13 (gravel).

I added a spawnFallingSand(Location location, boolean gravel) method to World.

CraftBukkit pull request:
https://github.com/Bukkit/CraftBukkit/pull/419
