### PR TITLE
Added PlayerLevelChangeEvent and Player addExperience functions

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -37,7 +37,7 @@ public interface Player extends HumanEntity, CommandSender, OfflinePlayer {
      * @param name The new display name.
      */
     public void setDisplayName(String name);
-    
+
     /**
      * Gets the name that is shown on the player list.
      *
@@ -350,6 +350,13 @@ public interface Player extends HumanEntity, CommandSender, OfflinePlayer {
      * @param exp New experience points
      */
     public void setExperience(int exp);
+
+    /**
+     * Adds to the players current experience points
+     *
+     * @param exp Experience points to add to player
+     */
+    public void addExperience(int exp);
 
     /**
      * Gets the players current experience level

--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -318,6 +318,13 @@ public abstract class Event implements Serializable {
          * @see org.bukkit.event.player.PlayerChangedWorldEvent
          */
         PLAYER_CHANGED_WORLD(Category.PLAYER),
+        
+        /**
+         * Called when a player's level is changed
+         *
+         * @see org.bukkit.event.player.PlayerLevelChangeEvent
+         */
+        PLAYER_LEVEL_CHANGE (Category.PLAYER),
 
         /**
          * BLOCK EVENTS

--- a/src/main/java/org/bukkit/event/player/PlayerLevelChangeEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerLevelChangeEvent.java
@@ -1,0 +1,22 @@
+package org.bukkit.event.player;
+
+import org.bukkit.entity.Player;
+
+public class PlayerLevelChangeEvent extends PlayerEvent {
+    private final int oldLevel;
+    private final int newLevel;
+
+    public PlayerLevelChangeEvent(Player player, int oldLevel, int newLevel) {
+        super(Type.PLAYER_LEVEL_CHANGE, player);
+        this.oldLevel = oldLevel;
+        this.newLevel = newLevel;
+    }
+
+    public int getOldLevel() {
+        return oldLevel;
+    }
+
+    public int getNewLevel() {
+        return newLevel;
+    }
+}

--- a/src/main/java/org/bukkit/event/player/PlayerListener.java
+++ b/src/main/java/org/bukkit/event/player/PlayerListener.java
@@ -1,6 +1,7 @@
 package org.bukkit.event.player;
 
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
 
 /**
  * Handles all events thrown in relation to a Player
@@ -65,7 +66,6 @@ public class PlayerListener implements Listener {
      * @param event Relevant event details
      */
     public void onPlayerTeleport(PlayerTeleportEvent event) {}
-
     /**
      * Called when a player respawns
      *
@@ -212,4 +212,11 @@ public class PlayerListener implements Listener {
      * @param event Relevant event details
      */
     public void onPlayerChangedWorld(PlayerChangedWorldEvent event) {}
+    
+    /**
+     * Called when player's level is changed
+     *
+     * @param event Relevant event details
+     */
+    public void onPlayerLevelChange(PlayerLevelChangeEvent event) {}
 }

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -440,6 +440,13 @@ public class JavaPluginLoader implements PluginLoader {
                     ((PlayerListener) listener).onPlayerChangedWorld((PlayerChangedWorldEvent) event);
                 }
             };
+        
+        case PLAYER_LEVEL_CHANGE:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((PlayerListener) listener).onPlayerLevelChange((PlayerLevelChangeEvent) event);
+                }
+            };
 
         // Block Events
         case BLOCK_PHYSICS:


### PR DESCRIPTION
Player setExperience now correctly sets experience.

setTotalExperience and setLevel should be Deprecated. (I will add that if necessary)

Craftbukkit Pull: https://github.com/Bukkit/CraftBukkit/pull/494
