### PR TITLE
Allow the player's name in PlayerPreLoginEvent to be changed.

### DIFF
--- a/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java
@@ -1,6 +1,8 @@
 package org.bukkit.event.player;
 
 import java.net.InetAddress;
+
+import org.bukkit.ChatColor;
 import org.bukkit.event.Event;
 
 /**
@@ -10,6 +12,7 @@ public class PlayerPreLoginEvent extends Event {
     private Result result;
     private String message;
     private String name;
+    private final String realName;
     private InetAddress ipAddress;
 
     public PlayerPreLoginEvent(String name, InetAddress ipAddress) {
@@ -17,6 +20,7 @@ public class PlayerPreLoginEvent extends Event {
         this.result = Result.ALLOWED;
         this.message = "";
         this.name = name;
+        this.realName = name;
         this.ipAddress = ipAddress;
     }
 
@@ -82,6 +86,24 @@ public class PlayerPreLoginEvent extends Event {
      */
     public String getName() {
         return name;
+    }
+
+    /**
+     * Gets the player's real name, as it was sent by the client.
+     *
+     * @return the player's name
+     */
+    public String getRealName() {
+        return realName;
+    }
+
+    /**
+     * Sets the player's name
+     *
+     * @param name the player's new name
+     */
+    public void setName(String name) {
+        this.name = ChatColor.stripColor(name);
     }
 
     /**


### PR DESCRIPTION
Changed PlayerPreLoginEvent to allow plugins to set the real name of the player as it appears to the server and all other clients.

CraftBukkit pullrequest: https://github.com/Bukkit/CraftBukkit/pull/483
