### PR TITLE
Docs fixups

### DIFF
--- a/src/main/java/org/bukkit/BlockChangeDelegate.java
+++ b/src/main/java/org/bukkit/BlockChangeDelegate.java
@@ -12,10 +12,10 @@ public interface BlockChangeDelegate {
     /**
      * Set a block type at the specified coordinates.
      *
-     * @param x
-     * @param y
-     * @param z
-     * @param typeId
+     * @param x X coordinate
+     * @param y Y coordinate
+     * @param z Z coordinate
+     * @param typeId New block ID
      * @return true if the block was set successfully
      */
     public boolean setRawTypeId(int x, int y, int z, int typeId);
@@ -23,21 +23,21 @@ public interface BlockChangeDelegate {
     /**
      * Set a block type and data at the specified coordinates.
      *
-     * @param x
-     * @param y
-     * @param z
-     * @param typeId
-     * @param data
+     * @param x X coordinate
+     * @param y Y coordinate
+     * @param z Z coordinate
+     * @param typeId New block ID
+     * @param data Block data
      * @return true if the block was set successfully
      */
     public boolean setRawTypeIdAndData(int x, int y, int z, int typeId, int data);
 
     /**
      * Get the block type at the location.
-     * @param x
-     * @param y
-     * @param z
-     * @return
+     * @param x X coordinate
+     * @param y Y coordinate
+     * @param z Z coordinate
+     * @return The block ID
      */
     public int getTypeId(int x, int y, int z);
 }

--- a/src/main/java/org/bukkit/ChatColor.java
+++ b/src/main/java/org/bukkit/ChatColor.java
@@ -98,7 +98,7 @@ public enum ChatColor {
      * Gets the color represented by the specified color code
      *
      * @param code Code to check
-     * @return Associative {@link Color} with the given code, or null if it doesn't exist
+     * @return Associative {@link org.bukkit.ChatColor} with the given code, or null if it doesn't exist
      */
     public static ChatColor getByCode(final int code) {
         return colors.get(code);

--- a/src/main/java/org/bukkit/Chunk.java
+++ b/src/main/java/org/bukkit/Chunk.java
@@ -55,14 +55,22 @@ public interface Chunk {
      */
     ChunkSnapshot getChunkSnapshot(boolean includeMaxblocky, boolean includeBiome, boolean includeBiomeTempRain);
 
+    /**
+     * Get a list of all entities in the chunk.
+     * @return The entities.
+     */
     Entity[] getEntities();
 
+    /**
+     * Get a list of all tile entities in the chunk.
+     * @return The tile entities.
+     */
     BlockState[] getTileEntities();
 
     /**
      * Checks if the chunk is loaded.
      *
-     * @return
+     * @return True if it is loaded.
      */
     boolean isLoaded();
 

--- a/src/main/java/org/bukkit/Location.java
+++ b/src/main/java/org/bukkit/Location.java
@@ -217,7 +217,7 @@ public class Location implements Cloneable {
      * Adds the location by another.
      *
      * @see Vector
-     * @param vec
+     * @param vec The other location
      * @return the same location
      * @throws IllegalArgumentException for differing worlds
      */
@@ -236,9 +236,9 @@ public class Location implements Cloneable {
      * Adds the location by another. Not world-aware.
      *
      * @see Vector
-     * @param x
-     * @param y
-     * @param z
+     * @param x X coordinate
+     * @param y Y coordinate
+     * @param z Z coordinate
      * @return the same location
      */
     public Location add(double x, double y, double z) {
@@ -252,7 +252,7 @@ public class Location implements Cloneable {
      * Subtracts the location by another.
      *
      * @see Vector
-     * @param vec
+     * @param vec The other location
      * @return the same location
      * @throws IllegalArgumentException for differing worlds
      */
@@ -272,9 +272,9 @@ public class Location implements Cloneable {
      * orientation independent.
      *
      * @see Vector
-     * @param x
-     * @param y
-     * @param z
+     * @param x X coordinate
+     * @param y Y coordinate
+     * @param z Z coordinate
      * @return the same location
      */
     public Location subtract(double x, double y, double z) {
@@ -318,7 +318,7 @@ public class Location implements Cloneable {
      * which will be caused if the distance is too long.
      *
      * @see Vector
-     * @param o
+     * @param o The other location
      * @return the distance
      * @throws IllegalArgumentException for differing worlds
      */
@@ -334,7 +334,7 @@ public class Location implements Cloneable {
      * Get the squared distance between this location and another.
      *
      * @see Vector
-     * @param o
+     * @param o The other location
      * @return the distance
      * @throws IllegalArgumentException for differing worlds
      */
@@ -350,7 +350,7 @@ public class Location implements Cloneable {
      * Performs scalar multiplication, multiplying all components with a scalar.
      * Not world-aware.
      *
-     * @param m
+     * @param m The factor
      * @see Vector
      * @return the same location
      */

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -10,6 +10,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Logger;
+
+import org.bukkit.command.CommandException;
 import org.bukkit.command.PluginCommand;
 
 import org.bukkit.command.CommandSender;

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -335,11 +335,12 @@ public interface Server {
     /**
      * Dispatches a command on the server, and executes it if found.
      *
-     * @param cmdLine command + arguments. Example: "test abc 123"
-     * @return targetFound returns false if no target is found.
+     * @param sender The apparent sender of the command
+     * @param commandLine command + arguments. Example: "test abc 123"
+     * @return returns false if no target is found.
      * @throws CommandException Thrown when the executor for the given command fails with an unhandled exception
      */
-    public boolean dispatchCommand(CommandSender sender, String commandLine);
+    public boolean dispatchCommand(CommandSender sender, String commandLine) throws CommandException;
 
     /**
      * Populates a given {@link ServerConfig} with values attributes to this server

--- a/src/main/java/org/bukkit/TravelAgent.java
+++ b/src/main/java/org/bukkit/TravelAgent.java
@@ -6,7 +6,7 @@ public interface TravelAgent {
      * Set the Block radius to search in for available portals.
      *
      * @param radius The radius in which to search for a portal from the location.
-     * @return
+     * @return This travel agent.
      */
     public TravelAgent setSearchRadius(int radius);
 
@@ -21,7 +21,7 @@ public interface TravelAgent {
      * Sets the maximum radius from the given location to create a portal.
      *
      * @param radius The radius in which to create a portal from the location.
-     * @return
+     * @return This travel agent.
      */
     public TravelAgent setCreationRadius(int radius);
 
@@ -57,13 +57,15 @@ public interface TravelAgent {
     /**
      * Attempt to find a portal near the given location.
      *
+     * @param location The desired location of the portal.
      * @return Returns the location of the nearest portal to the location.
      */
     public Location findPortal(Location location);
 
     /**
      * Attempt to create a portal near the given location.
-     *
+     * 
+     * @param location The desired location of the portal.
      * @return True if a nether portal was successfully created.
      */
     public boolean createPortal(Location location);

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -315,7 +315,7 @@ public interface World {
      * Strikes lightning at the given {@link Location}
      *
      * @param loc The location to strike lightning
-     * @return
+     * @return The lightning entity.
      */
     public LightningStrike strikeLightning(Location loc);
 
@@ -323,7 +323,7 @@ public interface World {
      * Strikes lightning at the given {@link Location} without doing damage
      *
      * @param loc The location to strike lightning
-     * @return
+     * @return The lightning entity.
      */
     public LightningStrike strikeLightningEffect(Location loc);
 
@@ -384,9 +384,9 @@ public interface World {
     /**
      * Sets the spawn location of the world
      *
-     * @param x
-     * @param y
-     * @param z
+     * @param x X coordinate
+     * @param y Y coordinate
+     * @param z Z coordinate
      * @return True if it was successfully set.
      */
     public boolean setSpawnLocation(int x, int y, int z);
@@ -494,9 +494,9 @@ public interface World {
     /**
      * Creates explosion at given coordinates with given power
      *
-     * @param x
-     * @param y
-     * @param z
+     * @param x X coordinate
+     * @param y Y coordinate
+     * @param z Z coordinate
      * @param power The power of explosion, where 4F is TNT
      * @return false if explosion was canceled, otherwise true
      */
@@ -506,9 +506,9 @@ public interface World {
      * Creates explosion at given coordinates with given power and optionally setting
      * blocks on fire.
      *
-     * @param x
-     * @param y
-     * @param z
+     * @param x X coordinate
+     * @param y Y coordinate
+     * @param z Z coordinate
      * @param power The power of explosion, where 4F is TNT
      * @param setFire Whether or not to set blocks on fire
      * @return false if explosion was canceled, otherwise true
@@ -518,7 +518,7 @@ public interface World {
     /**
      * Creates explosion at given coordinates with given power
      *
-     * @param loc
+     * @param loc Location to blow up
      * @param power The power of explosion, where 4F is TNT
      * @return false if explosion was canceled, otherwise true
      */
@@ -528,7 +528,7 @@ public interface World {
      * Creates explosion at given coordinates with given power and optionally setting
      * blocks on fire.
      *
-     * @param loc
+     * @param loc Location to blow up
      * @param power The power of explosion, where 4F is TNT
      * @param setFire Whether or not to set blocks on fire
      * @return false if explosion was canceled, otherwise true
@@ -551,7 +551,7 @@ public interface World {
 
     /**
      * Gets the current PVP setting for this world.
-     * @return
+     * @return True if PVP is enabled
      */
     public boolean getPVP();
 
@@ -585,8 +585,9 @@ public interface World {
      *
      * @param location the {@link Location} to spawn the entity at
      * @param clazz the class of the {@link Entity} to spawn
+     * @param <T> the class of the {@link Entity} to spawn
      * @return an instance of the spawned {@link Entity}
-     * @throws an {@link IllegalArgumentException} if either parameter is null or the {@link Entity} requested cannot be spawned
+     * @throws IllegalArgumentException if either parameter is null or the {@link Entity} requested cannot be spawned
      */
     public <T extends Entity> T spawn(Location location, Class<T> clazz) throws IllegalArgumentException;
 
@@ -616,6 +617,7 @@ public interface World {
      * @param z - chunk z coordinate
      * @param includeBiome - if true, snapshot includes per-coordinate biome type
      * @param includeBiomeTempRain - if true, snapshot includes per-coordinate raw biome temperature and rainfall
+     * @return The empty snapshot.
      */
     public ChunkSnapshot getEmptyChunkSnapshot(int x, int z, boolean includeBiome, boolean includeBiomeTempRain);
 

--- a/src/main/java/org/bukkit/block/Block.java
+++ b/src/main/java/org/bukkit/block/Block.java
@@ -47,7 +47,7 @@ public interface Block {
      *
      * @param face Face of this block to return
      * @return Block at the given face
-     * @see Block.getRelative(BlockFace face, int distance);
+     * @see #getRelative(BlockFace, int)
      */
     Block getRelative(BlockFace face);
 
@@ -199,28 +199,30 @@ public interface Block {
     /**
      * Returns true if the block is being powered by Redstone.
      *
-     * @return
+     * @return True if the block is powered.
      */
     boolean isBlockPowered();
 
     /**
      * Returns true if the block is being indirectly powered by Redstone.
      *
-     * @return
+     * @return True if the block is indirectly powered.
      */
     boolean isBlockIndirectlyPowered();
 
     /**
      * Returns true if the block face is being powered by Redstone.
      *
-     * @return
+     * @param face The block face
+     * @return True if the block face is powered.
      */
     boolean isBlockFacePowered(BlockFace face);
 
     /**
      * Returns true if the block face is being indirectly powered by Redstone.
      *
-     * @return
+     * @param face The block face
+     * @return True if the block face is indirectly powered.
      */
     boolean isBlockFaceIndirectlyPowered(BlockFace face);
 
@@ -228,14 +230,14 @@ public interface Block {
      * Returns the redstone power being provided to this block face
      *
      * @param face the face of the block to query or BlockFace.SELF for the block itself
-     * @return
+     * @return The power level.
      */
     int getBlockPower(BlockFace face);
 
     /**
      * Returns the redstone power being provided to this block
      *
-     * @return
+     * @return The power level.
      */
     int getBlockPower();
 

--- a/src/main/java/org/bukkit/block/BlockState.java
+++ b/src/main/java/org/bukkit/block/BlockState.java
@@ -103,6 +103,7 @@ public interface BlockState {
      * Sets the type-id of this block
      *
      * @param type Type-Id to change this block to
+     * @return Whether it worked?
      */
     boolean setTypeId(int type);
 
@@ -116,7 +117,7 @@ public interface BlockState {
      * eventuality.
      *
      * @return true if the update was successful, otherwise false
-     * @see BlockState.update(boolean force)
+     * @see #update(boolean)
      */
     boolean update();
 

--- a/src/main/java/org/bukkit/block/ContainerBlock.java
+++ b/src/main/java/org/bukkit/block/ContainerBlock.java
@@ -12,7 +12,7 @@ public interface ContainerBlock {
     /**
      * Get the block's inventory.
      *
-     * @return
+     * @return The inventory.
      */
     public Inventory getInventory();
 }

--- a/src/main/java/org/bukkit/block/CreatureSpawner.java
+++ b/src/main/java/org/bukkit/block/CreatureSpawner.java
@@ -13,42 +13,42 @@ public interface CreatureSpawner extends BlockState {
     /**
      * Get the spawner's creature type.
      *
-     * @return
+     * @return The creature type.
      */
     public CreatureType getCreatureType();
 
     /**
      * Set the spawner creature type.
      *
-     * @param mobType
+     * @param creatureType The creature type.
      */
     public void setCreatureType(CreatureType creatureType);
 
     /**
      * Get the spawner's creature type.
      *
-     * @return
+     * @return The creature type's name.
      */
     public String getCreatureTypeId();
 
     /**
      * Set the spawner mob type.
      *
-     * @param creatureType
+     * @param creatureType The creature type's name.
      */
     public void setCreatureTypeId(String creatureType);
 
     /**
      * Get the spawner's delay.
      *
-     * @return
+     * @return The delay.
      */
     public int getDelay();
 
     /**
      * Set the spawner's delay.
      *
-     * @param delay
+     * @param delay The delay.
      */
     public void setDelay(int delay);
 }

--- a/src/main/java/org/bukkit/block/Furnace.java
+++ b/src/main/java/org/bukkit/block/Furnace.java
@@ -10,28 +10,28 @@ public interface Furnace extends BlockState, ContainerBlock {
     /**
      * Get burn time.
      *
-     * @return
+     * @return Burn time
      */
     public short getBurnTime();
 
     /**
      * Set burn time.
      *
-     * @param burnTime
+     * @param burnTime Burn time
      */
     public void setBurnTime(short burnTime);
 
     /**
      * Get cook time.
      *
-     * @return
+     * @return Cook time
      */
     public short getCookTime();
 
     /**
      * Set cook time.
      *
-     * @param cookTime
+     * @param cookTime Cook time
      */
     public void setCookTime(short cookTime);
 }

--- a/src/main/java/org/bukkit/block/NoteBlock.java
+++ b/src/main/java/org/bukkit/block/NoteBlock.java
@@ -11,28 +11,28 @@ public interface NoteBlock extends BlockState {
     /**
      * Gets the note.
      *
-     * @return
+     * @return The note.
      */
     public Note getNote();
 
     /**
      * Gets the note.
      *
-     * @return
+     * @return The note ID.
      */
     public byte getRawNote();
 
     /**
      * Set the note.
      *
-     * @param note
+     * @param note The note.
      */
     public void setNote(Note note);
 
     /**
      * Set the note.
      *
-     * @param note
+     * @param note The note ID.
      */
     public void setRawNote(byte note);
 
@@ -47,15 +47,20 @@ public interface NoteBlock extends BlockState {
 
     /**
      * Plays an arbitrary note with an arbitrary instrument
-     *
+     * 
+     * @param instrument Instrument ID
+     * @param note Note ID
      * @return true if successful, otherwise false
      */
     public boolean play(byte instrument, byte note);
 
     /**
      * Plays an arbitrary note with an arbitrary instrument
-     *
+     * 
+     * @param instrument The instrument
+     * @param note The note
      * @return true if successful, otherwise false
+     * @see Instrument Note
      */
     public boolean play(Instrument instrument, Note note);
 }

--- a/src/main/java/org/bukkit/block/Sign.java
+++ b/src/main/java/org/bukkit/block/Sign.java
@@ -31,7 +31,7 @@ public interface Sign extends BlockState {
      *
      * @param index Line number to set the text at, starting from 0
      * @param line New text to set at the specified index
-     * @throws IndexOutOfBoundsException
+     * @throws IndexOutOfBoundsException If the index is out of the range 0..3
      */
     public void setLine(int index, String line) throws IndexOutOfBoundsException;
 }

--- a/src/main/java/org/bukkit/command/Command.java
+++ b/src/main/java/org/bukkit/command/Command.java
@@ -104,6 +104,7 @@ public abstract class Command {
      * If the command is currently registered the label change will only take effect after
      * its been reregistered e.g. after a /reload
      *
+     * @param name The command's name
      * @return returns true if the name change happened instantly or false if it was scheduled for reregistration
      */
     public boolean setLabel(String name) {

--- a/src/main/java/org/bukkit/command/CommandMap.java
+++ b/src/main/java/org/bukkit/command/CommandMap.java
@@ -43,8 +43,9 @@ public interface CommandMap {
     /**
      * Looks for the requested command and executes it if found.
      *
+     * @param sender The command's sender
      * @param cmdLine command + arguments. Example: "/test abc 123"
-     * @return targetFound returns false if no target is found, true otherwise.
+     * @return returns false if no target is found, true otherwise.
      * @throws CommandException Thrown when the executor for the given command fails with an unhandled exception
      */
     public boolean dispatch(CommandSender sender, String cmdLine) throws CommandException;

--- a/src/main/java/org/bukkit/command/PluginCommand.java
+++ b/src/main/java/org/bukkit/command/PluginCommand.java
@@ -24,6 +24,7 @@ public final class PluginCommand extends Command {
      * @param args All arguments passed to the command, split via ' '
      * @return true if the command was successful, otherwise false
      */
+    @Override
     public boolean execute(CommandSender sender, String commandLabel, String[] args) {
         boolean success = false;
 

--- a/src/main/java/org/bukkit/entity/Boat.java
+++ b/src/main/java/org/bukkit/entity/Boat.java
@@ -10,14 +10,14 @@ public interface Boat extends Vehicle {
     /**
      * Gets the maximum speed of a boat. The speed is unrelated to the velocity.
      *
-     * @param speed
+     * @return The max speed.
      */
     public double getMaxSpeed();
 
     /**
      * Sets the maximum speed of a boat. Must be nonnegative. Default is 0.4D.
      *
-     * @param speed
+     * @param speed The max speed.
      */
     public void setMaxSpeed(double speed);
 }

--- a/src/main/java/org/bukkit/entity/Entity.java
+++ b/src/main/java/org/bukkit/entity/Entity.java
@@ -92,7 +92,7 @@ public interface Entity {
     /**
      * Sets the entity's current fire ticks (ticks before the entity stops being on fire).
      *
-     * @param ticks
+     * @param ticks Current ticks remaining
      */
     public void setFireTicks(int ticks);
 
@@ -103,6 +103,7 @@ public interface Entity {
 
     /**
      * Returns true if this entity has been marked for removal.
+     * @return True if it is dead.
      */
     public boolean isDead();
 
@@ -124,34 +125,34 @@ public interface Entity {
     /**
      * Set the passenger of a vehicle.
      *
-     * @param passenger
+     * @param passenger The new passenger.
      * @return false if it could not be done for whatever reason
      */
     public abstract boolean setPassenger(Entity passenger);
 
     /**
-     * Returns true if the vehicle has no passengers.
+     * Check if a vehicle has passengers.
      *
-     * @return
+     * @return True if the vehicle has no passengers.
      */
     public abstract boolean isEmpty();
 
     /**
-     * Eject any passenger. True if there was a passenger.
+     * Eject any passenger.
      *
-     * @return
+     * @return True if there was a passenger.
      */
     public abstract boolean eject();
 
     /**
      * Returns the distance this entity has fallen
-     * @return
+     * @return The distance.
      */
     public float getFallDistance();
 
     /**
      * Sets the fall distance for this entity
-     * @param distance
+     * @param distance The new distance.
      */
     public void setFallDistance(float distance);
 

--- a/src/main/java/org/bukkit/entity/Explosive.java
+++ b/src/main/java/org/bukkit/entity/Explosive.java
@@ -6,7 +6,7 @@ package org.bukkit.entity;
 public interface Explosive extends Entity {
     /**
      * Set the radius affected by this explosive's explosion
-     * @param yield
+     * @param yield The explosive yield
      */
     public void setYield(float yield);
 
@@ -18,7 +18,7 @@ public interface Explosive extends Entity {
 
     /**
      * Set whether or not this explosive's explosion causes fire
-     * @param isIncendiary
+     * @param isIncendiary Whether it should cause fire
      */
     public void setIsIncendiary(boolean isIncendiary);
 

--- a/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -36,7 +36,6 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, Permissible {
      * user was holding.
      *
      * @param item The ItemStack which will end up in the hand
-     * @return
      */
     public void setItemInHand(ItemStack item);
 

--- a/src/main/java/org/bukkit/entity/Item.java
+++ b/src/main/java/org/bukkit/entity/Item.java
@@ -13,14 +13,14 @@ public interface Item extends Entity {
     /**
      * Gets the item stack associated with this item drop.
      *
-     * @return
+     * @return An item stack.
      */
     public ItemStack getItemStack();
 
     /**
      * Sets the item stack associated with this item drop.
      *
-     * @param stack
+     * @param stack An item stack.
      */
     public void setItemStack(ItemStack stack);
 }

--- a/src/main/java/org/bukkit/entity/LivingEntity.java
+++ b/src/main/java/org/bukkit/entity/LivingEntity.java
@@ -35,7 +35,7 @@ public interface LivingEntity extends Entity {
     /**
      * Gets the height of the entity's head above its Location
      *
-     * @param boolean If set to true, the effects of sneaking will be ignored
+     * @param ignoreSneaking If set to true, the effects of sneaking will be ignored
      * @return Height of the entity's eyes above its Location
      */
     public double getEyeHeight(boolean ignoreSneaking);
@@ -51,8 +51,8 @@ public interface LivingEntity extends Entity {
      * Gets all blocks along the player's line of sight
      * List iterates from player's position to target inclusive
      *
-     * @param HashSet<Byte> HashSet containing all transparent block IDs. If set to null only air is considered transparent.
-     * @param int This is the maximum distance to scan. This may be further limited by the server, but never to less than 100 blocks.
+     * @param transparent HashSet containing all transparent block IDs. If set to null only air is considered transparent.
+     * @param maxDistance This is the maximum distance to scan. This may be further limited by the server, but never to less than 100 blocks.
      * @return List containing all blocks along the player's line of sight
      */
     public List<Block> getLineOfSight(HashSet<Byte> transparent, int maxDistance);
@@ -60,8 +60,8 @@ public interface LivingEntity extends Entity {
     /**
      * Gets the block that the player has targeted
      *
-     * @param HashSet<Byte> HashSet containing all transparent block IDs. If set to null only air is considered transparent.
-     * @param int This is the maximum distance to scan. This may be further limited by the server, but never to less than 100 blocks.
+     * @param transparent HashSet containing all transparent block IDs. If set to null only air is considered transparent.
+     * @param maxDistance This is the maximum distance to scan. This may be further limited by the server, but never to less than 100 blocks.
      * @return Block that the player has targeted
      */
     public Block getTargetBlock(HashSet<Byte> transparent, int maxDistance);
@@ -70,33 +70,35 @@ public interface LivingEntity extends Entity {
      * Gets the last two blocks along the player's line of sight.
      * The target block will be the last block in the list.
      *
-     * @param HashSet<Byte> HashSet containing all transparent block IDs. If set to null only air is considered transparent.
-     * @param int This is the maximum distance to scan. This may be further limited by the server, but never to less than 100 blocks
+     * @param transparent HashSet containing all transparent block IDs. If set to null only air is considered transparent.
+     * @param maxDistance This is the maximum distance to scan. This may be further limited by the server, but never to less than 100 blocks
      * @return List containing the last 2 blocks along the player's line of sight
      */
     public List<Block> getLastTwoTargetBlocks(HashSet<Byte> transparent, int maxDistance);
 
     /**
      * Throws an egg from the entity.
+     * @return The egg thrown.
      */
     public Egg throwEgg();
 
     /**
      * Throws a snowball from the entity.
+     * @return The snowball thrown.
      */
     public Snowball throwSnowball();
 
     /**
      * Shoots an arrow from the entity.
      *
-     * @return
+     * @return The arrow shot.
      */
     public Arrow shootArrow();
 
     /**
      * Returns whether this entity is inside a vehicle.
      *
-     * @return
+     * @return True if the entity is in a vehicle.
      */
     public boolean isInsideVehicle();
 
@@ -105,7 +107,7 @@ public interface LivingEntity extends Entity {
      * (and is removed from it), true will be returned, otherwise false will
      * be returned.
      *
-     * @return
+     * @return True if the entity was in a vehicle.
      */
     public boolean leaveVehicle();
 
@@ -113,7 +115,7 @@ public interface LivingEntity extends Entity {
      * Get the vehicle that this player is inside. If there is no vehicle,
      * null will be returned.
      *
-     * @return
+     * @return The current vehicle.
      */
     public Vehicle getVehicle();
 

--- a/src/main/java/org/bukkit/entity/Minecart.java
+++ b/src/main/java/org/bukkit/entity/Minecart.java
@@ -19,34 +19,35 @@ public interface Minecart extends Vehicle {
     /**
      * Gets a minecart's damage.
      *
-     * @param damage
+     * @return The damage
      */
     public int getDamage();
 
     /**
      * Gets the maximum speed of a minecart. The speed is unrelated to the velocity.
-     *
-     * @param speed
+     * 
+     * @return The max speed
      */
     public double getMaxSpeed();
 
     /**
      * Sets the maximum speed of a minecart. Must be nonnegative. Default is 0.4D.
      *
-     * @param speed
+     * @param speed The max speed
      */
     public void setMaxSpeed(double speed);
 
     /**
      * Returns whether this minecart will slow down faster without a passenger occupying it
      *
+     * @return Whether it decelerates faster
      */
     public boolean isSlowWhenEmpty();
 
     /**
      * Sets whether this minecart will slow down faster without a passenger occupying it
      *
-     * @param slow
+     * @param slow Whether it will decelerate faster
      */
     public void setSlowWhenEmpty(boolean slow);
 
@@ -54,7 +55,7 @@ public interface Minecart extends Vehicle {
      * Gets the flying velocity modifier. Used for minecarts that are in mid-air.
      * A flying minecart's velocity is multiplied by this factor each tick.
      *
-     * @param flying velocity modifier
+     * @return The vector factor
      */
     public Vector getFlyingVelocityMod();
 
@@ -62,7 +63,7 @@ public interface Minecart extends Vehicle {
      * Sets the flying velocity modifier. Used for minecarts that are in mid-air.
      * A flying minecart's velocity is multiplied by this factor each tick.
      *
-     * @param flying velocity modifier
+     * @param flying velocity modifier vector
      */
     public void setFlyingVelocityMod(Vector flying);
 
@@ -70,7 +71,7 @@ public interface Minecart extends Vehicle {
      * Gets the derailed velocity modifier. Used for minecarts that are on the ground, but not on rails.
      *
      * A derailed minecart's velocity is multiplied by this factor each tick.
-     * @param visible speed
+     * @return derailed visible speed
      */
     public Vector getDerailedVelocityMod();
 
@@ -78,7 +79,7 @@ public interface Minecart extends Vehicle {
      * Sets the derailed velocity modifier. Used for minecarts that are on the ground, but not on rails.
      * A derailed minecart's velocity is multiplied by this factor each tick.
      *
-     * @param visible speed
+     * @param derailed visible speed
      */
     public void setDerailedVelocityMod(Vector derailed);
 }

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -317,7 +317,7 @@ public interface Player extends HumanEntity, CommandSender, OfflinePlayer {
     /**
      * Sets the players current experience level
      *
-     * @param exp New experience level
+     * @param level New experience level
      */
     public void setLevel(int level);
 

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -33,14 +33,14 @@ public interface Player extends HumanEntity, CommandSender, OfflinePlayer {
      * Note that this name will not be displayed in game, only in chat and places
      * defined by plugins
      *
-     * @param name
+     * @param name The new display name.
      */
     public void setDisplayName(String name);
 
     /**
      * Set the target of the player's compass.
      *
-     * @param loc
+     * @param loc Location to point to
      */
     public void setCompassTarget(Location loc);
 
@@ -116,14 +116,14 @@ public interface Player extends HumanEntity, CommandSender, OfflinePlayer {
      * next day. If everyone has this flag set but no one is actually in bed,
      * then nothing will happen.
      *
-     * @param isSleeping
+     * @param isSleeping Whether to ignore.
      */
     public void setSleepingIgnored(boolean isSleeping);
 
     /**
      * Returns whether the player is sleeping ignored.
      *
-     * @return
+     * @return Whether player is ignoring sleep.
      */
     public boolean isSleepingIgnored();
 
@@ -132,9 +132,9 @@ public interface Player extends HumanEntity, CommandSender, OfflinePlayer {
      * at the particular location (as far as the client is concerned). This
      * will not work without a note block. This will not work with cake.
      *
-     * @param loc
-     * @param instrument
-     * @param note
+     * @param loc The location of a note block.
+     * @param instrument The instrument ID.
+     * @param note The note ID.
      */
     public void playNote(Location loc, byte instrument, byte note);
 
@@ -143,16 +143,16 @@ public interface Player extends HumanEntity, CommandSender, OfflinePlayer {
      * at the particular location (as far as the client is concerned). This
      * will not work without a note block. This will not work with cake.
      *
-     * @param loc
-     * @param instrument
-     * @param note
+     * @param loc The location of a note block
+     * @param instrument The instrument
+     * @param note The note
      */
     public void playNote(Location loc, Instrument instrument, Note note);
 
     /**
      * Plays an effect to just this player.
      *
-     * @param loc the player to play the effect for
+     * @param loc the location to play the effect at
      * @param effect the {@link Effect}
      * @param data a data bit needed for the RECORD_PLAY, SMOKE, and STEP_SOUND sounds
      */
@@ -162,9 +162,9 @@ public interface Player extends HumanEntity, CommandSender, OfflinePlayer {
      * Send a block change. This fakes a block change packet for a user at
      * a certain location. This will not actually change the world in any way.
      *
-     * @param loc
-     * @param material
-     * @param data
+     * @param loc The location of the changed block
+     * @param material The new block
+     * @param data The block data
      */
     public void sendBlockChange(Location loc, Material material, byte data);
 
@@ -191,9 +191,9 @@ public interface Player extends HumanEntity, CommandSender, OfflinePlayer {
      * Send a block change. This fakes a block change packet for a user at
      * a certain location. This will not actually change the world in any way.
      *
-     * @param loc
-     * @param material
-     * @param data
+     * @param loc The location of the changed block
+     * @param material The new block ID
+     * @param data The block data
      */
     public void sendBlockChange(Location loc, int material, byte data);
     
@@ -201,7 +201,7 @@ public interface Player extends HumanEntity, CommandSender, OfflinePlayer {
      * Render a map and send it to the player in its entirety. This may be used
      * when streaming the map in the normal manner is not desirbale.
      * 
-     * @pram map The map to be sent
+     * @param map The map to be sent
      */
     public void sendMap(MapView map);
 
@@ -267,7 +267,7 @@ public interface Player extends HumanEntity, CommandSender, OfflinePlayer {
     /**
      * Returns the player's current timestamp.
      *
-     * @return
+     * @return The player's time
      */
     public long getPlayerTime();
 
@@ -275,7 +275,7 @@ public interface Player extends HumanEntity, CommandSender, OfflinePlayer {
      * Returns the player's current time offset relative to server time, or the current player's fixed time
      * if the player's time is absolute.
      *
-     * @return
+     * @return The player's time
      */
     public long getPlayerTimeOffset();
 

--- a/src/main/java/org/bukkit/entity/Projectile.java
+++ b/src/main/java/org/bukkit/entity/Projectile.java
@@ -1,5 +1,7 @@
 package org.bukkit.entity;
 
+import org.bukkit.block.Dispenser;
+
 /**
  * Represents a shootable entity
  */

--- a/src/main/java/org/bukkit/entity/TNTPrimed.java
+++ b/src/main/java/org/bukkit/entity/TNTPrimed.java
@@ -6,7 +6,7 @@ package org.bukkit.entity;
 public interface TNTPrimed extends Explosive {
     /**
      * Set the number of ticks until the TNT blows up after being primed.
-     * @param fuseTicks
+     * @param fuseTicks The fuse ticks
      */
     public void setFuseTicks(int fuseTicks);
 

--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -90,8 +90,8 @@ public abstract class Event implements Serializable {
 
         /**
          * Represents Player-based events
-         *
-         * @see Category.LIVING_ENTITY
+         * 
+         * @see #LIVING_ENTITY
          */
         PLAYER,
         /**
@@ -134,8 +134,6 @@ public abstract class Event implements Serializable {
 
     /**
      * Provides a lookup for all core events
-     *
-     * @see org.bukkit.event.
      */
     public enum Type {
 
@@ -408,13 +406,13 @@ public abstract class Event implements Serializable {
         /**
          * Called when a piston extends
          *
-         * @see org.bukkit.event.block.PistonExtendEvent
+         * @see org.bukkit.event.block.BlockPistonExtendEvent
          */
         BLOCK_PISTON_EXTEND (Category.BLOCK),
         /**
          * Called when a piston retracts
          *
-         * @see org.bukkit.event.block.PistonRetractEvent
+         * @see org.bukkit.event.block.BlockPistonRetractEvent
          */
         BLOCK_PISTON_RETRACT (Category.BLOCK),
 
@@ -516,7 +514,7 @@ public abstract class Event implements Serializable {
         /**
          * Called when a newly created chunk has been populated.
          *
-         * If your intent is to populate the chunk using this event, please see {@link BlockPopulator}
+         * If your intent is to populate the chunk using this event, please see {@link org.bukkit.generator.BlockPopulator}
          *
          * @see org.bukkit.event.world.ChunkPopulateEvent
          */

--- a/src/main/java/org/bukkit/event/EventException.java
+++ b/src/main/java/org/bukkit/event/EventException.java
@@ -22,6 +22,8 @@ public class EventException extends Exception {
 
     /**
      * Constructs a new EventException with the given message
+     * @param cause The exception that caused this
+     * @param message The message
      */
     public EventException(Throwable cause, String message) {
         super(message);
@@ -30,6 +32,7 @@ public class EventException extends Exception {
 
     /**
      * Constructs a new EventException with the given message
+     * @param message The message
      */
     public EventException(String message) {
         super(message);

--- a/src/main/java/org/bukkit/event/block/BlockFormEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockFormEvent.java
@@ -11,7 +11,7 @@ import org.bukkit.event.Cancellable;
  * Examples:
  *<ul>
  *     <li>Snow forming due to a snow storm.</li>
- *     <li>Ice forming in a snowy Biome like Tiga or Tundra.</li>
+ *     <li>Ice forming in a snowy Biome like Taiga or Tundra.</li>
  * </ul>
  *<p />
  * If a Block Form event is cancelled, the block will not be formed.

--- a/src/main/java/org/bukkit/event/block/BlockListener.java
+++ b/src/main/java/org/bukkit/event/block/BlockListener.java
@@ -1,7 +1,6 @@
 package org.bukkit.event.block;
 
 import org.bukkit.event.Listener;
-import org.bukkit.plugin.AuthorNagException;
 
 /**
  * Handles all events thrown in relation to Blocks

--- a/src/main/java/org/bukkit/event/entity/CreeperPowerEvent.java
+++ b/src/main/java/org/bukkit/event/entity/CreeperPowerEvent.java
@@ -11,20 +11,17 @@ import org.bukkit.event.Cancellable;
 public class CreeperPowerEvent extends EntityEvent implements Cancellable {
 
     private boolean canceled;
-    private Entity creeper;
     private PowerCause cause;
     private Entity bolt;
 
     public CreeperPowerEvent(Entity creeper, Entity bolt, PowerCause cause) {
         super(Type.CREEPER_POWER, creeper);
-        this.creeper = creeper;
         this.bolt = bolt;
         this.cause = cause;
     }
 
     public CreeperPowerEvent(Entity creeper, PowerCause cause) {
         super(Type.CREEPER_POWER, creeper);
-        this.creeper = creeper;
         this.cause = cause;
         this.bolt = null;
     }

--- a/src/main/java/org/bukkit/event/entity/EntityDamageByBlockEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDamageByBlockEvent.java
@@ -2,12 +2,11 @@ package org.bukkit.event.entity;
 
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
-import org.bukkit.event.Cancellable;
 
 /**
  * Called when an entity is damaged by a block
  */
-public class EntityDamageByBlockEvent extends EntityDamageEvent implements Cancellable {
+public class EntityDamageByBlockEvent extends EntityDamageEvent {
 
     private Block damager;
 

--- a/src/main/java/org/bukkit/event/entity/EntityDamageByEntityEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDamageByEntityEvent.java
@@ -1,12 +1,11 @@
 package org.bukkit.event.entity;
 
 import org.bukkit.entity.Entity;
-import org.bukkit.event.Cancellable;
 
 /**
  * Called when an entity is damaged by an entity
  */
-public class EntityDamageByEntityEvent extends EntityDamageEvent implements Cancellable {
+public class EntityDamageByEntityEvent extends EntityDamageEvent {
 
     private Entity damager;
 

--- a/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java
@@ -33,6 +33,7 @@ public class EntityExplodeEvent extends EntityEvent implements Cancellable {
     /**
      * Returns the list of blocks that would have been removed or were
      * removed from the explosion event.
+     * @return All blown-up blocks
      */
     public List<Block> blockList() {
         return blocks;
@@ -42,6 +43,7 @@ public class EntityExplodeEvent extends EntityEvent implements Cancellable {
      * Returns the location where the explosion happened.
      * It is not possible to get this value from the Entity as
      * the Entity no longer exists in the world.
+     * @return The location of the explosion
      */
     public Location getLocation() {
         return location;
@@ -50,7 +52,7 @@ public class EntityExplodeEvent extends EntityEvent implements Cancellable {
     /**
      * Returns the percentage of blocks to drop from this explosion
      *
-     * @return
+     * @return The yield.
      */
     public float getYield() {
         return yield;
@@ -58,6 +60,7 @@ public class EntityExplodeEvent extends EntityEvent implements Cancellable {
 
     /**
      * Sets the percentage of blocks to drop from this explosion
+     * @param yield The new yield percentage
      */
     public void setYield(float yield) {
         this.yield = yield;

--- a/src/main/java/org/bukkit/event/entity/EntityPortalEnterEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityPortalEnterEvent.java
@@ -3,7 +3,6 @@ package org.bukkit.event.entity;
 
 import org.bukkit.entity.Entity;
 import org.bukkit.Location;
-import org.bukkit.event.Cancellable;
 
 /**
  * Stores data for entities standing inside a portal block

--- a/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java
@@ -4,7 +4,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.event.Cancellable;
 
 /**
- * Called when a creature targets another entity
+ * Called when a creature targets or untargets another entity
  */
 public class EntityTargetEvent extends EntityEvent implements Cancellable {
     private boolean cancel;
@@ -34,8 +34,8 @@ public class EntityTargetEvent extends EntityEvent implements Cancellable {
     }
 
     /**
-     * Get the entity that this is target.
-     * This is possible to be null in the case that the event is called when
+     * Get the entity that this is targeting.
+     * This will be null in the case that the event is called when
      * the mob forgets its target.
      */
     public Entity getTarget() {

--- a/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java
@@ -28,6 +28,7 @@ public class EntityTargetEvent extends EntityEvent implements Cancellable {
 
     /**
      * Returns the reason for the targeting
+     * @return The reason
      */
     public TargetReason getReason() {
         return reason;
@@ -37,6 +38,7 @@ public class EntityTargetEvent extends EntityEvent implements Cancellable {
      * Get the entity that this is targeting.
      * This will be null in the case that the event is called when
      * the mob forgets its target.
+     * @return The entity
      */
     public Entity getTarget() {
         return target;

--- a/src/main/java/org/bukkit/event/entity/PigZapEvent.java
+++ b/src/main/java/org/bukkit/event/entity/PigZapEvent.java
@@ -9,13 +9,11 @@ import org.bukkit.event.Cancellable;
 public class PigZapEvent extends EntityEvent implements Cancellable {
 
     private boolean canceled;
-    private Entity pig;
     private Entity pigzombie;
     private Entity bolt;
 
     public PigZapEvent(Entity pig, Entity bolt, Entity pigzombie) {
         super(Type.PIG_ZAP, pig);
-        this.pig = pig;
         this.bolt = bolt;
         this.pigzombie = pigzombie;
     }

--- a/src/main/java/org/bukkit/event/painting/PaintingBreakEvent.java
+++ b/src/main/java/org/bukkit/event/painting/PaintingBreakEvent.java
@@ -1,6 +1,5 @@
 package org.bukkit.event.painting;
 
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.Painting;
 import org.bukkit.event.Cancellable;
 

--- a/src/main/java/org/bukkit/event/painting/PaintingPlaceEvent.java
+++ b/src/main/java/org/bukkit/event/painting/PaintingPlaceEvent.java
@@ -2,7 +2,6 @@ package org.bukkit.event.painting;
 
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.Painting;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;

--- a/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java
@@ -87,7 +87,7 @@ public class PlayerPreLoginEvent extends Event {
     /**
      * Gets the player IP address.
      *
-     * @return
+     * @return The IP address
      */
     public InetAddress getAddress() {
         return ipAddress;

--- a/src/main/java/org/bukkit/event/server/ServerCommandEvent.java
+++ b/src/main/java/org/bukkit/event/server/ServerCommandEvent.java
@@ -35,6 +35,7 @@ public class ServerCommandEvent extends ServerEvent {
 
     /**
      * Get the command sender.
+     * @return The sender
      */
     public CommandSender getSender() {
         return sender;

--- a/src/main/java/org/bukkit/event/vehicle/VehicleDamageEvent.java
+++ b/src/main/java/org/bukkit/event/vehicle/VehicleDamageEvent.java
@@ -39,7 +39,7 @@ public class VehicleDamageEvent extends VehicleEvent implements Cancellable {
     /**
      * Sets the damage done to the vehicle
      *
-     * @param damage
+     * @param damage The damage
      */
     public void setDamage(int damage) {
         this.damage = damage;

--- a/src/main/java/org/bukkit/event/vehicle/VehicleExitEvent.java
+++ b/src/main/java/org/bukkit/event/vehicle/VehicleExitEvent.java
@@ -19,7 +19,7 @@ public class VehicleExitEvent extends VehicleEvent implements Cancellable {
     /**
      * Get the living entity that exited the vehicle.
      *
-     * @return
+     * @return The entity.
      */
     public LivingEntity getExited() {
         return exited;

--- a/src/main/java/org/bukkit/event/vehicle/VehicleListener.java
+++ b/src/main/java/org/bukkit/event/vehicle/VehicleListener.java
@@ -14,63 +14,63 @@ public class VehicleListener implements Listener {
      * Called when a vehicle is created by a player. This hook will be called
      * for all vehicles created.
      *
-     * @param event
+     * @param event The event
      */
     public void onVehicleCreate(VehicleCreateEvent event) {}
 
     /**
      * Called when a vehicle is damaged by the player.
      *
-     * @param event
+     * @param event The event
      */
     public void onVehicleDamage(VehicleDamageEvent event) {}
 
     /**
      * Called when a vehicle collides with a block.
      *
-     * @param event
+     * @param event The event
      */
     public void onVehicleBlockCollision(VehicleBlockCollisionEvent event) {}
 
     /**
      * Called when a vehicle collides with an entity.
      *
-     * @param event
+     * @param event The event
      */
     public void onVehicleEntityCollision(VehicleEntityCollisionEvent event) {}
 
     /**
      * Called when an entity enters a vehicle.
      *
-     * @param event
+     * @param event The event
      */
     public void onVehicleEnter(VehicleEnterEvent event) {}
 
     /**
      * Called when an entity exits a vehicle.
      *
-     * @param event
+     * @param event The event
      */
     public void onVehicleExit(VehicleExitEvent event) {}
 
     /**
      * Called when an vehicle moves.
      *
-     * @param event
+     * @param event The event
      */
     public void onVehicleMove(VehicleMoveEvent event) {}
 
     /**
      * Called when a vehicle is destroyed.
      *
-     * @param event
+     * @param event The event
      */
     public void onVehicleDestroy(VehicleDestroyEvent event) {}
 
     /**
      * Called when a vehicle goes through an update cycle
      *
-     * @param event
+     * @param event The event
      */
     public void onVehicleUpdate(VehicleUpdateEvent event) {}
 }

--- a/src/main/java/org/bukkit/event/vehicle/VehicleMoveEvent.java
+++ b/src/main/java/org/bukkit/event/vehicle/VehicleMoveEvent.java
@@ -22,7 +22,7 @@ public class VehicleMoveEvent extends VehicleEvent {
     /**
      * Get the previous position.
      *
-     * @return
+     * @return Old position.
      */
     public Location getFrom() {
         return from;
@@ -31,7 +31,7 @@ public class VehicleMoveEvent extends VehicleEvent {
     /**
      * Get the next position.
      *
-     * @return
+     * @return New position.
      */
     public Location getTo() {
         return to;

--- a/src/main/java/org/bukkit/event/weather/LightningStrikeEvent.java
+++ b/src/main/java/org/bukkit/event/weather/LightningStrikeEvent.java
@@ -1,7 +1,6 @@
 package org.bukkit.event.weather;
 
 import org.bukkit.World;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.LightningStrike;
 import org.bukkit.event.Cancellable;
 
@@ -12,12 +11,10 @@ public class LightningStrikeEvent extends WeatherEvent implements Cancellable {
 
     private boolean canceled;
     private LightningStrike bolt;
-    private World world;
 
     public LightningStrikeEvent(World world, LightningStrike bolt) {
         super(Type.LIGHTNING_STRIKE, world);
         this.bolt = bolt;
-        this.world = world;
     }
 
     public boolean isCancelled() {

--- a/src/main/java/org/bukkit/event/world/WorldListener.java
+++ b/src/main/java/org/bukkit/event/world/WorldListener.java
@@ -17,7 +17,7 @@ public class WorldListener implements Listener {
     /**
      * Called when a newly created chunk has been populated.
      *
-     * If your intent is to populate the chunk using this event, please see {@link BlockPopulator}
+     * If your intent is to populate the chunk using this event, please see {@link org.bukkit.generator.BlockPopulator}
      *
      * @param event Relevant event details
      */

--- a/src/main/java/org/bukkit/generator/BlockPopulator.java
+++ b/src/main/java/org/bukkit/generator/BlockPopulator.java
@@ -20,7 +20,7 @@ public abstract class BlockPopulator {
      *
      * @param world The world to generate in
      * @param random The random generator to use
-     * @param chunk The chunk to generate for
+     * @param source The chunk to generate for
      */
     public abstract void populate(World world, Random random, Chunk source);
 }

--- a/src/main/java/org/bukkit/inventory/FurnaceRecipe.java
+++ b/src/main/java/org/bukkit/inventory/FurnaceRecipe.java
@@ -60,7 +60,7 @@ public class FurnaceRecipe implements Recipe {
      * @return The input material.
      */
     public MaterialData getInput() {
-        return (MaterialData) ingredient;
+        return ingredient;
     }
 
     /**

--- a/src/main/java/org/bukkit/inventory/Inventory.java
+++ b/src/main/java/org/bukkit/inventory/Inventory.java
@@ -45,7 +45,7 @@ public interface Inventory {
      * It will return a HashMap of what it couldn't fit.
      *
      * @param items The ItemStacks to add
-     * @return
+     * @return The items that didn't fit.
      */
     public HashMap<Integer, ItemStack> addItem(ItemStack... items);
 
@@ -56,7 +56,7 @@ public interface Inventory {
      * give as arguments. It will return a HashMap of what it couldn't remove.
      *
      * @param items The ItemStacks to remove
-     * @return
+     * @return The items that couldn't be removed.
      */
     public HashMap<Integer, ItemStack> removeItem(ItemStack... items);
 
@@ -70,7 +70,7 @@ public interface Inventory {
     /**
      * Set the inventory's contents
      *
-     * @return All the ItemStacks from all slots
+     * @param items A complete replacement for the contents; the length must be equal to {@link #getSize()}.
      */
     public void setContents(ItemStack[] items);
 
@@ -112,6 +112,7 @@ public interface Inventory {
      * Check if the inventory contains any ItemStacks with the given material and at least the minimum amount specified
      *
      * @param material The material to check for
+     * @param amount The minimum amount
      * @return If any ItemStacks were found
      */
     public boolean contains(Material material, int amount);
@@ -121,6 +122,7 @@ public interface Inventory {
      * This will only match if both the type and the amount of the stack match
      *
      * @param item The ItemStack to match against
+     * @param amount The minimum amount
      * @return If any matching ItemStacks were found
      */
     public boolean contains(ItemStack item, int amount);
@@ -136,7 +138,7 @@ public interface Inventory {
     /**
      * Find all slots in the inventory containing any ItemStacks with the given material
      *
-     * @param materialId The material to look for
+     * @param material The material to look for
      * @return The Slots found.
      */
     public HashMap<Integer, ? extends ItemStack> all(Material material);
@@ -161,7 +163,7 @@ public interface Inventory {
     /**
      * Find the first slot in the inventory containing an ItemStack with the given material
      *
-     * @param materialId The material to look for
+     * @param material The material to look for
      * @return The Slot found.
      */
     public int first(Material material);

--- a/src/main/java/org/bukkit/inventory/ItemStack.java
+++ b/src/main/java/org/bukkit/inventory/ItemStack.java
@@ -125,7 +125,7 @@ public class ItemStack {
     /**
      * Sets the MaterialData for this stack of items
      *
-     * @param amount New MaterialData for this item
+     * @param data New MaterialData for this item
      */
     public void setData(MaterialData data) {
         Material mat = getType();

--- a/src/main/java/org/bukkit/map/MapCanvas.java
+++ b/src/main/java/org/bukkit/map/MapCanvas.java
@@ -65,9 +65,9 @@ public interface MapCanvas {
      * will move down one line and return to the original column, and the text
      * color can be changed using sequences such as "§12;", replacing 12 with
      * the palette index of the color (see {@link MapPalette}).
-     * @param map The MapInfo to render to.
      * @param x The column to start rendering on.
      * @param y The row to start rendering on.
+     * @param font The font to use.
      * @param text The formatted text to render.
      */
     public void drawText(int x, int y, MapFont font, String text);

--- a/src/main/java/org/bukkit/map/MapRenderer.java
+++ b/src/main/java/org/bukkit/map/MapRenderer.java
@@ -10,7 +10,7 @@ public abstract class MapRenderer {
     private boolean contextual;
     
     /**
-     * Initialize the map renderer base to be non-contextual. See {@link isContextual}.
+     * Initialize the map renderer base to be non-contextual. See {@link #isContextual()}.
      */
     public MapRenderer() {
         this(false);
@@ -18,7 +18,7 @@ public abstract class MapRenderer {
     
     /**
      * Initialize the map renderer base with the given contextual status.
-     * @param contextual Whether the renderer is contextual. See {@link isContextual}.
+     * @param contextual Whether the renderer is contextual. See {@link #isContextual()}.
      */
     public MapRenderer(boolean contextual) {
         this.contextual = contextual;

--- a/src/main/java/org/bukkit/map/MapView.java
+++ b/src/main/java/org/bukkit/map/MapView.java
@@ -26,6 +26,8 @@ public interface MapView {
         
         /**
          * Get the scale given the raw value.
+         * @param value The raw scale
+         * @return The enum scale, or null for an invalid input
          */
         public static Scale valueOf(byte value) {
             switch(value) {
@@ -40,6 +42,7 @@ public interface MapView {
         
         /**
          * Get the raw value of this scale level.
+         * @return The scale value
          */
         public byte getValue() {
             return value;

--- a/src/main/java/org/bukkit/material/Bed.java
+++ b/src/main/java/org/bukkit/material/Bed.java
@@ -51,7 +51,7 @@ public class Bed extends MaterialData implements Directional {
 
     /**
      * Configure this to be either the head or the foot of the bed
-     * @param isHeadOfBed
+     * @param isHeadOfBed True to make it the head.
      */
     public void setHeadOfBed(boolean isHeadOfBed) {
         setData((byte) (isHeadOfBed ? (getData() | 0x8) : (getData() & ~0x8)));

--- a/src/main/java/org/bukkit/material/Directional.java
+++ b/src/main/java/org/bukkit/material/Directional.java
@@ -6,6 +6,7 @@ public interface Directional {
 
     /**
      * Sets the direction that this block is facing in
+     * @param face The facing direction
      */
     public void setFacingDirection(BlockFace face);
 

--- a/src/main/java/org/bukkit/material/Door.java
+++ b/src/main/java/org/bukkit/material/Door.java
@@ -37,7 +37,7 @@ public class Door extends MaterialData implements Directional {
 
     /**
      * Configure this door to be either open or closed;
-     * @param isOpen
+     * @param isOpen True to open the door.
      */
     public void setOpen(boolean isOpen) {
         setData((byte) (isOpen ? (getData() | 0x4) : (getData() & ~0x4)));
@@ -52,7 +52,7 @@ public class Door extends MaterialData implements Directional {
 
     /**
      * Configure this part of the door to be either the top or the bottom half;
-     * @param isTopHalf
+     * @param isTopHalf True to make it the top half.
      */
     public void setTopHalf(boolean isTopHalf) {
         setData((byte) (isTopHalf ? (getData() | 0x8) : (getData() & ~0x8)));

--- a/src/main/java/org/bukkit/material/MaterialData.java
+++ b/src/main/java/org/bukkit/material/MaterialData.java
@@ -75,6 +75,7 @@ public class MaterialData {
     /**
      * Creates a new ItemStack based on this MaterialData
      *
+     * @param amount The stack size of the new stak
      * @return New ItemStack containing a copy of this MaterialData
      */
     public ItemStack toItemStack(int amount) {

--- a/src/main/java/org/bukkit/permissions/Permission.java
+++ b/src/main/java/org/bukkit/permissions/Permission.java
@@ -47,7 +47,7 @@ public class Permission {
     public Permission(String name, String description, PermissionDefault defaultValue, Map<String, Boolean> children) {
         this.name = name;
         this.description = (description == null) ? "" : description;
-        this.defaultValue = (defaultValue == null) ? defaultValue.FALSE : defaultValue;
+        this.defaultValue = (defaultValue == null) ? PermissionDefault.FALSE : defaultValue;
         
         if (children != null) {
             this.children.putAll(children);

--- a/src/main/java/org/bukkit/plugin/AuthorNagException.java
+++ b/src/main/java/org/bukkit/plugin/AuthorNagException.java
@@ -4,10 +4,9 @@ public class AuthorNagException extends RuntimeException {
     private final String message;
 
     /**
-     * Constructs a new UnknownDependencyException based on the given Exception
+     * Constructs a new AuthorNagException based on the given Exception
      *
      * @param message Brief message explaining the cause of the exception
-     * @param throwable Exception that triggered this Exception
      */
     public AuthorNagException(final String message) {
         this.message = message;

--- a/src/main/java/org/bukkit/plugin/Plugin.java
+++ b/src/main/java/org/bukkit/plugin/Plugin.java
@@ -16,7 +16,7 @@ public interface Plugin extends CommandExecutor {
      * Returns the folder that the plugin data's files are located in. The
      * folder may not yet exist.
      *
-     * @return
+     * @return The folder
      */
     public File getDataFolder();
 
@@ -30,7 +30,7 @@ public interface Plugin extends CommandExecutor {
     /**
      * Returns the main configuration file. It should be loaded.
      *
-     * @return
+     * @return The configuration
      */
     public Configuration getConfiguration();
 

--- a/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
+++ b/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
@@ -38,7 +38,8 @@ public final class PluginDescriptionFile {
 
     /**
      * Loads a PluginDescriptionFile from the specified reader
-     * @param reader
+     * @param reader The reader
+     * @throws InvalidDescriptionException If the PluginDescriptionFile is invalid
      */
     @SuppressWarnings("unchecked")
     public PluginDescriptionFile(final Reader reader) throws InvalidDescriptionException {
@@ -49,6 +50,7 @@ public final class PluginDescriptionFile {
      * Creates a new PluginDescriptionFile with the given detailed
      *
      * @param pluginName Name of this plugin
+     * @param pluginVersion Version of this plugin
      * @param mainClass Full location of the main class of this plugin
      */
     public PluginDescriptionFile(final String pluginName, final String pluginVersion, final String mainClass) {
@@ -121,7 +123,7 @@ public final class PluginDescriptionFile {
     /**
      * Gets the description of this plugin
      *
-     * return Description of this plugin
+     * @return Description of this plugin
      */
     public String getDescription() {
         return description;

--- a/src/main/java/org/bukkit/plugin/PluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/PluginLoader.java
@@ -19,6 +19,8 @@ public interface PluginLoader {
      * @return Plugin that was contained in the specified file, or null if
      * unsuccessful
      * @throws InvalidPluginException Thrown when the specified file is not a plugin
+     * @throws InvalidDescriptionException If the plugin description file was invalid
+     * @throws UnknownDependencyException If a required dependency could not be found
      */
     public Plugin loadPlugin(File file) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException;
 
@@ -30,11 +32,14 @@ public interface PluginLoader {
      * @return Plugin that was contained in the specified file, or null if
      * unsuccessful
      * @throws InvalidPluginException Thrown when the specified file is not a plugin
+     * @throws InvalidDescriptionException If the plugin description file was invalid
+     * @throws UnknownDependencyException If a required dependency could not be found
      */
     public Plugin loadPlugin(File file, boolean ignoreSoftDependencies) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException;
 
     /**
      * Returns a list of all filename filters expected by this PluginLoader
+     * @return The filters
      */
     public Pattern[] getPluginFileFilters();
 
@@ -43,6 +48,7 @@ public interface PluginLoader {
      *
      * @param type Type of the event executor to create
      * @param listener the object that will handle the eventual call back
+     * @return The new executor
      */
     public EventExecutor createExecutor(Event.Type type, Listener listener);
 

--- a/src/main/java/org/bukkit/plugin/PluginManager.java
+++ b/src/main/java/org/bukkit/plugin/PluginManager.java
@@ -66,6 +66,7 @@ public interface PluginManager {
      * @return The Plugin loaded, or null if it was invalid
      * @throws InvalidPluginException Thrown when the specified file is not a valid plugin
      * @throws InvalidDescriptionException Thrown when the specified file contains an invalid description
+     * @throws UnknownDependencyException If a required dependency could not be resolved
      */
     public Plugin loadPlugin(File file) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException;
 
@@ -88,9 +89,8 @@ public interface PluginManager {
     public void clearPlugins();
 
     /**
-     * Calls a player related event with the given details
+     * Calls an event with the given details
      *
-     * @param type Type of player related event to call
      * @param event Event details
      */
     public void callEvent(Event event);
@@ -179,6 +179,7 @@ public interface PluginManager {
      * Gets the default permissions for the given op status
      *
      * @param op Which set of default permissions to get
+     * @return The default permissions
      */
     public Set<Permission> getDefaultPermissions(boolean op);
 

--- a/src/main/java/org/bukkit/plugin/RegisteredListener.java
+++ b/src/main/java/org/bukkit/plugin/RegisteredListener.java
@@ -52,7 +52,7 @@ public class RegisteredListener {
 
     /**
      * Calls the event executor
-     * @return Registered Priority
+     * @param event The event
      */
     public void callEvent(Event event) {
         executor.execute(listener, event);

--- a/src/main/java/org/bukkit/plugin/ServicesManager.java
+++ b/src/main/java/org/bukkit/plugin/ServicesManager.java
@@ -30,22 +30,22 @@ public interface ServicesManager {
     /**
      * Unregister all the providers registered by a particular plugin.
      *
-     * @param plugin
+     * @param plugin The plugin
      */
     public void unregisterAll(Plugin plugin);
 
     /**
      * Unregister a particular provider for a particular service.
      *
-     * @param service
-     * @param provider
+     * @param service The service interface
+     * @param provider The service provider implementation
      */
     public void unregister(Class<?> service, Object provider);
 
     /**
      * Unregister a particular provider.
      *
-     * @param provider
+     * @param provider The service provider implementation
      */
     public void unregister(Object provider);
 
@@ -53,8 +53,8 @@ public interface ServicesManager {
      * Queries for a provider. This may return if no provider has been
      * registered for a service. The highest priority provider is returned.
      *
-     * @param <T>
-     * @param service
+     * @param <T> The service interface
+     * @param service The service interface
      * @return provider or null
      */
     public <T> T load(Class<T> service);
@@ -63,8 +63,8 @@ public interface ServicesManager {
      * Queries for a provider registration. This may return if no provider
      * has been registered for a service.
      *
-     * @param <T>
-     * @param service
+     * @param <T> The service interface
+     * @param service The service interface
      * @return provider registration or null
      */
     public <T> RegisteredServiceProvider<T> getRegistration(Class<T> service);
@@ -72,7 +72,7 @@ public interface ServicesManager {
     /**
      * Get registrations of providers for a plugin.
      *
-     * @param plugin
+     * @param plugin The plugin
      * @return provider registration or null
      */
     public List<RegisteredServiceProvider<?>> getRegistrations(Plugin plugin);
@@ -81,8 +81,8 @@ public interface ServicesManager {
      * Get registrations of providers for a service. The returned list is
      * unmodifiable.
      *
-     * @param <T>
-     * @param service
+     * @param <T> The service interface
+     * @param service The service interface
      * @return list of registrations
      */
     public <T> Collection<RegisteredServiceProvider<T>> getRegistrations(

--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -175,6 +175,7 @@ public final class SimplePluginManager implements PluginManager {
      * @return The Plugin loaded, or null if it was invalid
      * @throws InvalidPluginException Thrown when the specified file is not a valid plugin
      * @throws InvalidDescriptionException Thrown when the specified file contains an invalid description
+     * @throws UnknownDependencyException If a required dependency could not be found
      */
     public synchronized Plugin loadPlugin(File file) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException {
         return loadPlugin(file, true);
@@ -190,6 +191,7 @@ public final class SimplePluginManager implements PluginManager {
      * @return The Plugin loaded, or null if it was invalid
      * @throws InvalidPluginException Thrown when the specified file is not a valid plugin
      * @throws InvalidDescriptionException Thrown when the specified file contains an invalid description
+     * @throws UnknownDependencyException If a required dependency could not be found
      */
     public synchronized Plugin loadPlugin(File file, boolean ignoreSoftDependencies) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException {
         File updateFile = null;
@@ -324,9 +326,8 @@ public final class SimplePluginManager implements PluginManager {
     }
 
     /**
-     * Calls a player related event with the given details
+     * Calls an event with the given details
      *
-     * @param type Type of player related event to call
      * @param event Event details
      */
     public synchronized void callEvent(Event event) {

--- a/src/main/java/org/bukkit/plugin/SimpleServicesManager.java
+++ b/src/main/java/org/bukkit/plugin/SimpleServicesManager.java
@@ -52,7 +52,7 @@ public class SimpleServicesManager implements ServicesManager {
     /**
      * Unregister all the providers registered by a particular plugin.
      *
-     * @param plugin
+     * @param plugin The plugin
      */
     public void unregisterAll(Plugin plugin) {
         synchronized (providers) {
@@ -86,8 +86,8 @@ public class SimpleServicesManager implements ServicesManager {
     /**
      * Unregister a particular provider for a particular service.
      *
-     * @param service
-     * @param provider
+     * @param service The service interface
+     * @param provider The service provider implementation
      */
     public void unregister(Class<?> service, Object provider) {
         synchronized (providers) {
@@ -127,7 +127,7 @@ public class SimpleServicesManager implements ServicesManager {
     /**
      * Unregister a particular provider.
      *
-     * @param provider
+     * @param provider The service provider implementation
      */
     public void unregister(Object provider) {
         synchronized (providers) {
@@ -162,8 +162,8 @@ public class SimpleServicesManager implements ServicesManager {
      * Queries for a provider. This may return if no provider has been
      * registered for a service. The highest priority provider is returned.
      *
-     * @param <T>
-     * @param service
+     * @param <T> The service interface
+     * @param service The service interface
      * @return provider or null
      */
     @SuppressWarnings("unchecked")
@@ -184,8 +184,8 @@ public class SimpleServicesManager implements ServicesManager {
      * Queries for a provider registration. This may return if no provider
      * has been registered for a service.
      *
-     * @param <T>
-     * @param service
+     * @param <T> The service interface
+     * @param service The service interface
      * @return provider registration or null
      */
     @SuppressWarnings("unchecked")
@@ -205,7 +205,7 @@ public class SimpleServicesManager implements ServicesManager {
     /**
      * Get registrations of providers for a plugin.
      *
-     * @param plugin
+     * @param plugin The plugin
      * @return provider registration or null
      */
     public List<RegisteredServiceProvider<?>> getRegistrations(Plugin plugin) {
@@ -228,8 +228,8 @@ public class SimpleServicesManager implements ServicesManager {
      * Get registrations of providers for a service. The returned list is
      * unmodifiable.
      *
-     * @param <T>
-     * @param service
+     * @param <T> The service interface
+     * @param service The service interface
      * @return list of registrations
      */
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
@@ -41,7 +41,7 @@ public abstract class JavaPlugin implements Plugin {
      * Returns the folder that the plugin data's files are located in. The
      * folder may not yet exist.
      *
-     * @return
+     * @return The folder.
      */
     public File getDataFolder() {
         return dataFolder;
@@ -98,7 +98,7 @@ public abstract class JavaPlugin implements Plugin {
      * does not exist and it cannot be loaded, no error will be emitted and
      * the configuration file will have no values.
      *
-     * @return
+     * @return The configuration.
      */
     public Configuration getConfiguration() {
         return config;

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -177,9 +177,9 @@ public class JavaPluginLoader implements PluginLoader {
             throw new InvalidPluginException(ex);
         }
 
-        loaders.put(description.getName(), (PluginClassLoader) loader);
+        loaders.put(description.getName(), loader);
 
-        return (Plugin) result;
+        return result;
     }
 
     protected File getDataFolder(File file) {

--- a/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
+++ b/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
@@ -11,10 +11,10 @@ public interface BukkitScheduler {
      * Schedules a once off task to occur after a delay
      * This task will be executed by the main server thread
      *
-     * @param Plugin Plugin that owns the task
-     * @param Runnable Task to be executed
-     * @param long Delay in server ticks before executing task
-     * @return int Task id number (-1 if scheduling failed)
+     * @param plugin Plugin that owns the task
+     * @param task Task to be executed
+     * @param delay Delay in server ticks before executing task
+     * @return Task id number (-1 if scheduling failed)
      */
     public int scheduleSyncDelayedTask(Plugin plugin, Runnable task, long delay);
 
@@ -22,9 +22,9 @@ public interface BukkitScheduler {
      * Schedules a once off task to occur as soon as possible
      * This task will be executed by the main server thread
      *
-     * @param Plugin Plugin that owns the task
-     * @param Runnable Task to be executed
-     * @return int Task id number (-1 if scheduling failed)
+     * @param plugin Plugin that owns the task
+     * @param task Task to be executed
+     * @return Task id number (-1 if scheduling failed)
      */
     public int scheduleSyncDelayedTask(Plugin plugin, Runnable task);
 
@@ -32,11 +32,11 @@ public interface BukkitScheduler {
      * Schedules a repeating task
      * This task will be executed by the main server thread
      *
-     * @param Plugin Plugin that owns the task
-     * @param Runnable Task to be executed
-     * @param long Delay in server ticks before executing first repeat
-     * @param long Period in server ticks of the task
-     * @return int Task id number (-1 if scheduling failed)
+     * @param plugin Plugin that owns the task
+     * @param task Task to be executed
+     * @param delay Delay in server ticks before executing first repeat
+     * @param period Period in server ticks of the task
+     * @return Task id number (-1 if scheduling failed)
      */
     public int scheduleSyncRepeatingTask(Plugin plugin, Runnable task, long delay, long period);
 
@@ -44,10 +44,10 @@ public interface BukkitScheduler {
      * Schedules a once off task to occur after a delay
      * This task will be executed by a thread managed by the scheduler
      *
-     * @param Plugin Plugin that owns the task
-     * @param Runnable Task to be executed
-     * @param long Delay in server ticks before executing task
-     * @return int Task id number (-1 if scheduling failed)
+     * @param plugin Plugin that owns the task
+     * @param task Task to be executed
+     * @param delay Delay in server ticks before executing task
+     * @return Task id number (-1 if scheduling failed)
      */
     public int scheduleAsyncDelayedTask(Plugin plugin, Runnable task, long delay);
 
@@ -55,9 +55,9 @@ public interface BukkitScheduler {
      * Schedules a once off task to occur as soon as possible
      * This task will be executed by a thread managed by the scheduler
      *
-     * @param Plugin Plugin that owns the task
-     * @param Runnable Task to be executed
-     * @return int Task id number (-1 if scheduling failed)
+     * @param plugin Plugin that owns the task
+     * @param task Task to be executed
+     * @return Task id number (-1 if scheduling failed)
      */
     public int scheduleAsyncDelayedTask(Plugin plugin, Runnable task);
 
@@ -65,11 +65,11 @@ public interface BukkitScheduler {
      * Schedules a repeating task
      * This task will be executed by a thread managed by the scheduler
      *
-     * @param Plugin Plugin that owns the task
-     * @param Runnable Task to be executed
-     * @param long Delay in server ticks before executing first repeat
-     * @param long Period in server ticks of the task
-     * @return int Task id number (-1 if scheduling failed)
+     * @param plugin Plugin that owns the task
+     * @param task Task to be executed
+     * @param delay Delay in server ticks before executing first repeat
+     * @param period Period in server ticks of the task
+     * @return Task id number (-1 if scheduling failed)
      */
     public int scheduleAsyncRepeatingTask(Plugin plugin, Runnable task, long delay, long period);
 
@@ -80,8 +80,9 @@ public interface BukkitScheduler {
      * Note:  The Future.get() methods must NOT be called from the main thread
      * Note2: There is at least an average of 10ms latency until the isDone() method returns true
      *
-     * @param Plugin Plugin that owns the task
-     * @param Callable Task to be executed
+     * @param <T> The callable's return type
+     * @param plugin Plugin that owns the task
+     * @param task Task to be executed
      * @return Future Future object related to the task
      */
     public <T> Future<T> callSyncMethod(Plugin plugin, Callable<T> task);
@@ -89,14 +90,14 @@ public interface BukkitScheduler {
     /**
      * Removes task from scheduler
      *
-     * @param int Id number of task to be removed
+     * @param taskId Id number of task to be removed
      */
     public void cancelTask(int taskId);
 
     /**
      * Removes all tasks associated with a particular plugin from the scheduler
      *
-     * @param Plugin Owner of tasks to be removed
+     * @param plugin Owner of tasks to be removed
      */
     public void cancelTasks(Plugin plugin);
 

--- a/src/main/java/org/bukkit/util/BlockVector.java
+++ b/src/main/java/org/bukkit/util/BlockVector.java
@@ -21,6 +21,7 @@ public class BlockVector extends Vector {
 
     /**
      * Construct the vector with another vector.
+     * @param vec The other vector.
      */
     public BlockVector(Vector vec) {
         this.x = vec.getX();
@@ -31,9 +32,9 @@ public class BlockVector extends Vector {
     /**
      * Construct the vector with provided integer components.
      *
-     * @param x
-     * @param y
-     * @param z
+     * @param x X component
+     * @param y Y component
+     * @param z Z component
      */
     public BlockVector(int x, int y, int z) {
         this.x = x;
@@ -44,9 +45,9 @@ public class BlockVector extends Vector {
     /**
      * Construct the vector with provided double components.
      *
-     * @param x
-     * @param y
-     * @param z
+     * @param x X component
+     * @param y Y component
+     * @param z Z component
      */
     public BlockVector(double x, double y, double z) {
         this.x = x;
@@ -57,9 +58,9 @@ public class BlockVector extends Vector {
     /**
      * Construct the vector with provided float components.
      *
-     * @param x
-     * @param y
-     * @param z
+     * @param x X component
+     * @param y Y component
+     * @param z Z component
      */
     public BlockVector(float x, float y, float z) {
         this.x = x;
@@ -70,7 +71,7 @@ public class BlockVector extends Vector {
     /**
      * Checks if another object is equivalent.
      *
-     * @param obj
+     * @param obj The other object
      * @return whether the other object is equivalent
      */
     @Override

--- a/src/main/java/org/bukkit/util/Vector.java
+++ b/src/main/java/org/bukkit/util/Vector.java
@@ -38,9 +38,9 @@ public class Vector implements Cloneable {
     /**
      * Construct the vector with provided integer components.
      *
-     * @param x
-     * @param y
-     * @param z
+     * @param x X component
+     * @param y Y component
+     * @param z Z component
      */
     public Vector(int x, int y, int z) {
         this.x = x;
@@ -51,9 +51,9 @@ public class Vector implements Cloneable {
     /**
      * Construct the vector with provided double components.
      *
-     * @param x
-     * @param y
-     * @param z
+     * @param x X component
+     * @param y Y component
+     * @param z Z component
      */
     public Vector(double x, double y, double z) {
         this.x = x;
@@ -64,9 +64,9 @@ public class Vector implements Cloneable {
     /**
      * Construct the vector with provided float components.
      *
-     * @param x
-     * @param y
-     * @param z
+     * @param x X component
+     * @param y Y component
+     * @param z Z component
      */
     public Vector(float x, float y, float z) {
         this.x = x;
@@ -75,9 +75,9 @@ public class Vector implements Cloneable {
     }
 
     /**
-     * Adds the vector by another.
+     * Adds a vector to this one
      *
-     * @param vec
+     * @param vec The other vector
      * @return the same vector
      */
     public Vector add(Vector vec) {
@@ -88,9 +88,9 @@ public class Vector implements Cloneable {
     }
 
     /**
-     * Subtracts the vector by another.
+     * Subtracts a vector from this one.
      *
-     * @param vec
+     * @param vec The other vector
      * @return the same vector
      */
     public Vector subtract(Vector vec) {
@@ -103,7 +103,7 @@ public class Vector implements Cloneable {
     /**
      * Multiplies the vector by another.
      *
-     * @param vec
+     * @param vec The other vector
      * @return the same vector
      */
     public Vector multiply(Vector vec) {
@@ -116,7 +116,7 @@ public class Vector implements Cloneable {
     /**
      * Divides the vector by another.
      *
-     * @param vec
+     * @param vec The other vector
      * @return the same vector
      */
     public Vector divide(Vector vec) {
@@ -129,7 +129,7 @@ public class Vector implements Cloneable {
     /**
      * Copies another vector
      *
-     * @param vec
+     * @param vec The other vector
      * @return the same vector
      */
     public Vector copy(Vector vec) {
@@ -168,6 +168,7 @@ public class Vector implements Cloneable {
      * will be returned if the inner result of the sqrt() function overflows,
      * which will be caused if the distance is too long.
      *
+     * @param o The other vector
      * @return the distance
      */
     public double distance(Vector o) {
@@ -177,6 +178,7 @@ public class Vector implements Cloneable {
     /**
      * Get the squared distance between this vector and another.
      *
+     * @param o The other vector
      * @return the distance
      */
     public double distanceSquared(Vector o) {
@@ -186,7 +188,7 @@ public class Vector implements Cloneable {
     /**
      * Gets the angle between this vector and another in radians.
      *
-     * @param other
+     * @param other The other vector
      * @return angle in radians
      */
     public float angle(Vector other) {
@@ -198,7 +200,7 @@ public class Vector implements Cloneable {
     /**
      * Sets this vector to the midpoint between this vector and another.
      *
-     * @param other
+     * @param other The other vector
      * @return this same vector (now a midpoint)
      */
     public Vector midpoint(Vector other) {
@@ -211,7 +213,7 @@ public class Vector implements Cloneable {
     /**
      * Gets a new midpoint vector between this vector and another.
      *
-     * @param other
+     * @param other The other vector
      * @return a new midpoint vector
      */
     public Vector getMidpoint(Vector other) {
@@ -224,7 +226,7 @@ public class Vector implements Cloneable {
     /**
      * Performs scalar multiplication, multiplying all components with a scalar.
      *
-     * @param m
+     * @param m The factor
      * @return the same vector
      */
     public Vector multiply(int m) {
@@ -237,7 +239,7 @@ public class Vector implements Cloneable {
     /**
      * Performs scalar multiplication, multiplying all components with a scalar.
      *
-     * @param m
+     * @param m The factor
      * @return the same vector
      */
     public Vector multiply(double m) {
@@ -250,7 +252,7 @@ public class Vector implements Cloneable {
     /**
      * Performs scalar multiplication, multiplying all components with a scalar.
      *
-     * @param m
+     * @param m The factor
      * @return the same vector
      */
     public Vector multiply(float m) {
@@ -264,7 +266,7 @@ public class Vector implements Cloneable {
      * Calculates the dot product of this vector with another. The dot product
      * is defined as x1*x2+y1*y2+z1*z2. The returned value is a scalar.
      *
-     * @param other
+     * @param other The other vector
      * @return dot product
      */
     public double dot(Vector other) {
@@ -279,7 +281,7 @@ public class Vector implements Cloneable {
      * y = z1 * x2 - z2 * x1<br/>
      * z = x1 * y2 - x2 * y1
      *
-     * @param o
+     * @param o The other vector
      * @return the same vector
      */
     public Vector crossProduct(Vector o) {
@@ -325,8 +327,8 @@ public class Vector implements Cloneable {
      * The minimum and maximum vectors given must be truly the minimum and
      * maximum X, Y and Z components.
      *
-     * @param min
-     * @param max
+     * @param min Minimum vector
+     * @param max Maximum vector
      * @return whether this vector is in the AABB
      */
     public boolean isInAABB(Vector min, Vector max) {
@@ -336,8 +338,8 @@ public class Vector implements Cloneable {
     /**
      * Returns whether this vector is within a sphere.
      *
-     * @param origin
-     * @param radius
+     * @param origin Sphere origin.
+     * @param radius Sphere radius
      * @return whether this vector is in the sphere
      */
     public boolean isInSphere(Vector origin, double radius) {
@@ -347,7 +349,7 @@ public class Vector implements Cloneable {
     /**
      * Gets the X component.
      *
-     * @return
+     * @return The X component.
      */
     public double getX() {
         return x;
@@ -366,7 +368,7 @@ public class Vector implements Cloneable {
     /**
      * Gets the Y component.
      *
-     * @return
+     * @return The Y component.
      */
     public double getY() {
         return y;
@@ -385,7 +387,7 @@ public class Vector implements Cloneable {
     /**
      * Gets the Z component.
      *
-     * @return
+     * @return The Z component.
      */
     public double getZ() {
         return z;
@@ -404,8 +406,8 @@ public class Vector implements Cloneable {
     /**
      * Set the X component.
      *
-     * @param x
-     * @return x
+     * @param x The new X component.
+     * @return This vector.
      */
     public Vector setX(int x) {
         this.x = x;
@@ -415,8 +417,8 @@ public class Vector implements Cloneable {
     /**
      * Set the X component.
      *
-     * @param x
-     * @return x
+     * @param x The new X component.
+     * @return This vector.
      */
     public Vector setX(double x) {
         this.x = x;
@@ -426,8 +428,8 @@ public class Vector implements Cloneable {
     /**
      * Set the X component.
      *
-     * @param x
-     * @return x
+     * @param x The new X component.
+     * @return This vector.
      */
     public Vector setX(float x) {
         this.x = x;
@@ -437,8 +439,8 @@ public class Vector implements Cloneable {
     /**
      * Set the Y component.
      *
-     * @param y
-     * @return y
+     * @param y The new Y component.
+     * @return This vector.
      */
     public Vector setY(int y) {
         this.y = y;
@@ -448,8 +450,8 @@ public class Vector implements Cloneable {
     /**
      * Set the Y component.
      *
-     * @param y
-     * @return y
+     * @param y The new Y component.
+     * @return This vector.
      */
     public Vector setY(double y) {
         this.y = y;
@@ -459,8 +461,8 @@ public class Vector implements Cloneable {
     /**
      * Set the Y component.
      *
-     * @param y
-     * @return y
+     * @param y The new Y component.
+     * @return This vector.
      */
     public Vector setY(float y) {
         this.y = y;
@@ -470,8 +472,8 @@ public class Vector implements Cloneable {
     /**
      * Set the Z component.
      *
-     * @param z
-     * @return z
+     * @param z The new Z component.
+     * @return This vector.
      */
     public Vector setZ(int z) {
         this.z = z;
@@ -481,8 +483,8 @@ public class Vector implements Cloneable {
     /**
      * Set the Z component.
      *
-     * @param z
-     * @return z
+     * @param z The new Z component.
+     * @return This vector.
      */
     public Vector setZ(double z) {
         this.z = z;
@@ -492,8 +494,8 @@ public class Vector implements Cloneable {
     /**
      * Set the Z component.
      *
-     * @param z
-     * @return z
+     * @param z The new Z component.
+     * @return This vector.
      */
     public Vector setZ(float z) {
         this.z = z;
@@ -565,7 +567,7 @@ public class Vector implements Cloneable {
     /**
      * Gets a Location version of this vector with yaw and pitch being 0.
      *
-     * @param world
+     * @param world The world to link the location to.
      * @return the location
      */
     public Location toLocation(World world) {
@@ -575,7 +577,9 @@ public class Vector implements Cloneable {
     /**
      * Gets a Location version of this vector.
      *
-     * @param world
+     * @param world The world to link the location to.
+     * @param yaw The desired yaw.
+     * @param pitch The desired pitch.
      * @return the location
      */
     public Location toLocation(World world, float yaw, float pitch) {
@@ -585,7 +589,7 @@ public class Vector implements Cloneable {
     /**
      * Get the block vector of this vector.
      *
-     * @return
+     * @return A block vector.
      */
     public BlockVector toBlockVector() {
         return new BlockVector(x, y, z);
@@ -594,7 +598,7 @@ public class Vector implements Cloneable {
     /**
      * Get the threshold used for equals().
      *
-     * @return
+     * @return The epsilon.
      */
     public static double getEpsilon() {
         return epsilon;
@@ -603,8 +607,8 @@ public class Vector implements Cloneable {
     /**
      * Gets the minimum components of two vectors.
      *
-     * @param v1
-     * @param v2
+     * @param v1 The first vector.
+     * @param v2 The second vector.
      * @return minimum
      */
     public static Vector getMinimum(Vector v1, Vector v2) {
@@ -614,8 +618,8 @@ public class Vector implements Cloneable {
     /**
      * Gets the maximum components of two vectors.
      *
-     * @param v1
-     * @param v2
+     * @param v1 The first vector.
+     * @param v2 The second vector.
      * @return maximum
      */
     public static Vector getMaximum(Vector v1, Vector v2) {
@@ -626,7 +630,7 @@ public class Vector implements Cloneable {
      * Gets a random vector with components having a random value between
      * 0 and 1.
      *
-     * @return
+     * @return A random vector.
      */
     public static Vector getRandom() {
         return new Vector(random.nextDouble(), random.nextDouble(), random.nextDouble());

--- a/src/main/java/org/bukkit/util/config/Configuration.java
+++ b/src/main/java/org/bukkit/util/config/Configuration.java
@@ -127,7 +127,7 @@ public class Configuration extends ConfigurationNode {
     /**
      * Return the set header.
      *
-     * @return
+     * @return The header comment.
      */
     public String getHeader() {
         return header;
@@ -136,7 +136,6 @@ public class Configuration extends ConfigurationNode {
     /**
      * Saves the configuration to disk. All errors are clobbered.
      *
-     * @param header header to prepend
      * @return true if it was successful
      */
     public boolean save() {
@@ -184,7 +183,7 @@ public class Configuration extends ConfigurationNode {
     /**
      * This method returns an empty ConfigurationNode for using as a
      * default in methods that select a node from a node list.
-     * @return
+     * @return The empty node.
      */
     public static ConfigurationNode getEmptyNode() {
         return new ConfigurationNode(new HashMap<String, Object>());

--- a/src/main/java/org/bukkit/util/config/ConfigurationNode.java
+++ b/src/main/java/org/bukkit/util/config/ConfigurationNode.java
@@ -107,8 +107,8 @@ public class ConfigurationNode {
      * Set the property at a location. This will override existing
      * configuration data to have it conform to key/value mappings.
      *
-     * @param path
-     * @param value
+     * @param path The property path
+     * @param value The new value
      */
     @SuppressWarnings("unchecked")
     public void setProperty(String path, Object value) {
@@ -450,7 +450,7 @@ public class ConfigurationNode {
      * path does not lead to a node, null will be returned. A node has
      * key/value mappings.
      *
-     * @param path
+     * @param path The property path
      * @return node or null
      */
     @SuppressWarnings("unchecked")
@@ -560,7 +560,7 @@ public class ConfigurationNode {
      * Remove the property at a location. This will override existing
      * configuration data to have it conform to key/value mappings.
      *
-     * @param path
+     * @param path The property path
      */
     @SuppressWarnings("unchecked")
     public void removeProperty(String path) {

--- a/src/main/java/org/bukkit/util/noise/SimplexNoiseGenerator.java
+++ b/src/main/java/org/bukkit/util/noise/SimplexNoiseGenerator.java
@@ -350,10 +350,10 @@ public class SimplexNoiseGenerator extends PerlinNoiseGenerator {
     /**
      * Computes and returns the 4D simplex noise for the given coordinates in 4D space
      *
-     * @param xin X coordinate
-     * @param yin Y coordinate
-     * @param zin Z coordinate
-     * @param win W coordinate
+     * @param x X coordinate
+     * @param y Y coordinate
+     * @param z Z coordinate
+     * @param w W coordinate
      * @return Noise at given location, from range -1 to 1
      */
     public double noise(double x, double y, double z, double w) {

--- a/src/main/java/org/bukkit/util/noise/SimplexOctaveGenerator.java
+++ b/src/main/java/org/bukkit/util/noise/SimplexOctaveGenerator.java
@@ -70,7 +70,7 @@ public class SimplexOctaveGenerator extends OctaveGenerator {
      * @param x X-coordinate
      * @param y Y-coordinate
      * @param z Z-coordinate
-     * @para, w W-coordinate
+     * @param w W-coordinate
      * @param frequency How much to alter the frequency by each octave
      * @param amplitude How much to alter the amplitude by each octave
      * @return Resulting noise
@@ -85,7 +85,7 @@ public class SimplexOctaveGenerator extends OctaveGenerator {
      * @param x X-coordinate
      * @param y Y-coordinate
      * @param z Z-coordinate
-     * @para, w W-coordinate
+     * @param w W-coordinate
      * @param frequency How much to alter the frequency by each octave
      * @param amplitude How much to alter the amplitude by each octave
      * @param normalized If true, normalize the value to [-1, 1]


### PR DESCRIPTION
I went through and filled in all the empty Javadoc tags, added missing ones, fixed typo'ed and wrongly used ones, and so forth; basically eliminating 90% of the javadoc-related compiler warnings Eclipse gave me. I also eliminated some additional warnings (such as unnecessary casts and imports); those are in a separate commit in case you'd rather not have them.
