### PR TITLE
Checked to see if listener is null in SimplePluginManager

### DIFF
--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -370,6 +370,7 @@ public final class SimplePluginManager implements PluginManager {
      * @param plugin Plugin to register
      */
     public void registerEvent(Event.Type type, Listener listener, Priority priority, Plugin plugin) {
+        if (listener == null) throw new NullPointerException("listener cannot be null");
         if (!plugin.isEnabled()) {
             throw new IllegalPluginAccessException("Plugin attempted to register " + type + " while not enabled");
         }
@@ -387,6 +388,7 @@ public final class SimplePluginManager implements PluginManager {
      * @param plugin Plugin to register
      */
     public void registerEvent(Event.Type type, Listener listener, EventExecutor executor, Priority priority, Plugin plugin) {
+        if (listener == null) throw new NullPointerException("listener cannot be null");
         if (!plugin.isEnabled()) {
             throw new IllegalPluginAccessException("Plugin attempted to register " + type + " while not enabled");
         }


### PR DESCRIPTION
When you register an event with the listener as null, it doesn't give any errors until the event gets called, and the stack trace doesn't list the plugin as the problem.  This helps plugin creators remember when they forget to change it :P.
