### PR TITLE
Added more options to projectileHitEvent

### DIFF
--- a/src/main/java/org/bukkit/event/entity/ProjectileHitBlockEvent.java
+++ b/src/main/java/org/bukkit/event/entity/ProjectileHitBlockEvent.java
@@ -1,0 +1,19 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.block.Block;
+import org.bukkit.entity.Projectile;
+
+public class ProjectileHitBlockEvent extends ProjectileHitEvent{
+	
+	protected Block block;
+
+	public ProjectileHitBlockEvent(Projectile projectile, Block block) {
+		super(projectile);
+		this.block = block;
+	}
+	
+	public Block getBlock(){
+		return block;
+	}
+
+}

--- a/src/main/java/org/bukkit/event/entity/ProjectileHitEntityEvent.java
+++ b/src/main/java/org/bukkit/event/entity/ProjectileHitEntityEvent.java
@@ -1,0 +1,19 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Projectile;
+
+public class ProjectileHitEntityEvent extends ProjectileHitEvent {
+	
+	protected Entity hit;
+
+	public ProjectileHitEntityEvent(Projectile projectile, Entity hit) {
+		super(projectile);
+		this.hit=hit;
+	}
+	
+	public Entity getHit(){
+		return hit;
+	}
+
+}


### PR DESCRIPTION
This version subclasses projectileHitEvent into projectileHitEntityEvent and projectileHitBlockEvent, with getHit() and getBlock respectively. Current pkugins that use the api will still work, since it's all subclassing.

The only current coding issue is that if the world that a fireball hits in is static, then projectileHitEvent will not be subclassed. If you look at the code you can see why I did this.

Craftbukkit pull:
https://github.com/Bukkit/CraftBukkit/pull/421
