### PR TITLE
Interface for getting recipes (by result) and removing recipes

### DIFF
--- a/src/main/java/org/bukkit/Bukkit.java
+++ b/src/main/java/org/bukkit/Bukkit.java
@@ -1,6 +1,8 @@
 package org.bukkit;
 
 import com.avaje.ebean.config.ServerConfig;
+
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -12,6 +14,7 @@ import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.entity.Player;
 import org.bukkit.generator.ChunkGenerator;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.map.MapView;
 import org.bukkit.plugin.PluginManager;
@@ -204,6 +207,22 @@ public final class Bukkit {
 
     public static boolean addRecipe(Recipe recipe) {
         return server.addRecipe(recipe);
+    }
+    
+    public List<Recipe> getRecipesFor(ItemStack result) {
+        return server.getRecipesFor(result);
+    }
+    
+    public Iterator<Recipe> recipeIterator() {
+        return server.recipeIterator();
+    }
+    
+    public void clearRecipes() {
+        server.clearRecipes();
+    }
+    
+    public void resetRecipes() {
+        server.resetRecipes();
     }
 
     public static Map<String, String[]> getCommandAliases() {

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -3,9 +3,12 @@ package org.bukkit;
 import org.bukkit.generator.ChunkGenerator;
 import com.avaje.ebean.config.ServerConfig;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -385,9 +388,33 @@ public interface Server {
     /**
      * Adds a recipe to the crafting manager.
      * @param recipe The recipe to add.
-     * @return True to indicate that the recipe was added.
+     * @return True if the recipe was added, false if it wasn't for some reason.
      */
     public boolean addRecipe(Recipe recipe);
+    
+    /**
+     * Get a list of all recipes for a given item. The stack size is ignored in comparisons.
+     * If the durability is -1, it will match any data value.
+     * @param result The item whose recipes you want
+     * @return The list of recipes
+     */
+    public List<Recipe> getRecipesFor(ItemStack result);
+    
+    /**
+     * Get an iterator through the list of crafting recipes.
+     * @return The iterator.
+     */
+    public Iterator<Recipe> recipeIterator();
+    
+    /**
+     * Clears the list of crafting recipes.
+     */
+    public void clearRecipes();
+    
+    /**
+     * Resets the list of crafting recipes to the default.
+     */
+    public void resetRecipes();
 
     /**
      * Gets a list of command aliases defined in the server properties.

--- a/src/main/java/org/bukkit/inventory/FurnaceRecipe.java
+++ b/src/main/java/org/bukkit/inventory/FurnaceRecipe.java
@@ -8,7 +8,7 @@ import org.bukkit.material.MaterialData;
  */
 public class FurnaceRecipe implements Recipe {
     private ItemStack output;
-    private MaterialData ingredient;
+    private ItemStack ingredient;
 
     /**
      * Create a furnace recipe to craft the specified ItemStack.
@@ -16,7 +16,7 @@ public class FurnaceRecipe implements Recipe {
      * @param source The input material.
      */
     public FurnaceRecipe(ItemStack result, Material source) {
-        this(result, source.getNewData((byte) 0));
+        this(result, source, 0);
         if (this.ingredient == null) {
             setInput(new MaterialData(source));
         }
@@ -28,8 +28,18 @@ public class FurnaceRecipe implements Recipe {
      * @param source The input material.
      */
     public FurnaceRecipe(ItemStack result, MaterialData source) {
+        this(result, source.getItemType(), source.getData());
+    }
+
+    /**
+     * Create a furnace recipe to craft the specified ItemStack.
+     * @param result The item you want the recipe to create.
+     * @param source The input material.
+     * @param data The data value. (Note: This is currently ignored by the CraftBukkit server.)
+     */
+    public FurnaceRecipe(ItemStack result, Material source, int data) {
         this.output = result;
-        this.ingredient = source;
+        this.ingredient = new ItemStack(source, 1, (short) data);
     }
 
     /**
@@ -38,8 +48,7 @@ public class FurnaceRecipe implements Recipe {
      * @return The changed recipe, so you can chain calls.
      */
     public FurnaceRecipe setInput(MaterialData input) {
-        this.ingredient = input;
-        return this;
+        return setInput(input.getItemType(), input.getData());
     }
 
     /**
@@ -48,19 +57,26 @@ public class FurnaceRecipe implements Recipe {
      * @return The changed recipe, so you can chain calls.
      */
     public FurnaceRecipe setInput(Material input) {
-        setInput(input.getNewData((byte) 0));
-        if (this.ingredient == null) {
-            setInput(new MaterialData(input));
-        }
+        return setInput(input, 0);
+    }
+    
+    /**
+     * Sets the input of this furnace recipe.
+     * @param input The input material.
+     * @param data The data value. (Note: This is currently ignored by the CraftBukkit server.)
+     * @return The changed recipe, so you can chain calls.
+     */
+    public FurnaceRecipe setInput(Material input, int data) {
+        this.ingredient = new ItemStack(input, 1, (short) data);
         return this;
     }
 
     /**
-     * Get the input material.
+     * Get a copy of the input material.
      * @return The input material.
      */
-    public MaterialData getInput() {
-        return ingredient;
+    public ItemStack getInput() {
+        return new ItemStack(ingredient.getType(), 1, ingredient.getDurability());
     }
 
     /**

--- a/src/main/java/org/bukkit/inventory/Recipe.java
+++ b/src/main/java/org/bukkit/inventory/Recipe.java
@@ -4,7 +4,6 @@ package org.bukkit.inventory;
  * Represents some type of crafting recipe.
  */
 public interface Recipe {
-
     /**
      * Get the result of this recipe.
      * @return The result stack

--- a/src/main/java/org/bukkit/inventory/ShapedRecipe.java
+++ b/src/main/java/org/bukkit/inventory/ShapedRecipe.java
@@ -1,6 +1,7 @@
 package org.bukkit.inventory;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import org.bukkit.Material;
 import org.bukkit.material.MaterialData;
@@ -11,7 +12,7 @@ import org.bukkit.material.MaterialData;
 public class ShapedRecipe implements Recipe {
     private ItemStack output;
     private String[] rows;
-    private HashMap<Character, MaterialData> ingredients = new HashMap<Character, MaterialData>();
+    private HashMap<Character, ItemStack> ingredients = new HashMap<Character, ItemStack>();
 
     /**
      * Create a shaped recipe to craft the specified ItemStack. The constructor merely determines the
@@ -44,12 +45,12 @@ public class ShapedRecipe implements Recipe {
         this.rows = shape;
 
         // Remove character mappings for characters that no longer exist in the shape
-        HashMap<Character, MaterialData> ingredientsTemp = this.ingredients;
+        HashMap<Character, ItemStack> ingredientsTemp = this.ingredients;
 
-        this.ingredients = new HashMap<Character, MaterialData>();
+        this.ingredients = new HashMap<Character, ItemStack>();
         for (char key : ingredientsTemp.keySet()) {
             try {
-                setIngredient(key, ingredientsTemp.get(key));
+                setIngredient(key, ingredientsTemp.get(key).getType(), ingredientsTemp.get(key).getDurability());
             } catch (IllegalArgumentException e) {}
         }
         return this;
@@ -62,11 +63,7 @@ public class ShapedRecipe implements Recipe {
      * @return The changed recipe, so you can chain calls.
      */
     public ShapedRecipe setIngredient(char key, MaterialData ingredient) {
-        if (!hasKey(key)) {
-            throw new IllegalArgumentException("Symbol " + key + " does not appear in the shape.");
-        }
-        ingredients.put(key, ingredient);
-        return this;
+        return setIngredient(key, ingredient.getItemType(), ingredient.getData());
     }
 
     /**
@@ -87,12 +84,11 @@ public class ShapedRecipe implements Recipe {
      * @return The changed recipe, so you can chain calls.
      */
     public ShapedRecipe setIngredient(char key, Material ingredient, int raw) {
-        MaterialData data = ingredient.getNewData((byte) raw);
-
-        if (data == null) {
-            data = new MaterialData(ingredient, (byte) raw);
+        if (!hasKey(key)) {
+            throw new IllegalArgumentException("Symbol " + key + " does not appear in the shape.");
         }
-        return setIngredient(key, data);
+        ingredients.put(key, new ItemStack(ingredient, 1, (short) raw));
+        return this;
     }
 
     private boolean hasKey(char c) {
@@ -107,11 +103,15 @@ public class ShapedRecipe implements Recipe {
     }
 
     /**
-     * Get the ingredients map.
+     * Get a copy of the ingredients map.
      * @return The mapping of character to ingredients.
      */
-    public HashMap<Character, MaterialData> getIngredientMap() {
-        return ingredients;
+    public Map<Character, ItemStack> getIngredientMap() {
+        Map<Character, ItemStack> toReturn = new HashMap<Character, ItemStack>();
+        for (char c : ingredients.keySet()) {
+            toReturn.put(c, new ItemStack(ingredients.get(c).getType(), 1, ingredients.get(c).getDurability()));
+        }
+        return toReturn;
     }
 
     /**

--- a/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
+++ b/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
@@ -1,6 +1,7 @@
 package org.bukkit.inventory;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.bukkit.Material;
 import org.bukkit.material.MaterialData;
@@ -11,7 +12,7 @@ import org.bukkit.material.MaterialData;
  */
 public class ShapelessRecipe implements Recipe {
     private ItemStack output;
-    private ArrayList<MaterialData> ingredients = new ArrayList<MaterialData>();
+    private ArrayList<ItemStack> ingredients = new ArrayList<ItemStack>();
 
     /**
      * Create a shapeless recipe to craft the specified ItemStack. The constructor merely determines the
@@ -19,6 +20,10 @@ public class ShapelessRecipe implements Recipe {
      * @param result The item you want the recipe to create.
      * @see ShapelessRecipe#addIngredient(Material)
      * @see ShapelessRecipe#addIngredient(MaterialData)
+     * @see ShapelessRecipe#addIngredient(Material,int)
+     * @see ShapelessRecipe#addIngredient(int,Material)
+     * @see ShapelessRecipe#addIngredient(int,MaterialData)
+     * @see ShapelessRecipe#addIngredient(int,Material,int)
      */
     public ShapelessRecipe(ItemStack result) {
         this.output = result;
@@ -45,7 +50,7 @@ public class ShapelessRecipe implements Recipe {
     /**
      * Adds the specified ingredient.
      * @param ingredient The ingredient to add.
-     * @param rawdata The data value.
+     * @param rawdata The data value, or -1 to allow any data value.
      * @return The changed recipe, so you can chain calls.
      */
     public ShapelessRecipe addIngredient(Material ingredient, int rawdata) {
@@ -59,13 +64,7 @@ public class ShapelessRecipe implements Recipe {
      * @return The changed recipe, so you can chain calls.
      */
     public ShapelessRecipe addIngredient(int count, MaterialData ingredient) {
-        if (ingredients.size() + count > 9) {
-            throw new IllegalArgumentException("Shapeless recipes cannot have more than 9 ingredients");
-        }
-        while (count-- > 0) {
-            ingredients.add(ingredient);
-        }
-        return this;
+        return addIngredient(count, ingredient.getItemType(), ingredient.getData());
     }
 
     /**
@@ -82,26 +81,92 @@ public class ShapelessRecipe implements Recipe {
      * Adds multiples of the specified ingredient.
      * @param count How many to add (can't be more than 9!)
      * @param ingredient The ingredient to add.
-     * @param rawdata The data value.
+     * @param rawdata The data value, or -1 to allow any data value.
      * @return The changed recipe, so you can chain calls.
      */
     public ShapelessRecipe addIngredient(int count, Material ingredient, int rawdata) {
-        MaterialData data = ingredient.getNewData((byte) rawdata);
-
-        if (data == null) {
-            data = new MaterialData(ingredient, (byte) rawdata);
+        if (ingredients.size() + count > 9) {
+            throw new IllegalArgumentException("Shapeless recipes cannot have more than 9 ingredients");
         }
-        return addIngredient(count, data);
+        while (count-- > 0) {
+            ingredients.add(new ItemStack(ingredient, 1, (short) rawdata));
+        }
+        return this;
     }
 
     /**
      * Removes an ingredient from the list. If the ingredient occurs multiple times,
-     * only one instance of it is removed.
+     * only one instance of it is removed. Only removes exact matches, with a data value
+     * of 0.
+     * @param ingredient The ingredient to remove
+     * @return The changed recipe.
+     */
+    public ShapelessRecipe removeIngredient(Material ingredient) {
+        return removeIngredient(ingredient, 0);
+    }
+    
+    /**
+     * Removes an ingredient from the list. If the ingredient occurs multiple times,
+     * only one instance of it is removed. If the data value is -1, only ingredients
+     * with a -1 data value will be removed.
      * @param ingredient The ingredient to remove
      * @return The changed recipe.
      */
     public ShapelessRecipe removeIngredient(MaterialData ingredient) {
-        this.ingredients.remove(ingredient);
+        return removeIngredient(ingredient.getItemType(), ingredient.getData());
+    }
+    
+    /**
+     * Removes multiple instances of an ingredient from the list. If there are less instances
+     * then specified, all will be removed. Only removes exact matches, with a data value
+     * of 0.
+     * @param count The number of copies to remove.
+     * @param ingredient The ingredient to remove
+     * @return The changed recipe.
+     */
+    public ShapelessRecipe removeIngredient(int count, Material ingredient) {
+        return removeIngredient(count, ingredient, 0);
+    }
+    
+    /**
+     * Removes multiple instances of an ingredient from the list. If there are less instances
+     * then specified, all will be removed. If the data value is -1, only ingredients
+     * with a -1 data value will be removed.
+     * @param count The number of copies to remove.
+     * @param ingredient The ingredient to remove.
+     * @return The changed recipe.
+     */
+    public ShapelessRecipe removeIngredient(int count, MaterialData ingredient) {
+        return removeIngredient(count, ingredient.getItemType(), ingredient.getData());
+    }
+
+    /**
+     * Removes an ingredient from the list. If the ingredient occurs multiple times,
+     * only one instance of it is removed. If the data value is -1, only ingredients
+     * with a -1 data value will be removed.
+     * @param ingredient The ingredient to remove
+     * @param rawdata The data value;
+     * @return The changed recipe.
+     */
+    public ShapelessRecipe removeIngredient(Material ingredient, int rawdata) {
+        ItemStack toRemove = new ItemStack(ingredient, 1, (short) rawdata);
+        this.ingredients.remove(toRemove);
+        return this;
+    }
+
+    /**
+     * Removes multiple instances of an ingredient from the list. If there are less instances
+     * then specified, all will be removed. If the data value is -1, only ingredients
+     * with a -1 data value will be removed.
+     * @param count The number of copies to remove.
+     * @param ingredient The ingredient to remove.
+     * @param rawdata The data value.
+     * @return The changed recipe.
+     */
+    public ShapelessRecipe removeIngredient(int count, Material ingredient, int rawdata) {
+        while (count-- > 0) {
+            removeIngredient(ingredient, rawdata);
+        }
         return this;
     }
 
@@ -114,10 +179,14 @@ public class ShapelessRecipe implements Recipe {
     }
 
     /**
-     * Get the list of ingredients used for this recipe.
+     * Get a copy of the list of ingredients used for this recipe.
      * @return The input list
      */
-    public ArrayList<MaterialData> getIngredientList() {
-        return ingredients;
+    public List<ItemStack> getIngredientList() {
+        List<ItemStack> toReturn = new ArrayList<ItemStack>();
+        for (ItemStack stack : ingredients) {
+            toReturn.add(new ItemStack(stack.getType(), 1, stack.getDurability()));
+        }
+        return toReturn;
     }
 }


### PR DESCRIPTION
I couldn't think of a nice way to add getRecipe and removeRecipe, but this commit provides the same functionality in a different way: by providing an iterator with which you can go through the registered recipes, examine them, and optionally remove them.
