### PR TITLE
Added PlayerLevelChange event and Player Experience Methods.

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -345,11 +345,25 @@ public interface Player extends HumanEntity, CommandSender, OfflinePlayer {
     public int getExperience();
 
     /**
-     * Sets the players current experience points
+     * Sets the players current experience, level, and total experience
      *
      * @param exp New experience points
      */
     public void setExperience(int exp);
+
+    /**
+     * Adds to the players current experience points, must be higher than 0
+     *
+     * @param exp Experience points to add to player
+     */
+    public void addExperience(int exp);
+
+    /**
+     * Removes from the players current experience points, must be higher than 0
+     *
+     * @param exp Experience points to add to player
+     */
+    public void removeExperience(int exp);
 
     /**
      * Gets the players current experience level
@@ -361,8 +375,9 @@ public interface Player extends HumanEntity, CommandSender, OfflinePlayer {
     /**
      * Sets the players current experience level
      *
-     * @param level New experience level
+     * @deprecated Use setExperience
      */
+    @Deprecated
     public void setLevel(int level);
 
     /**
@@ -375,8 +390,9 @@ public interface Player extends HumanEntity, CommandSender, OfflinePlayer {
     /**
      * Sets the players current experience level
      *
-     * @param exp New experience level
+     * @deprecated Use setExperience
      */
+    @Deprecated
     public void setTotalExperience(int exp);
 
     /**

--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -318,6 +318,13 @@ public abstract class Event implements Serializable {
          * @see org.bukkit.event.player.PlayerChangedWorldEvent
          */
         PLAYER_CHANGED_WORLD(Category.PLAYER),
+        
+        /**
+         * Called when a player's level is changed
+         *
+         * @see org.bukkit.event.player.PlayerLevelChangeEvent
+         */
+        PLAYER_LEVEL_CHANGE (Category.PLAYER),
 
         /**
          * BLOCK EVENTS

--- a/src/main/java/org/bukkit/event/player/PlayerLevelChangeEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerLevelChangeEvent.java
@@ -1,0 +1,22 @@
+package org.bukkit.event.player;
+
+import org.bukkit.entity.Player;
+
+public class PlayerLevelChangeEvent extends PlayerEvent {
+    private final int oldLevel;
+    private final int newLevel;
+
+    public PlayerLevelChangeEvent(Player player, int oldLevel, int newLevel) {
+        super(Type.PLAYER_LEVEL_CHANGE, player);
+        this.oldLevel = oldLevel;
+        this.newLevel = newLevel;
+    }
+
+    public int getOldLevel() {
+        return oldLevel;
+    }
+
+    public int getNewLevel() {
+        return newLevel;
+    }
+}

--- a/src/main/java/org/bukkit/event/player/PlayerListener.java
+++ b/src/main/java/org/bukkit/event/player/PlayerListener.java
@@ -212,4 +212,11 @@ public class PlayerListener implements Listener {
      * @param event Relevant event details
      */
     public void onPlayerChangedWorld(PlayerChangedWorldEvent event) {}
+    
+    /**
+     * Called when player's level is changed
+     *
+     * @param event Relevant event details
+     */
+    public void onPlayerLevelChange(PlayerLevelChangeEvent event) {}
 }

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -441,6 +441,13 @@ public class JavaPluginLoader implements PluginLoader {
                 }
             };
 
+        case PLAYER_LEVEL_CHANGE:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((PlayerListener) listener).onPlayerLevelChange((PlayerLevelChangeEvent) event);
+                }
+            };
+
         // Block Events
         case BLOCK_PHYSICS:
             return new EventExecutor() {


### PR DESCRIPTION
Added PlayerLevelChange event, called when player level is different. Passes old and new levels.

Changed setExperience to correctly set experience, total experience, and level. Sets exp to 0 if negative value passed.

Added addExperience, adds experience normally (if exp > 0)

Added removeExperience, removes experience from total, passes to "setExperience." (if exp > 0)

Deprecated setLevel and setTotalExperience in favor of setExperience.

For those of you that don't like to read the changes, or know how experience works.

CB: https://github.com/Bukkit/CraftBukkit/pull/495
