### PR TITLE
addition of PlayerChangedWorldEvent

### DIFF
--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -313,6 +313,13 @@ public abstract class Event implements Serializable {
         PLAYER_GAME_MODE_CHANGE(Category.PLAYER),
 
         /**
+         * Called after a player has changed to a new world
+         * 
+         * @see org.bukkit.event.player.PlayerChangedWorldEvent
+         */
+        PLAYER_CHANGED_WORLD(Category.PLAYER),
+
+        /**
          * BLOCK EVENTS
          */
 

--- a/src/main/java/org/bukkit/event/player/PlayerChangedWorldEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerChangedWorldEvent.java
@@ -1,0 +1,18 @@
+package org.bukkit.event.player;
+
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+
+public class PlayerChangedWorldEvent extends PlayerEvent {
+
+    private final World from;
+
+    public PlayerChangedWorldEvent(Player player, World from) {
+        super(Type.PLAYER_CHANGED_WORLD, player);
+        this.from = from;
+    }
+
+    public World getFrom() {
+        return from;
+    }
+}

--- a/src/main/java/org/bukkit/event/player/PlayerListener.java
+++ b/src/main/java/org/bukkit/event/player/PlayerListener.java
@@ -205,4 +205,11 @@ public class PlayerListener implements Listener {
      * @param event Relevant event details
      */
     public void onPlayerGameModeChange(PlayerGameModeChangeEvent event) {}
+
+    /**
+     * Called after a player changes to a new world
+     * 
+     * @param event Relevant event details
+     */
+    public void onPlayerChangedWorld(PlayerChangedWorldEvent event) {}
 }

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -434,6 +434,13 @@ public class JavaPluginLoader implements PluginLoader {
                 }
             };
 
+        case PLAYER_CHANGED_WORLD:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((PlayerListener) listener).onPlayerChangedWorld((PlayerChangedWorldEvent) event);
+                }
+            };
+
         // Block Events
         case BLOCK_PHYSICS:
             return new EventExecutor() {


### PR DESCRIPTION
There is currently no way to follow up on a player changing into a different world without using a scheduled task following either a PlayerTeleportEvent or a PlayerPortalEvent. This commit adds a PlayerChangedWorldEvent that allows a plugin to act after the transition to the new world is completed. This is particularly important since no permission information is available prior to the actual change to the new world.

Implemented in https://github.com/Bukkit/CraftBukkit/pull/489
