### PR TITLE
Fixed typo in EntityDeathEvent.setDroppedExp(int)

### DIFF
--- a/src/main/java/org/bukkit/event/entity/EntityDeathEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDeathEvent.java
@@ -41,7 +41,7 @@ public class EntityDeathEvent extends EntityEvent {
      *
      * @param exp Amount of EXP to drop.
      */
-    public void setDropedExp(int exp) {
+    public void setDroppedExp(int exp) {
         this.dropExp = exp;
     }
 

--- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
+++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
@@ -52,7 +52,7 @@ public class PlayerDeathEvent extends EntityDeathEvent {
      * Sets how much EXP the Player should have at respawn.
      * <p>
      * This does not indicate how much EXP should be dropped, please see
-     * {@link #setDropedExp(int)} for that.
+     * {@link #setDroppedExp(int)} for that.
      * 
      * @get exp New EXP of the respawned player
      */


### PR DESCRIPTION
Changed from setDropedExp to setDroppedExp. Fairly self-explanatory.
