### PR TITLE
Made events stop propagating if they have been cancelled.

### DIFF
--- a/src/main/java/org/bukkit/plugin/RegisteredListener.java
+++ b/src/main/java/org/bukkit/plugin/RegisteredListener.java
@@ -55,6 +55,11 @@ public class RegisteredListener {
      * @return Registered Priority
      */
     public void callEvent(Event event) {
+        if(event instanceof Cancellable && this.priority != Event.Priority.Monitor){
+            if(((Cancellable)event).isCancelled()){
+                return;
+            }
+        }
         executor.execute(listener, event);
     }
 }


### PR DESCRIPTION
Made events stop propagating if they have been cancelled, and the listener isn't Monitor priority. Further work should be done to ensure that monitor level listeners don't actually edit the event further.
