### PR TITLE
add add and subtract methods to Location accepting Vector

### DIFF
--- a/src/main/java/org/bukkit/Location.java
+++ b/src/main/java/org/bukkit/Location.java
@@ -233,6 +233,20 @@ public class Location implements Cloneable {
     }
 
     /**
+     * Adds the location by a vector.
+     * 
+     * @see Vector
+     * @param vec
+     * @return the same location
+     */
+    public Location add(Vector vec) {
+        this.x += vec.getX();
+        this.y += vec.getY();
+        this.z += vec.getZ();
+        return this;
+    }
+
+    /**
      * Adds the location by another. Not world-aware.
      *
      * @see Vector
@@ -264,6 +278,20 @@ public class Location implements Cloneable {
         x -= vec.x;
         y -= vec.y;
         z -= vec.z;
+        return this;
+    }
+
+    /**
+     * Subtracts the location by a vector.
+     * 
+     * @see Vector
+     * @param vec
+     * @return the same location
+     */
+    public Location subtract(Vector vec) {
+        this.x -= vec.getX();
+        this.y -= vec.getY();
+        this.z -= vec.getZ();
         return this;
     }
 


### PR DESCRIPTION
I added the following methods to `Location` because they're useful or convenient or something. I think their absence is kind of an oversight.

> public Location add(Vector vec);
> public Location subtract(Vector vec);

I mean, if you ask me, Location ought to be a subclass of Vector since every vector operation would be useful when applied to a location as well, but that's a more ambitious change. C:
