### PR TITLE
Add getBedSpawnLocation to Player

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -383,4 +383,11 @@ public interface Player extends HumanEntity, CommandSender, OfflinePlayer {
      * @param value New food level
      */
     public void setFoodLevel(int value);
+
+    /**
+     * Gets the Location where the player will spawn at their bed. Null if they have not slept in one.
+     *
+     * @return Bed Spawn Location if bed exists, otherwise NULL.
+     */
+    public Location getBedSpawnLocation();
 }


### PR DESCRIPTION
Allow plugins to easily get the bed that the player has slept in.

Associated implementation is [CraftBukkit Pull Request #468](https://github.com/Bukkit/CraftBukkit/pull/468).
