### PR TITLE
Added entity effect support

### DIFF
--- a/src/main/java/org/bukkit/EntityEffect.java
+++ b/src/main/java/org/bukkit/EntityEffect.java
@@ -1,0 +1,52 @@
+package org.bukkit;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Effects that can be applied to LivingEntities. Not all of them are implemented yet.
+ */
+public enum EntityEffect {
+
+    MOVE_SPEED(1),
+    MOVE_SLOW(2),
+    DIG_SPEED(3),
+    DIG_SLOW(4),
+    DAMAGE_BOOST(5),
+    HEAL(6),
+    HARM(7),
+    JUMP(8),
+    CONFUSION(9),
+    REGENERATION(10),
+    RESISTANCE(11),
+    FIRE_RESISTANCE(12),
+    WATER_BREATHING(13),
+    INVISIBILITY(14),
+    BLINDNESS(15),
+    NIGHT_VISION(16),
+    HUNGER(17),
+    WEAKNESS(18),
+    POISON(19);
+
+    private final byte id;
+
+    private static final Map<Integer, EntityEffect> lookup = new HashMap<Integer, EntityEffect>();
+
+    static {
+        for (EntityEffect effect : EntityEffect.values()) {
+            lookup.put((int)effect.getId(), effect);
+        }
+    }
+
+    public static EntityEffect getById(int id) {
+        return lookup.get(id);
+    }
+
+    private EntityEffect(int id) {
+        this.id = (byte) id;
+    }
+
+    public byte getId() {
+        return id;
+    }
+}

--- a/src/main/java/org/bukkit/entity/LivingEntity.java
+++ b/src/main/java/org/bukkit/entity/LivingEntity.java
@@ -3,6 +3,7 @@ package org.bukkit.entity;
 import java.util.HashSet;
 import java.util.List;
 
+import org.bukkit.EntityEffect;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 
@@ -204,5 +205,13 @@ public interface LivingEntity extends Entity {
      * @param ticks NoDamageTicks
      */
     public void setNoDamageTicks(int ticks);
+
+    /**
+     * Display an entity effect for this entity.
+     * @param effect The effect to send
+     * @param amplitude The strength of the effect. Can have different results depending on the effect
+     * @param duration How long, in ticks, to show this effect to clients.
+     */
+    public void addEntityEffect(EntityEffect effect, byte amplitude, short duration);
 
 }

--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -705,6 +705,20 @@ public abstract class Event implements Serializable {
         ENDERMAN_PLACE (Category.LIVING_ENTITY),
 
         /**
+         * Called when an entity effect is applied to a living entity
+         *
+         * @see org.bukkit.event.entity.EntityAddEffectEvent
+         */
+        ENTITY_ADD_EFECT(Category.LIVING_ENTITY),
+
+        /**
+         * Called when an entity effect is removed from a living entity
+         *
+         * @see org.bukkit.event.entity.EntityRemoveEffectEvent
+         */
+        ENTITY_REMOVE_EFFECT(Category.LIVING_ENTITY),
+
+        /**
          * WEATHER EVENTS
          */
 

--- a/src/main/java/org/bukkit/event/entity/EntityAddEffectEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityAddEffectEvent.java
@@ -1,0 +1,41 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.EntityEffect;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Cancellable;
+
+/**
+ * @author zml2008
+ */
+public class EntityAddEffectEvent extends EntityEvent implements Cancellable {
+    private final EntityEffect effect;
+    private byte amplitude;
+    private short duration;
+    private boolean cancelled = false;
+    public EntityAddEffectEvent(final Entity what, EntityEffect effect, byte amplitude, short duration) {
+        super(Type.ENTITY_ADD_EFECT, what);
+        this.effect = effect;
+        this.amplitude = amplitude;
+        this.duration = duration;
+    }
+
+    public EntityEffect getEffect() {
+        return effect;
+    }
+
+    public byte getAmplitude() {
+        return amplitude;
+    }
+
+    public short getDuration() {
+        return duration;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancelled;
+    }
+}

--- a/src/main/java/org/bukkit/event/entity/EntityListener.java
+++ b/src/main/java/org/bukkit/event/entity/EntityListener.java
@@ -148,4 +148,18 @@ public class EntityListener implements Listener {
      * @param event Relevant event details
      */
     public void onEndermanPlace(EndermanPlaceEvent event) {}
+
+    /**
+     * Called when an entity effect is applied to a living entity
+     *
+     * @param event Relevant event details
+     */
+    public void onEntityAddEffect(EntityAddEffectEvent event) {}
+
+    /**
+     * Called when an entity effect is removed from a living entity
+     *
+     * @param event Relevant event details
+     */
+    public void onEntityRemoveEffect(EntityRemoveEffectEvent event) {}
 }

--- a/src/main/java/org/bukkit/event/entity/EntityRemoveEffectEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityRemoveEffectEvent.java
@@ -1,0 +1,19 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.EntityEffect;
+import org.bukkit.entity.Entity;
+
+/**
+ * @author zml2008
+ */
+public class EntityRemoveEffectEvent extends EntityEvent {
+    private final EntityEffect effect;
+    public EntityRemoveEffectEvent(final Entity what, EntityEffect effect) {
+        super(Type.ENTITY_REMOVE_EFFECT, what);
+        this.effect = effect;
+    }
+
+    public EntityEffect getEffect() {
+        return effect;
+    }
+}

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -783,6 +783,20 @@ public class JavaPluginLoader implements PluginLoader {
                 }
             };
 
+        case ENTITY_ADD_EFECT:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((EntityListener) listener).onEntityAddEffect((EntityAddEffectEvent) event);
+                }
+            };
+
+        case ENTITY_REMOVE_EFFECT:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((EntityListener) listener).onEntityRemoveEffect((EntityRemoveEffectEvent) event);
+                }
+            };
+
         // Vehicle Events
         case VEHICLE_CREATE:
             return new EventExecutor() {


### PR DESCRIPTION
This allows adding of entity effects, adds events when entity effects (poisoning, regeneration, etc) are used which allows plugins to easily attach custom behaviors to effects.

CraftBukkit pull request: https://github.com/Bukkit/CraftBukkit/pull/477
