### PR TITLE
Allow OfflinePlayers to own tamed animals

### DIFF
--- a/src/main/java/org/bukkit/OfflinePlayer.java
+++ b/src/main/java/org/bukkit/OfflinePlayer.java
@@ -1,8 +1,9 @@
 package org.bukkit;
 
+import org.bukkit.entity.AnimalTamer;
 import org.bukkit.permissions.ServerOperator;
 
-public interface OfflinePlayer extends ServerOperator {
+public interface OfflinePlayer extends ServerOperator, AnimalTamer {
     /**
      * Checks if this player is currently online
      *


### PR DESCRIPTION
Currently if you wish to query the owner of a wolf when that owner is offline, you have to bypass Bukkit. This pull request, and its [accompanying one on CraftBukkit](https://github.com/Bukkit/CraftBukkit/pull/464), aim to fix that.
