### PR TITLE
Move getVehicle, leaveVehicle and isInsideVehicle from LivingEntity to Entity

### DIFF
--- a/src/main/java/org/bukkit/entity/Entity.java
+++ b/src/main/java/org/bukkit/entity/Entity.java
@@ -192,4 +192,28 @@ public interface Entity {
      * @param value Age of entity
      */
     public void setTicksLived(int value);
+
+    /**
+     * Returns whether this entity is inside a vehicle.
+     *
+     * @return True if the entity is in a vehicle.
+     */
+    public boolean isInsideVehicle();
+
+    /**
+     * Leave the current vehicle. If the entity is currently in a vehicle
+     * (and is removed from it), true will be returned, otherwise false will
+     * be returned.
+     *
+     * @return True if the entity was in a vehicle.
+     */
+    public boolean leaveVehicle();
+
+    /**
+     * Get the vehicle that this player is inside. If there is no vehicle,
+     * null will be returned.
+     *
+     * @return The current vehicle.
+     */
+    public Entity getVehicle();
 }

--- a/src/main/java/org/bukkit/entity/LivingEntity.java
+++ b/src/main/java/org/bukkit/entity/LivingEntity.java
@@ -96,30 +96,6 @@ public interface LivingEntity extends Entity {
     public Arrow shootArrow();
 
     /**
-     * Returns whether this entity is inside a vehicle.
-     *
-     * @return True if the entity is in a vehicle.
-     */
-    public boolean isInsideVehicle();
-
-    /**
-     * Leave the current vehicle. If the entity is currently in a vehicle
-     * (and is removed from it), true will be returned, otherwise false will
-     * be returned.
-     *
-     * @return True if the entity was in a vehicle.
-     */
-    public boolean leaveVehicle();
-
-    /**
-     * Get the vehicle that this player is inside. If there is no vehicle,
-     * null will be returned.
-     *
-     * @return The current vehicle.
-     */
-    public Vehicle getVehicle();
-
-    /**
      * Returns the amount of air that this entity has remaining, in ticks
      *
      * @return Amount of air remaining


### PR DESCRIPTION
notchcode supports non-Vehicle vehicles without any issue
get/setPassenger already work with any Entity

so why are these 3 still only working with living entities on vehicles?

See https://github.com/Bukkit/CraftBukkit/pull/516 for the accompanying CraftBukkit patch.

ticket: https://bukkit.atlassian.net/browse/BUKKIT-811
