### PR TITLE
A secondary constructor to allow a custom DumperOptions.

### DIFF
--- a/src/main/java/org/bukkit/util/config/Configuration.java
+++ b/src/main/java/org/bukkit/util/config/Configuration.java
@@ -70,6 +70,14 @@ public class Configuration extends ConfigurationNode {
 
         this.file = file;
     }
+    
+    public Configuration(File file, DumperOptions options) {
+        super(new HashMap<String, Object>());
+
+        yaml = new Yaml(new SafeConstructor(), new EmptyNullRepresenter(), options);
+
+        this.file = file;
+    }
 
     /**
      * Loads the configuration file. All errors are thrown away.


### PR DESCRIPTION
A secondary constructor to allow a custom DumperOptions. Use Case: set a custom width to prevent wrap around with string nodes longer than 80 characters. It's use case is a chat format line.

http://leaky.bukkit.org/issues/1627
