### PR TITLE
Methods to apply exhaustion on your own

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -461,6 +461,20 @@ public interface Player extends HumanEntity, CommandSender, OfflinePlayer {
     public void setFoodLevel(int value);
 
     /**
+     * Exhausts a specific level. For example walking a distance of 100 blocks would have an exhaustion of 1.
+     * 
+     * @param exhaustion The added exhaustion.
+     */
+    public void exhaust(float exhaustion);
+
+    /**
+     * Returns the total exhaustion the player have.
+     * 
+     * @return Total exhaustion.
+     */
+    public float getTotalExhaustion();
+
+    /**
      * Gets the Location where the player will spawn at their bed, null if they have not slept in one or their current bed spawn is invalid.
      *
      * @return Bed Spawn Location if bed exists, otherwise null.

--- a/src/main/java/org/bukkit/event/entity/AllFoodLevelsChangeEvent.java
+++ b/src/main/java/org/bukkit/event/entity/AllFoodLevelsChangeEvent.java
@@ -1,0 +1,54 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.util.Util;
+
+public class AllFoodLevelsChangeEvent extends FoodLevelChangeEvent {
+
+    private float saturationLevel;
+    private float exhaustionLevel;
+
+    public AllFoodLevelsChangeEvent(Entity what, int foodLevel, float saturationLevel, float exhaustionLevel) {
+        super(what, foodLevel);
+        this.setSaturationLevel(saturationLevel);
+        this.setExhaustionLevel(exhaustionLevel);
+    }
+
+    /**
+     * <p>Gets the resultant saturation level that the entity involved in this event should be set to.</p>
+     * <p>Where 20 is a fully saturated and 0 is causing the food level to drain.</p>
+     *
+     * @return The saturation food level
+     */
+    public float getSaturationLevel() {
+        return saturationLevel;
+    }
+
+    /**
+     * Sets the resultant food level that the entity involved in this event should be set to.
+     *
+     * @param level the resultant food level that the entity involved in this event should be set to.
+     */
+    public void setSaturationLevel(float saturationLevel) {
+        this.saturationLevel = Util.between(saturationLevel, 0F, 20F);
+    }
+
+    /**
+     * <p>Gets the resultant exhaustion level that the entity involved in this event should be set to.</p>
+     * <p>If the exhaustion level is greater than 4 it will decrease the saturation by 1 and the exhaustion by 4 each tick.</p>
+     *
+     * @return The saturation food level
+     */
+    public float getExhaustionLevel() {
+        return exhaustionLevel;
+    }
+
+    /**
+     * Sets the resultant exhaustion level that the entity involved in this event should be set to.
+     *
+     * @param level the resultant exhaustion level that the entity involved in this event should be set to.
+     */
+    public void setExhaustionLevel(float exhaustionLevel) {
+        this.exhaustionLevel = exhaustionLevel;
+    }
+}

--- a/src/main/java/org/bukkit/event/entity/FoodLevelChangeEvent.java
+++ b/src/main/java/org/bukkit/event/entity/FoodLevelChangeEvent.java
@@ -2,6 +2,7 @@ package org.bukkit.event.entity;
 
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Cancellable;
+import org.bukkit.util.Util;
 
 /**
  * Called when a human entity's food level changes
@@ -12,7 +13,7 @@ public class FoodLevelChangeEvent extends EntityEvent implements Cancellable {
 
     public FoodLevelChangeEvent(Entity what, int level) {
         super(Type.FOOD_LEVEL_CHANGE, what);
-        this.level = level;
+        this.setFoodLevel(level);
     }
 
     /**
@@ -32,10 +33,7 @@ public class FoodLevelChangeEvent extends EntityEvent implements Cancellable {
      * @param level the resultant food level that the entity involved in this event should be set to
      */
     public void setFoodLevel(int level) {
-        if (level > 20) level = 20;
-        else if (level < 0) level = 0;
-
-        this.level = level;
+        this.level = Util.between(level, 0, 20);
     }
 
     public boolean isCancelled() {

--- a/src/main/java/org/bukkit/util/Util.java
+++ b/src/main/java/org/bukkit/util/Util.java
@@ -1,0 +1,34 @@
+package org.bukkit.util;
+
+import java.util.Comparator;
+
+/**
+ * General utility class for Bukkit.
+ */
+public final class Util {
+
+    private Util() {}
+
+    /**
+     * Returns a value with the given boundary.
+     * @param value given value.
+     * @param min given minimum.
+     * @param max given maximum.
+     * @return a value greater equals the minimum and lower equals the maximum.
+     */
+    public static <T extends Comparable<T>> T between(T value, T min, T max) {
+        return value.compareTo(min) < 0 ? min : (value.compareTo(max) > 0 ? max : value);
+    }
+
+    /**
+     * Returns a value with the given boundary and comparator.
+     * @param value given value.
+     * @param min given minimum.
+     * @param max given maximum.
+     * @param comparator to compare the values.
+     * @return a value greater equals the minimum and lower equals the maximum.
+     */
+    public static <T> T between(T value, T min, T max, Comparator<T> comparator) {
+        return comparator.compare(value, min) < 0 ? min : (comparator.compare(value,max) > 0 ? max : value);
+    }
+}


### PR DESCRIPTION
I added two methods to player to handle the hunger stuff more smooth. For example if you want that users have to “pay” for a teleportation with hunger it is easily possible with both methods.

`Player.getTotalExhaustion()` gets the total exhaustion of a player. For example if the total exhaustion is 100 the player could walk 10 km and will then have no hunger level/saturation level left.

`Player.exhaust(float)` exhausts a specific value from the player. This method is very useful if you need to exhaust values larger than 4. Instead of changing the `exhaustion` field directly this will apply instantly. For example if you set exhaustion to 8 it will need two ticks to apply completely, because it will reduce the exhaustion only by 4 in each tick. `Player.exhaust(float)` instead will recalculate all values with one call and already on the next tick the player won't be healed/starve.

You could exhaust at maximum the value of getTotalExhaustion() but you will instantly starve.

Both could be done by outside of CraftBukkit, but then it is impossible to change the hunger behavior without breaking the plugins.

The corresponding CB pull request: https://github.com/Bukkit/CraftBukkit/pull/498

Fabian
