### PR TITLE
Added SlimeSplitEvent

### DIFF
--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -672,6 +672,13 @@ public abstract class Event implements Serializable {
          * @see org.bukkit.event.entity.ProjectileHitEvent
          */
         PROJECTILE_HIT (Category.ENTITY),
+        
+        /**
+         * Called when a Slime splits into smaller Slimes upon death
+         * 
+         * @see org.bukkit.event.entity.SlimeSplitEvent
+         */
+        SLIME_SPLIT (Category.LIVING_ENTITY),
 
         /**
          * Called when a LivingEntity is regains health

--- a/src/main/java/org/bukkit/event/entity/EntityListener.java
+++ b/src/main/java/org/bukkit/event/entity/EntityListener.java
@@ -134,4 +134,11 @@ public class EntityListener implements Listener {
      * @param event Relevant event details
      */
     public void onProjectileHit(ProjectileHitEvent event) {}
+    
+    /**
+     * Called when a Slime splits into smaller Slimes upon death
+     * 
+     * @param event Relevant event details
+     */
+    public void onSlimeSplit(SlimeSplitEvent event) {}
 }

--- a/src/main/java/org/bukkit/event/entity/SlimeSplitEvent.java
+++ b/src/main/java/org/bukkit/event/entity/SlimeSplitEvent.java
@@ -1,0 +1,44 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Cancellable;
+
+/**
+ * Called when a Slime splits into smaller Slimes upon death
+ */
+public class SlimeSplitEvent extends EntityEvent implements Cancellable {
+    private boolean cancel;
+    private int count;
+
+    public SlimeSplitEvent(Entity what, int count) {
+        super(Type.SLIME_SPLIT, what);
+        this.cancel = false;
+        this.count = count;
+    }
+
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+
+    /**
+     * Gets the amount of smaller slimes to spawn
+     *
+     * @return the amount of slimes to spawn
+     */
+    public int getCount() {
+        return count;
+    }
+
+    /**
+     * Sets how many smaller slimes will spawn on the split
+     *
+     * @param count the amount of slimes to spawn
+     */
+    public void setCount(int count) {
+        this.count = count;
+    }
+}

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -755,6 +755,13 @@ public final class JavaPluginLoader implements PluginLoader {
                 }
             };
 
+        case SLIME_SPLIT:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((EntityListener) listener).onSlimeSplit((SlimeSplitEvent) event);
+                }
+            };
+
         // Vehicle Events
         case VEHICLE_CREATE:
             return new EventExecutor() {


### PR DESCRIPTION
Adds a SlimeSplitEvent, which is fired when a Slime attempts to split upon death. The event may be cancelled, and the amount of smaller slimes may be customized.
