### PR TITLE
Make yamlOptions public so people can change DumperOptions. Use Case: Dum

### DIFF
--- a/src/main/java/org/bukkit/configuration/file/YamlConfiguration.java
+++ b/src/main/java/org/bukkit/configuration/file/YamlConfiguration.java
@@ -25,7 +25,7 @@ import org.yaml.snakeyaml.representer.Representer;
 public class YamlConfiguration extends FileConfiguration {
     protected static final String COMMENT_PREFIX = "# ";
     protected static final String BLANK_CONFIG = "{}\n";
-    private final DumperOptions yamlOptions = new DumperOptions();
+    public final DumperOptions yamlOptions = new DumperOptions();
     private final Representer yamlRepresenter = new Representer();
     private final Yaml yaml = new Yaml(new SafeConstructor(), yamlRepresenter, yamlOptions);
 


### PR DESCRIPTION
Make yamlOptions public so people can change DumperOptions. Use Case: DumperOptions.setWidth().

Why, oh why, did you guys think hiding everything behind a lame 'configoptions' class would cut it. >.<
http://leaky.bukkit.org/issues/1627

Option B:
Add a setLineWidth to your lame configoptions class, and call it on serialization.
