### PR TITLE
Added a Metadata framework for Player.

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -1,6 +1,8 @@
 package org.bukkit.entity;
 
 import java.net.InetSocketAddress;
+import java.util.List;
+
 import org.bukkit.Achievement;
 import org.bukkit.ChatColor;
 import org.bukkit.Effect;
@@ -12,6 +14,8 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.Statistic;
 import org.bukkit.command.CommandSender;
 import org.bukkit.map.MapView;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.util.metadata.MetadataNode;
 
 /**
  * Represents a player, connected or not
@@ -434,4 +438,42 @@ public interface Player extends HumanEntity, CommandSender, OfflinePlayer {
      * @return Bed Spawn Location if bed exists, otherwise null.
      */
     public Location getBedSpawnLocation();
+    
+    /**
+     * Assigns a Metadata value to the player from the plugin. 
+     * <p>
+     * Each plugin can assign 1 instance of the same metadata key.
+     * If the same plugin assigns the same key again it will overwrite.
+     * 
+     * @param plugin Plugin instance.
+     * @param key The Metadata key used to store the metadata value
+     * @param value The Metadata value to be stored
+     */
+    public void setMetadata(Plugin plugin, String key, String value);
+    
+    /**
+     * Gets a List of the MetadataNodes assigned to this player.
+     * 
+     * @param key The key for Metadata wanted
+     * @return List of MetadataNode values, if none exists, should return empty list.
+     */
+    public List<MetadataNode> getMetadata(String key);
+    
+    /**
+     * Gets the single MetadataNode assigned to this player by a certain plugin.
+     * 
+     * @param key The key for Metadata wanted
+     * @param plugin a Plugin instance
+     * @return A single MetadataNode
+     */
+    public MetadataNode getMetadata(String key, Plugin plugin);
+    
+    /**
+     * Gets the single MetadataNode assigned to this player by a certain plugin specified by pluginname.
+     * 
+     * @param key The key for Metadata wanted
+     * @param plugin a Plugin name
+     * @return A single MetadataNode
+     */
+    public MetadataNode getMetadata(String key, String plugin); 
 }

