### PR TITLE
add new API for managing entity trackers

### DIFF
--- a/src/main/java/org/bukkit/entity/Entity.java
+++ b/src/main/java/org/bukkit/entity/Entity.java
@@ -7,6 +7,7 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.util.Vector;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -67,6 +68,13 @@ public interface Entity {
      * @return List<Entity> List of entities nearby
      */
     public List<org.bukkit.entity.Entity> getNearbyEntities(double x, double y, double z);
+
+    /**
+     * Returns the set of players tracking an entity
+     *
+     * @return Set<Player> Set of players tracking
+     */
+    public Set<Player> getTrackers();
 
     /**
      * Returns a unique id for this entity

--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -610,6 +610,12 @@ public abstract class Event implements Serializable {
          * @see org.bukkit.event.entity.EntityPortalEnterEvent
          */
         ENTITY_PORTAL_ENTER (Category.ENTITY),
+        /**
+         * Called when an entity should be tracked by a player
+         *
+         * @see org.bukkit.event.entity.EntityTrackEvent
+         */
+        ENTITY_TRACK (Category.ENTITY),
 
         /**
          * LIVING_ENTITY EVENTS

--- a/src/main/java/org/bukkit/event/entity/EntityListener.java
+++ b/src/main/java/org/bukkit/event/entity/EntityListener.java
@@ -85,6 +85,13 @@ public class EntityListener implements Listener {
     public void onEntityPortalEnter(EntityPortalEnterEvent event) {}
 
     /**
+     * Called when an entity should be tracked by a player
+     *
+     * @param event Relevant event details
+     */
+    public void onEntityTrack(EntityTrackEvent event) {}
+
+    /**
      * Called when a painting is placed
      *
      * @param event Relevant event details

--- a/src/main/java/org/bukkit/event/entity/EntityTrackEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityTrackEvent.java
@@ -1,0 +1,35 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+
+/**
+ * Called when a player should start tracking an entity
+ */
+public class EntityTrackEvent extends EntityEvent implements Cancellable {
+    private boolean cancel;
+    private Player tracker;
+
+    public EntityTrackEvent(Entity entity, Player tracker) {
+        super(Type.ENTITY_TRACK, entity);
+        this.tracker = tracker;
+        this.cancel = false;
+    }
+
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+
+    /**
+     * Returns the player tracking the entity
+     */
+    public Player getTracker() {
+        return tracker;
+    }
+
+}

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -734,6 +734,13 @@ public class JavaPluginLoader implements PluginLoader {
                 }
             };
 
+        case ENTITY_TRACK:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((EntityListener) listener).onEntityTrack((EntityTrackEvent) event);
+                }
+            };
+
         case CREATURE_SPAWN:
             return new EventExecutor() {
                 public void execute(Listener listener, Event event) {


### PR DESCRIPTION
This allows vanish plugins to completely hide players and can be used to hide
a player from any entity.
