### PR TITLE
Adds a method that returns the File representation of the update folder. 

### DIFF
--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.logging.Logger;
+import java.io.File;
 import org.bukkit.command.PluginCommand;
 
 import org.bukkit.command.CommandSender;
@@ -112,9 +113,19 @@ public interface Server {
      * Gets the name of the update folder. The update folder is used to safely update
      * plugins at the right moment on a plugin load.
      *
+     * The update folder name is relative to the plugins folder.
+     *
      * @return The name of the update folder
      */
     public String getUpdateFolder();
+
+    /**
+     * Gets the update folder. The update folder is used to safely update
+     * plugins at the right moment on a plugin load.
+     *
+     * @return The name of the update folder
+     */
+    public File getUpdateFolderFile();
 
     /**
      * Gets a player object by the given username


### PR DESCRIPTION
The Server.getUpdateFolder() returns "update".

However, the actual update folder is "plugins/update".  

The new method getUpdateFolderFile returns a File which includes the path (relative to the server's folder).

There is also a CraftBukkit pull:
https://github.com/Bukkit/CraftBukkit/pull/427
