### PR TITLE
add EntityTrackEvent and Entity.setInvisible and Entity.isInvisible

### DIFF
--- a/src/main/java/org/bukkit/entity/Entity.java
+++ b/src/main/java/org/bukkit/entity/Entity.java
@@ -88,6 +88,18 @@ public interface Entity {
     public List<org.bukkit.entity.Entity> getNearbyEntities(double x, double y, double z);
 
     /**
+     * Checks if entity is invisible
+     *
+     * @return boolean visibility status
+     */
+    public boolean isInvisible();
+
+    /**
+     * Sets entity visibility status
+     */
+    public void setInvisible(boolean invisible);
+
+    /**
      * Returns a unique id for this entity
      *
      * @return Entity id

--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -622,6 +622,12 @@ public abstract class Event implements Serializable {
          * @see org.bukkit.event.entity.EntityPortalEnterEvent
          */
         ENTITY_PORTAL_ENTER (Category.ENTITY),
+        /**
+         * Called when an entity should be tracked by a player
+         *
+         * @see org.bukkit.event.entity.EntityTrackEvent
+         */
+        ENTITY_TRACK (Category.ENTITY),
 
         /**
          * LIVING_ENTITY EVENTS

--- a/src/main/java/org/bukkit/event/entity/EntityListener.java
+++ b/src/main/java/org/bukkit/event/entity/EntityListener.java
@@ -84,6 +84,13 @@ public class EntityListener implements Listener {
      */
     public void onEntityPortalEnter(EntityPortalEnterEvent event) {}
 
+     /**
+     * Called when an entity should be tracked by a player
+     *
+     * @param event Relevant event details
+     */
+    public void onEntityTrack(EntityTrackEvent event) {}
+
     /**
      * Called when a painting is placed
      *

--- a/src/main/java/org/bukkit/event/entity/EntityTrackEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityTrackEvent.java
@@ -1,0 +1,56 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+
+/**
+ * Called when a player should start tracking an entity
+ */
+public class EntityTrackEvent extends EntityEvent implements Cancellable {
+    private boolean cancel;
+    private boolean handled;
+    private Player tracker;
+
+    public EntityTrackEvent(Entity entity, Player tracker) {
+        super(Type.ENTITY_TRACK, entity);
+        this.tracker = tracker;
+        this.cancel = false;
+        this.handled = false;
+    }
+
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+
+    /**
+     * Checks if the event was handled by a plugin
+     * 
+     * @return boolean if event was handled
+     */
+    public boolean wasHandled() {
+        return handled;
+    }
+
+    /**
+     * Sets if the event is being handled by a plugin
+     * 
+     * @param handled If event is handled
+     */
+    public void setHandled(boolean handled) {
+        this.handled = handled;
+    }
+
+    /**
+     * Returns the player tracking the entity
+     * 
+     * @return Player the player tracking the entity
+     */
+    public Player getTracker() {
+        return tracker;
+    }
+}

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -761,6 +761,13 @@ public class JavaPluginLoader implements PluginLoader {
                 }
             };
 
+        case ENTITY_TRACK:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((EntityListener) listener).onEntityTrack((EntityTrackEvent) event);
+                }
+            };
+
         case CREATURE_SPAWN:
             return new EventExecutor() {
                 public void execute(Listener listener, Event event) {


### PR DESCRIPTION
This allows plugins to mark entities as invisible and hides them completely (no further packets sent about them).

A plugin can also handle the ENTITY_TRACK event to setup custom rules for what players can see what invisible entities.
