### PR TITLE
Fix stripColor

### DIFF
--- a/src/main/java/org/bukkit/ChatColor.java
+++ b/src/main/java/org/bukkit/ChatColor.java
@@ -115,7 +115,7 @@ public enum ChatColor {
             return null;
         }
 
-        return input.replaceAll("(?i)\u00A7[0-F]", "");
+        return input.replaceAll("(?i)\u00A7[0-9A-F]", "");
     }
 
     static {


### PR DESCRIPTION
This commit will fix the problem that "stripColor" removes more than it should, because it removes not only §0 §1 ... §9 and §A §B ... §F but also §: §; §< §= §> §? and §@

_description by Evenprime_