--- a/src/main/java/org/bukkit/util/metadata/Metadata.java
+++ b/src/main/java/org/bukkit/util/metadata/Metadata.java
@@ -1,0 +1,88 @@
+package org.bukkit.util.metadata;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Represents a metadata collection
+ */
+public class Metadata {
+
+    private HashMap<String, MetadataGroup> meta;
+
+    public Metadata() {
+        meta = new HashMap<String, MetadataGroup>();
+    }
+
+    /**
+     * Assigns some metadata based on two keys, a plugin instance and a string key
+     * <p>
+     * If the same plugin assigns a metadata value to a key that already has been assigned by the plugin
+     * the former value will be overwriten.
+     * The same key can however be used by different plugins, they will be added to a internal list of values.
+     * 
+     * @param plugin The instance of the plugin calling this function
+     * @param key The key that the value should be stored under
+     * @param value The value of the metadata
+     */
+    public void setMetadata(Plugin plugin, String key, String value) {		
+        if(meta.containsKey(key)) {
+            meta.get(key).setMetadata(plugin,key,value);
+        } else {
+            MetadataGroup group = new MetadataGroup();
+            group.setMetadata(plugin,key,value);
+            meta.put(key, group);
+        }
+    }
+
+    /**
+     * Gets a list of MetadataNodes. Each node represents a metadata value assigned by a unique plugin.
+     * 
+     * @param key The metadata key to get the data.
+     * @return A List of MetaDataNode (Empty list of no values found)
+     */
+    public List<MetadataNode> getMetadata(String key) {
+        if(meta.containsKey(key)) {
+            MetadataGroup group = meta.get(key);
+            return group.getValues();
+        } else {
+            //Could also return null instead?
+            return new ArrayList<MetadataNode>();
+        }
+    }
+
+
+    /**
+     * Gets a single MetadataNode assigned by a specific plugin
+     * 
+     * @param key The metadata key
+     * @param plugin Instance of the specific plugin
+     * @return A MetadataNode object
+     */
+    public MetadataNode getMetadata(String key, Plugin plugin) {
+        if(meta.containsKey(key)) {
+            return meta.get(key).getValue(plugin);
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Gets a single MetadataNode assigned by a specific plugin (by plugin name)
+     * 
+     * @param key The metadata key
+     * @param plugin Name of the specific plugin
+     * @return A MetadataNode object
+     */
+    public MetadataNode getMetadata(String key, String plugin) {
+        Plugin plug = Bukkit.getServer().getPluginManager().getPlugin(plugin);
+        if(plug != null) { 
+            return getMetadata(key, plug);
+        }
+	    return null;
+    }
+}

--- a/src/main/java/org/bukkit/util/metadata/MetadataGroup.java
+++ b/src/main/java/org/bukkit/util/metadata/MetadataGroup.java
@@ -1,0 +1,57 @@
+package org.bukkit.util.metadata;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Represents a group of metadata from the same key, each entry is unique per plugin
+ */
+public class MetadataGroup {
+
+    private HashMap<Plugin, MetadataNode> map;
+
+    public MetadataGroup() {
+        map = new HashMap<Plugin, MetadataNode>();
+    }
+
+    /**
+     * Assigns the MetadataNode by either creating a new instance or overwriting the value of the already existing instance
+     * 
+     * @param plugin Instance of plugin that is used as key in the group
+     * @param key Metadata key
+     * @param value Metadata value to be assigned
+     */
+    public void setMetadata(Plugin plugin, String key, String value) {
+        if(map.containsKey(plugin)) {
+            map.get(plugin).setValue(value);
+        } else {
+            map.put(plugin, new MetadataNode(plugin,key,value));
+        }
+    }
+
+    /**
+     * Gets all MetadataNodes assigned to this group.
+     * 
+     * @return A List of MetadataNode
+     */
+    public List<MetadataNode> getValues() {
+        return new ArrayList<MetadataNode>(map.values());
+    }
+
+    /**
+     * Gets a specific MetadataNode assigned by a plugin from this group.
+     * 
+     * @param plugin Instance of plugin
+     * @return A single MetadataNode instance
+     */
+    public MetadataNode getValue(Plugin plugin) {
+        if(map.containsKey(plugin))	{
+            return map.get(plugin);
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/bukkit/util/metadata/MetadataNode.java
+++ b/src/main/java/org/bukkit/util/metadata/MetadataNode.java
@@ -1,0 +1,66 @@
+package org.bukkit.util.metadata;
+
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Represents a Metadata node
+ */
+public class MetadataNode {    	
+    private Plugin plugin;
+    private String key;
+    private Object value;
+    
+    /**
+     * Constructor creating the MetadataNode 
+     * 
+     * @param plugin Instance of plugin that created this metadata
+     * @param key The key the metadata is stored under
+     * @param value The value of this MetadataNode.
+     */
+    public MetadataNode(Plugin plugin, String key, String value)
+    {
+        this.plugin = plugin;
+        this.key = key;
+        this.value = value;
+    }
+    
+    /**
+     * Overwrite the assigned value
+     * @param value
+     */
+    protected void setValue(String value) {
+        this.value = value;
+    }
+    
+    /**
+     * Get the value of the MetadataNode
+     * @return Value
+     */
+    public Object getValue() {
+        return value;
+    }
+    
+    /**
+     * Get the key the MetadataNode
+     * @return Key
+     */
+    public String getKey() {
+        return key;
+    }
+    
+    /**
+     * Get the instance of the plugin that assigned this MetadataNode
+     * @return Instance of plugin
+     */
+    public Plugin getPlugin() {
+        return plugin;
+    }
+    
+    /**
+     * Get the name of the plugin that assigned this MetadataNode
+     * @return Name of plugin
+     */
+    public String getPluginName() {
+        return plugin.getDescription().getName();
+    }
+}


### PR DESCRIPTION
Consists of 3 classes: Metadata, MetadataGroup, MetadataNode

I tried implementing a Metadata framework that allows plugins to add additional metadata to a Player.
This can be used by e.g Permission Managers to assign a "group", "prefix" or similar additional data to the player.

Another plugin can then get this metadata easily without depending on a specific Permission Manager.
If a unofficial unwritten agreement is that group names will be assigned to a Metadata named "group" every plugin can use this information.

Every plugin can assign a metadata key/value, when a plugin assigns the same key/value again the value is overwriting the old value, this a plugin can only assign 1 value to a key.
HOWEVER I've implemented that each plugin can assign a key/value pair with the same key, it will just be added to a internal list/hashmap.

When asking for the Metadata, a list of metadata will be returned (if only 1 value is present only 1 value will be in the list), if multiple plugins have added metadata to the same key, e.g. "group", then the list will contain all the "group" metadata assigned by the plugins.
Plugins can then decide whether to just use one of the value or generate a delimited joined string of the values. E.g multiple groups could be joined to form "Group1/Group2/Group3" if 3 different plugins have assigned 3 different groups.
More work on this is probably need as the nodes are contained in a HashMap and will be returned in no particular order (Hashed order). Something like a level/priority property or FIFO queue would probably be needed, TreeMap?.

A metadata assigned by a specific plugin can also be requested either by the Plugin instance or by plugin name.

I am only using groups as an example because many people can relate to this, but there are MANY more uses of this.

I was thinking whether it would be useful to move this "up the tree", so instead of just allowing metadata on Player, move it to HumanEntity or maybe even all the way up to Entity allow metadata on ALL entities. But I'd like to take this discussion first.

I am not sure my implementation is absolutely perfect, but I'm hoping for some response and a little discussion about this subject, hopefully this could catch on. It would probably also need access methods such as getString, getBoolean, getInt and the likes. Currently it is only implemented as getValue, which returns a object.

Setting a Metadata example:
player.setMetadata(plugin, "key", "value");

Getting Metadata examples (4 examples, so BukkitDev paste'd it):
http://dev.bukkit.org/paste/4153/

Forum thread discussing the matter about Permissions/Metadata: 
http://forums.bukkit.org/threads/idea-design-a-better-permissions-plugin.42131/

Corresponding CraftBukkit Pull Request: 
https://github.com/Bukkit/CraftBukkit/pull/517
