### PR TITLE
Fixed SimplePluginManager for plugins that add pluginloaders

### DIFF
--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -134,7 +134,6 @@ public final class SimplePluginManager implements PluginManager {
 
                 try {
                     plugin = loadPlugin(file, finalPass);
-                    itr.remove();
                 } catch (UnknownDependencyException ex) {
                     if (finalPass) {
                         server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + directory.getPath() + "': " + ex.getMessage(), ex);
@@ -154,6 +153,7 @@ public final class SimplePluginManager implements PluginManager {
                     result.add(plugin);
                     allFailed = false;
                     finalPass = false;
+                    itr.remove();
                 }
             }
             if (finalPass) {


### PR DESCRIPTION
Moved itr.remove() in SimplePluginManager.loadPlugins() so that non-plugin files that do not get loaded are not removed from the iterator, so that the loop does not end until it has gone through a whole pass without finding any plugin-loadable files. This is so that if a plugin adds a pluginloader that is not jar-based, that pluginloader will get a chance to run.
