### PR TITLE
Added getDrops() to BLOCK_BREAK, PAINTING_BREAK, VEHICLE_DESTROY events

### DIFF
--- a/src/main/java/org/bukkit/event/block/BlockBreakEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockBreakEvent.java
@@ -1,8 +1,11 @@
 package org.bukkit.event.block;
 
+import java.util.List;
+
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
+import org.bukkit.inventory.ItemStack;
 
 /**
  * Called when a block is broken by a player.
@@ -17,11 +20,13 @@ public class BlockBreakEvent extends BlockEvent implements Cancellable {
 
     private Player player;
     private boolean cancel;
+    private List<ItemStack> drops;
 
-    public BlockBreakEvent(final Block theBlock, Player player) {
+    public BlockBreakEvent(final Block theBlock, Player player, List<ItemStack> drops) {
         super(Type.BLOCK_BREAK, theBlock);
         this.player = player;
         this.cancel = false;
+        this.drops = drops;
     }
 
     /**
@@ -31,6 +36,10 @@ public class BlockBreakEvent extends BlockEvent implements Cancellable {
      */
     public Player getPlayer() {
         return player;
+    }
+    
+    public List<ItemStack> getDrops() {
+        return drops;
     }
 
     public boolean isCancelled() {

--- a/src/main/java/org/bukkit/event/painting/PaintingBreakByEntityEvent.java
+++ b/src/main/java/org/bukkit/event/painting/PaintingBreakByEntityEvent.java
@@ -1,7 +1,10 @@
 package org.bukkit.event.painting;
 
+import java.util.List;
+
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Painting;
+import org.bukkit.inventory.ItemStack;
 
 /**
  * Triggered when a painting is removed by an entity
@@ -9,8 +12,8 @@ import org.bukkit.entity.Painting;
 public class PaintingBreakByEntityEvent extends PaintingBreakEvent {
     private Entity remover;
 
-    public PaintingBreakByEntityEvent(final Painting painting, final Entity remover) {
-        super(painting, RemoveCause.ENTITY);
+    public PaintingBreakByEntityEvent(final Painting painting, final Entity remover, List<ItemStack> drops) {
+        super(painting, RemoveCause.ENTITY, drops);
         this.remover = remover;
     }
 

--- a/src/main/java/org/bukkit/event/painting/PaintingBreakEvent.java
+++ b/src/main/java/org/bukkit/event/painting/PaintingBreakEvent.java
@@ -1,7 +1,10 @@
 package org.bukkit.event.painting;
 
+import java.util.List;
+
 import org.bukkit.entity.Painting;
 import org.bukkit.event.Cancellable;
+import org.bukkit.inventory.ItemStack;
 
 /**
  * Triggered when a painting is removed
@@ -10,10 +13,12 @@ public class PaintingBreakEvent extends PaintingEvent implements Cancellable {
 
     private boolean cancelled;
     private RemoveCause cause;
+    private List<ItemStack> drops;
 
-    public PaintingBreakEvent(final Painting painting, RemoveCause cause) {
+    public PaintingBreakEvent(final Painting painting, RemoveCause cause, List<ItemStack> drops) {
         super(Type.PAINTING_BREAK, painting);
         this.cause = cause;
+        this.drops = drops;
     }
 
     /**
@@ -31,6 +36,10 @@ public class PaintingBreakEvent extends PaintingEvent implements Cancellable {
 
     public void setCancelled(boolean cancel) {
         this.cancelled = cancel;
+    }
+
+    public List<ItemStack> getDrops() {
+        return drops;
     }
 
     /**

--- a/src/main/java/org/bukkit/event/vehicle/VehicleDestroyEvent.java
+++ b/src/main/java/org/bukkit/event/vehicle/VehicleDestroyEvent.java
@@ -1,8 +1,11 @@
 package org.bukkit.event.vehicle;
 
+import java.util.List;
+
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Vehicle;
 import org.bukkit.event.Cancellable;
+import org.bukkit.inventory.ItemStack;
 
 /**
  * Raised when a vehicle is destroyed
@@ -10,10 +13,12 @@ import org.bukkit.event.Cancellable;
 public class VehicleDestroyEvent extends VehicleEvent implements Cancellable {
     private Entity attacker;
     private boolean cancelled;
+    private List<ItemStack> drops;
 
-    public VehicleDestroyEvent(Vehicle vehicle, Entity attacker) {
+    public VehicleDestroyEvent(Vehicle vehicle, Entity attacker, List<ItemStack> drops) {
         super(Type.VEHICLE_DESTROY, vehicle);
         this.attacker = attacker;
+        this.drops = drops;
     }
 
     /**
@@ -31,5 +36,9 @@ public class VehicleDestroyEvent extends VehicleEvent implements Cancellable {
 
     public void setCancelled(boolean cancel) {
         this.cancelled = cancel;
+    }
+
+    public List<ItemStack> getDrops() {
+        return drops;
     }
 }


### PR DESCRIPTION
Interface for getting and setting drops in BLOCK_BREAK, PAINTING_BREAK, and VEHICLE_DESTROY events in a manner analogous to the method used in ENTITY_DEATH events
