### PR TITLE
Added a Metadata framework for Entities, Blocks, and Worlds

### DIFF
--- a/src/main/java/org/bukkit/OfflinePlayer.java
+++ b/src/main/java/org/bukkit/OfflinePlayer.java
@@ -3,9 +3,10 @@ package org.bukkit;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.entity.AnimalTamer;
 import org.bukkit.entity.Player;
+import org.bukkit.metadata.Metadatable;
 import org.bukkit.permissions.ServerOperator;
 
-public interface OfflinePlayer extends ServerOperator, AnimalTamer, ConfigurationSerializable {
+public interface OfflinePlayer extends ServerOperator, AnimalTamer, ConfigurationSerializable, Metadatable {
     /**
      * Checks if this player is currently online
      *

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -18,6 +18,8 @@ import org.bukkit.command.PluginCommand;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.map.MapView;
+import org.bukkit.metadata.BlockMetadataStore;
+import org.bukkit.metadata.EntityMetadataStore;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.ServicesManager;
 import org.bukkit.scheduler.BukkitScheduler;
@@ -504,4 +506,10 @@ public interface Server {
      * @return The Console CommandSender
      */
     public ConsoleCommandSender getConsoleSender();
+
+    /**
+     * Gets the {@link EntityMetadataStore} that can be used to find all metatadata for all entities, including players.
+     * @return
+     */
+    public EntityMetadataStore getEntityMetadata();
 }

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -11,6 +11,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.*;
 import org.bukkit.generator.BlockPopulator;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.metadata.BlockMetadataStore;
 import org.bukkit.util.Vector;
 
 /**
@@ -738,6 +739,12 @@ public interface World {
      * @return The difficulty of the world.
      */
     public Difficulty getDifficulty();
+
+        /**
+     * Gets the {@link BlockMetadataStore} that can be used to find all metatadata for all blocks in this world.
+     * @return
+     */
+    public BlockMetadataStore getBlockMetadata();
 
     /**
      * Represents various map environment types that a world may be

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -12,12 +12,13 @@ import org.bukkit.entity.*;
 import org.bukkit.generator.BlockPopulator;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.BlockMetadataStore;
+import org.bukkit.metadata.Metadatable;
 import org.bukkit.util.Vector;
 
 /**
  * Represents a world, which may contain entities, chunks and blocks
  */
-public interface World {
+public interface World extends Metadatable{
 
     /**
      * Gets the {@link Block} at the given coordinates

--- a/src/main/java/org/bukkit/block/Block.java
+++ b/src/main/java/org/bukkit/block/Block.java
@@ -4,6 +4,7 @@ import org.bukkit.Chunk;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.Location;
+import org.bukkit.metadata.Metadatable;
 
 /**
  * Represents a block. This is a live object, and only one Block may exist for
@@ -11,7 +12,7 @@ import org.bukkit.Location;
  * to your own handling of it; use block.getState() to get a snapshot state of a
  * block which will not be modified.
  */
-public interface Block {
+public interface Block extends Metadatable {
 
     /**
      * Gets the metadata for this block

--- a/src/main/java/org/bukkit/block/BlockState.java
+++ b/src/main/java/org/bukkit/block/BlockState.java
@@ -4,6 +4,7 @@ import org.bukkit.Chunk;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.material.MaterialData;
+import org.bukkit.metadata.Metadatable;
 
 /**
  * Represents a captured state of a block, which will not change automatically.
@@ -13,7 +14,7 @@ import org.bukkit.material.MaterialData;
  * the state of the block and you will not know, or they may change the block to
  * another type entirely, causing your BlockState to become invalid.
  */
-public interface BlockState {
+public interface BlockState extends Metadatable{
 
     /**
      * Gets the block represented by this BlockState

--- a/src/main/java/org/bukkit/entity/Entity.java
+++ b/src/main/java/org/bukkit/entity/Entity.java
@@ -4,6 +4,7 @@ import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.World;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.metadata.Metadatable;
 import org.bukkit.util.Vector;
 
 import java.util.List;
@@ -12,7 +13,7 @@ import java.util.UUID;
 /**
  * Represents a base entity in the world
  */
-public interface Entity {
+public interface Entity extends Metadatable{
 
     /**
      * Gets the entity's current position

--- a/src/main/java/org/bukkit/metadata/BlockMetadataStore.java
+++ b/src/main/java/org/bukkit/metadata/BlockMetadataStore.java
@@ -1,13 +1,60 @@
 package org.bukkit.metadata;
 
+import org.bukkit.World;
 import org.bukkit.block.Block;
+import org.bukkit.plugin.Plugin;
+
+import java.util.List;
 
 /**
  * A BlockMetadataStore stores metadata values for {@link Block} objects.
  */
 public class BlockMetadataStore extends MetadataStoreBase<Block> implements MetadataStore<Block> {
+
+    private World owningWorld;
+
+    public BlockMetadataStore(World owningWorld) {
+        this.owningWorld = owningWorld;
+    }
+
     @Override
     protected String Disambiguate(Block block, String metadataKey) {
         return Integer.toString(block.getX()) + ":" + Integer.toString(block.getY()) + ":"  + Integer.toString(block.getZ()) + ":"  + metadataKey;
+    }
+
+    @Override
+    public List<MetadataValue> getMetadata(Block block, String metadataKey) {
+        if(block.getWorld() == owningWorld) {
+            return super.getMetadata(block, metadataKey);
+        } else {
+            throw new IllegalArgumentException("Block does not belong to world " + owningWorld.getName());
+        }
+    }
+
+    @Override
+    public boolean hasMetadata(Block block, String metadataKey) {
+        if(block.getWorld() == owningWorld) {
+            return super.hasMetadata(block, metadataKey);
+        } else {
+            throw new IllegalArgumentException("Block does not belong to world " + owningWorld.getName());
+        }
+    }
+
+    @Override
+    public void removeMetadata(Block block, String metadataKey, Plugin owningPlugin) {
+        if(block.getWorld() == owningWorld) {
+            super.removeMetadata(block, metadataKey, owningPlugin);
+        } else {
+            throw new IllegalArgumentException("Block does not belong to world " + owningWorld.getName());
+        }
+    }
+
+    @Override
+    public void setMetadata(Block block, String metadataKey, MetadataValue newMetadataValue) {
+        if(block.getWorld() == owningWorld) {
+            super.setMetadata(block, metadataKey, newMetadataValue);
+        } else {
+            throw new IllegalArgumentException("Block does not belong to world " + owningWorld.getName());
+        }
     }
 }

--- a/src/main/java/org/bukkit/metadata/BlockMetadataStore.java
+++ b/src/main/java/org/bukkit/metadata/BlockMetadataStore.java
@@ -1,0 +1,13 @@
+package org.bukkit.metadata;
+
+import org.bukkit.block.Block;
+
+/**
+ * A BlockMetadataStore stores metadata values for {@link Block} objects.
+ */
+public class BlockMetadataStore extends MetadataStoreBase<Block> implements MetadataStore<Block> {
+    @Override
+    protected String Disambiguate(Block block, String metadataKey) {
+        return Integer.toString(block.getX()) + ":" + Integer.toString(block.getY()) + ":"  + Integer.toString(block.getZ()) + ":"  + metadataKey;
+    }
+}

--- a/src/main/java/org/bukkit/metadata/BlockMetadataStore.java
+++ b/src/main/java/org/bukkit/metadata/BlockMetadataStore.java
@@ -13,15 +13,34 @@ public class BlockMetadataStore extends MetadataStoreBase<Block> implements Meta
 
     private World owningWorld;
 
+    /**
+     * Initializes a BlockMetadataStore.
+     * @param owningWorld The world to which this BlockMetadataStore belongs.
+     */
     public BlockMetadataStore(World owningWorld) {
         this.owningWorld = owningWorld;
     }
 
+    /**
+     * Generates a unique metadata key for a {@link Block} object based on its coordinates in the world.
+     * @see MetadataStoreBase#Disambiguate(Object, String)
+     * @param block
+     * @param metadataKey
+     * @return
+     */
     @Override
     protected String Disambiguate(Block block, String metadataKey) {
         return Integer.toString(block.getX()) + ":" + Integer.toString(block.getY()) + ":"  + Integer.toString(block.getZ()) + ":"  + metadataKey;
     }
 
+    /**
+     * Retrieves the metadata for a {@link Block}, ensuring the block being asked for actually belongs to this BlockMetadataStore's
+     * owning world.
+     * @see MetadataStoreBase#getMetadata(Object, String)
+     * @param block
+     * @param metadataKey
+     * @return
+     */
     @Override
     public List<MetadataValue> getMetadata(Block block, String metadataKey) {
         if(block.getWorld() == owningWorld) {
@@ -31,6 +50,14 @@ public class BlockMetadataStore extends MetadataStoreBase<Block> implements Meta
         }
     }
 
+    /**
+     * Tests to see if a metadata value has been added to a {@link Block}, ensuring the block being interrogated belongs
+     * to this BlockMetadataStore's owning world.
+     * @see MetadataStoreBase#hasMetadata(Object, String)
+     * @param block
+     * @param metadataKey
+     * @return
+     */
     @Override
     public boolean hasMetadata(Block block, String metadataKey) {
         if(block.getWorld() == owningWorld) {
@@ -40,6 +67,14 @@ public class BlockMetadataStore extends MetadataStoreBase<Block> implements Meta
         }
     }
 
+    /**
+     * Removes metadata from from a {@link Block} belonging to a given {@link Plugin}, ensuring the block being deleted from belongs
+     * to this BlockMetadataStore's owning world.
+     * @see MetadataStoreBase#removeMetadata(Object, String, org.bukkit.plugin.Plugin)
+     * @param block
+     * @param metadataKey
+     * @param owningPlugin
+     */
     @Override
     public void removeMetadata(Block block, String metadataKey, Plugin owningPlugin) {
         if(block.getWorld() == owningWorld) {
@@ -49,6 +84,13 @@ public class BlockMetadataStore extends MetadataStoreBase<Block> implements Meta
         }
     }
 
+    /**
+     * Sets or overwrites a metadata value on a {@link Block} from a given {@link Plugin}, ensuring the target block belongs
+     * to this BlockMetadataStore's owning world.
+     * @param block
+     * @param metadataKey A unique key to identify this metadata.
+     * @param newMetadataValue
+     */
     @Override
     public void setMetadata(Block block, String metadataKey, MetadataValue newMetadataValue) {
         if(block.getWorld() == owningWorld) {

--- a/src/main/java/org/bukkit/metadata/EntityMetadataStore.java
+++ b/src/main/java/org/bukkit/metadata/EntityMetadataStore.java
@@ -7,13 +7,15 @@ import org.bukkit.entity.Player;
  * An EntityMetadataStore stores metadata values for all {@link Entity} classes an their descendants.
  */
 public class EntityMetadataStore extends MetadataStoreBase<Entity> implements MetadataStore<Entity> {
+    /**
+     * Generates a unique metadata key for an {@link Entity} entity ID.
+     * @see MetadataStoreBase#Disambiguate(Object, String)
+     * @param entity
+     * @param metadataKey
+     * @return
+     */
     @Override
     protected String Disambiguate(Entity entity, String metadataKey) {
-        if(entity instanceof Player) {
-            Player p = (Player) entity;
-            return p.getName() + ":" + metadataKey;
-        } else {
-            return Integer.toString(entity.getEntityId()) + ":" + metadataKey;
-        }
+        return Integer.toString(entity.getEntityId()) + ":" + metadataKey;
     }
 }

--- a/src/main/java/org/bukkit/metadata/EntityMetadataStore.java
+++ b/src/main/java/org/bukkit/metadata/EntityMetadataStore.java
@@ -1,0 +1,19 @@
+package org.bukkit.metadata;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+
+/**
+ * An EntityMetadataStore stores metadata values for all {@link Entity} classes an their descendants.
+ */
+public class EntityMetadataStore extends MetadataStoreBase<Entity> implements MetadataStore<Entity> {
+    @Override
+    protected String Disambiguate(Entity entity, String metadataKey) {
+        if(entity instanceof Player) {
+            Player p = (Player) entity;
+            return p.getName() + ":" + metadataKey;
+        } else {
+            return Integer.toString(entity.getEntityId()) + ":" + metadataKey;
+        }
+    }
+}

--- a/src/main/java/org/bukkit/metadata/FixedMetadataValue.java
+++ b/src/main/java/org/bukkit/metadata/FixedMetadataValue.java
@@ -1,0 +1,63 @@
+package org.bukkit.metadata;
+
+import org.bukkit.plugin.Plugin;
+
+import java.util.concurrent.Callable;
+
+/**
+ * A FixedMetadataValue is a special case metadata item that contains the same value forever after initialization.
+ * Invalidating a FixedMetadataValue has no affect.
+ */
+public class FixedMetadataValue extends LazyMetadataValue{
+    /**
+     * Initializes a FixedMetadataValue as an int
+     * @param owningPlugin
+     * @param value
+     */
+    public FixedMetadataValue(Plugin owningPlugin, final int value) {
+        super(owningPlugin, CacheStrategy.CACHE_ETERNALLY, new Callable<Object>() {
+            public Object call() throws Exception {
+                return value;
+            }
+        });
+    }
+
+    /**
+     * Initializes a FixedMetadataValue as a boolean
+     * @param owningPlugin
+     * @param value
+     */
+    public FixedMetadataValue(Plugin owningPlugin, final boolean value) {
+        super(owningPlugin, CacheStrategy.CACHE_ETERNALLY, new Callable<Object>() {
+            public Object call() throws Exception {
+                return value;
+            }
+        });
+    }
+
+    /**
+     * Initializes a FixedMetadataValue as a double
+     * @param owningPlugin
+     * @param value
+     */
+    public FixedMetadataValue(Plugin owningPlugin, final double value) {
+        super(owningPlugin, CacheStrategy.CACHE_ETERNALLY, new Callable<Object>() {
+            public Object call() throws Exception {
+                return value;
+            }
+        });
+    }
+
+    /**
+     * Initializes a FixedMetadataValue as a string
+     * @param owningPlugin
+     * @param value
+     */
+    public FixedMetadataValue(Plugin owningPlugin, final String value) {
+        super(owningPlugin, CacheStrategy.CACHE_ETERNALLY, new Callable<Object>() {
+            public Object call() throws Exception {
+                return value;
+            }
+        });
+    }
+}

--- a/src/main/java/org/bukkit/metadata/LazyMetadataValue.java
+++ b/src/main/java/org/bukkit/metadata/LazyMetadataValue.java
@@ -123,9 +123,23 @@ public class LazyMetadataValue implements MetadataValue {
         }
     }
 
+    /**
+     * Describes possible caching strategies for metadata.
+     */
     public enum CacheStrategy {
+        /**
+         * Once the metadata value has been evaluated, do not re-evaluate the value until it is manually invalidated.
+         */
         CACHE_AFTER_FIRST_EVAL,
+
+        /**
+         * Re-evaluate the metadata item every time it is requested
+         */
         NEVER_CACHE,
+
+        /**
+         * Once the metadata value has been evaluated, do not re-evaluate the value in spite of manual invalidation.
+         */
         CACHE_ETERNALLY
     }
 }

--- a/src/main/java/org/bukkit/metadata/LazyMetadataValue.java
+++ b/src/main/java/org/bukkit/metadata/LazyMetadataValue.java
@@ -1,0 +1,131 @@
+package org.bukkit.metadata;
+
+import org.bukkit.plugin.Plugin;
+
+import java.util.concurrent.Callable;
+
+/**
+ * The LazyMetadataValue class implements a type of metadata that is not computed until another plugin asks for it.
+ * By making metadata values lazy, no computation is done by the providing plugin until absolutely necessary (if ever).
+ * Additionally, LazyMetadataValue objects cache their values internally unless overridden by a {@link CacheStrategy}
+ * or invalidated at the individual or plugin level. Once invalidated, the LazyMetadataValue will recompute its value
+ * when asked.
+ */
+public class LazyMetadataValue implements MetadataValue {
+    private Callable<Object> lazyValue;
+    private CacheStrategy cacheStrategy;
+    private String internalValue;
+    private boolean internalValueEvaluated;
+    private Plugin owningPlugin;
+
+    /**
+     * Initialized a LazyMetadataValue object with the default CACHE_AFTER_FIRST_EVAL cache strategy.
+     * @param owningPlugin
+     * @param lazyValue
+     */
+    public LazyMetadataValue(Plugin owningPlugin, Callable<Object> lazyValue) {
+        this(owningPlugin, CacheStrategy.CACHE_AFTER_FIRST_EVAL, lazyValue);
+    }
+
+    /**
+     * Initializes a LazyMetadataValue object with a specific cache strategy.
+     * @param owningPlugin
+     * @param cacheStrategy
+     * @param lazyValue
+     */
+    public LazyMetadataValue(Plugin owningPlugin, CacheStrategy cacheStrategy, Callable<Object> lazyValue) {
+        this.lazyValue = lazyValue;
+        this.owningPlugin = owningPlugin;
+        this.cacheStrategy = cacheStrategy;
+        internalValueEvaluated = false;
+    }
+
+    /**
+     * Converts the metadata value into an int and returns it.
+     * @return
+     * @throws MetadataConversionException Thrown if the value cannot be converted to an int. Ex: String => int
+     */
+    public int asInt() throws MetadataConversionException {
+        try {
+            eval();
+            return Integer.parseInt(internalValue);
+        } catch (NumberFormatException e) {
+            throw new MetadataConversionException("Could not convert metadata value of " + internalValue + " to type int.");
+        }
+    }
+
+    /**
+     * Converts the metadata value into a double and returns it.
+     * @return
+     * @throws MetadataConversionException Thrown if the value cannot be converted to a double. Ex: String => double
+     */
+    public double asDouble() throws MetadataConversionException {
+        try {
+            eval();
+            return Double.parseDouble(internalValue);
+        } catch (NumberFormatException e) {
+            throw new MetadataConversionException("Could not convert metadata value of " + internalValue + " to type double.");
+        }
+    }
+
+     /**
+     * Converts the metadata value into a boolean and returns it.
+     * @return
+     * @throws MetadataConversionException Thrown if the value cannot be converted to a double. Ex: String => double
+     */
+    public boolean asBoolean() throws MetadataConversionException {
+        try {
+            eval();
+            return internalValue != null && (internalValue.equalsIgnoreCase("true") || internalValue.equalsIgnoreCase("1") || internalValue.equalsIgnoreCase("1.0"));
+        } catch (NumberFormatException e) {
+            throw new MetadataConversionException("Could not convert metadata value of " + internalValue + " to type double.");
+        }
+    }
+
+    /**
+     * Returns the metadata value as a string. This method will always succeed.
+     * @return
+     */
+    public String asString() {
+        eval();
+        return internalValue;
+    }
+
+    /**
+     * Returns the {@link Plugin} that created this metadata item.
+     * @return
+     */
+    public Plugin getOwningPlugin() {
+        return owningPlugin;
+    }
+
+    /**
+     * Lazially evaluates the value of this metadata item.
+     * @throws MetadataEvaluationException
+     */
+    private synchronized void eval() throws MetadataEvaluationException {
+        if(cacheStrategy == CacheStrategy.NEVER_CACHE || !internalValueEvaluated) {
+            try {
+                internalValue = lazyValue.call().toString();
+                internalValueEvaluated = true;
+            } catch (Exception e) {
+                throw new MetadataEvaluationException(e);
+            }
+        }
+    }
+
+    /**
+     * Invalidates this metadata item's value. The next time the value is requested it will be recomputed.
+     */
+    public synchronized void invalidate() {
+        if(cacheStrategy != CacheStrategy.CACHE_ETERNALLY) {
+            internalValueEvaluated = false;
+        }
+    }
+
+    public enum CacheStrategy {
+        CACHE_AFTER_FIRST_EVAL,
+        NEVER_CACHE,
+        CACHE_ETERNALLY
+    }
+}

--- a/src/main/java/org/bukkit/metadata/MetadataConversionException.java
+++ b/src/main/java/org/bukkit/metadata/MetadataConversionException.java
@@ -1,0 +1,11 @@
+package org.bukkit.metadata;
+
+/**
+ * A MetadataConversionException is thrown any time a {@link LazyMetadataValue} attempts to convert a metadata value
+ * to an inappropriate data type.
+ */
+public class MetadataConversionException extends RuntimeException {
+    MetadataConversionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/bukkit/metadata/MetadataEvaluationException.java
+++ b/src/main/java/org/bukkit/metadata/MetadataEvaluationException.java
@@ -1,0 +1,11 @@
+package org.bukkit.metadata;
+
+/**
+ * A MetadataEvaluationException is thrown any time a {@link LazyMetadataValue} fails to evaluate its value due to
+ * an exception. The originating exception will be included as this exception's cause.
+ */
+public class MetadataEvaluationException extends RuntimeException {
+    MetadataEvaluationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/org/bukkit/metadata/MetadataStore.java
+++ b/src/main/java/org/bukkit/metadata/MetadataStore.java
@@ -13,7 +13,7 @@ public interface MetadataStore <TSubject> {
      * @param metadataKey A unique key to identify this metadata.
      * @param newMetadataValue
      */
-    public void addMetadata(TSubject subject, String metadataKey, MetadataValue newMetadataValue);
+    public void setMetadata(TSubject subject, String metadataKey, MetadataValue newMetadataValue);
 
     /**
      * Returns all metadata values attached to an object. If multiple plugins have attached metadata, each will value
@@ -31,6 +31,14 @@ public interface MetadataStore <TSubject> {
      * @return
      */
     public boolean hasMetadata(TSubject subject, String metadataKey);
+
+    /**
+     * Removes a metadata item owned by a plugin from a subject.
+     * @param subject
+     * @param metadataKey
+     * @param owningPlugin
+     */
+    public void removeMetadata(TSubject subject, String metadataKey, Plugin owningPlugin);
 
     /**
      * Invalidates all metadata in the metadata store that originates from the given plugin. Doing this will force

--- a/src/main/java/org/bukkit/metadata/MetadataStore.java
+++ b/src/main/java/org/bukkit/metadata/MetadataStore.java
@@ -1,0 +1,41 @@
+package org.bukkit.metadata;
+
+import org.bukkit.plugin.Plugin;
+
+import java.util.List;
+
+/**
+ */
+public interface MetadataStore <TSubject> {
+    /**
+     * Adds a metadata value to an object.
+     * @param subject The object receiving the metadata.
+     * @param metadataKey A unique key to identify this metadata.
+     * @param newMetadataValue
+     */
+    public void addMetadata(TSubject subject, String metadataKey, MetadataValue newMetadataValue);
+
+    /**
+     * Returns all metadata values attached to an object. If multiple plugins have attached metadata, each will value
+     * will be included.
+     * @param subject
+     * @param metadataKey
+     * @return
+     */
+    public List<MetadataValue> getMetadata(TSubject subject, String metadataKey);
+
+    /**
+     * Tests to see if a metadata attribute has been set on an object.
+     * @param subject
+     * @param metadataKey
+     * @return
+     */
+    public boolean hasMetadata(TSubject subject, String metadataKey);
+
+    /**
+     * Invalidates all metadata in the metadata store that originates from the given plugin. Doing this will force
+     * each invalidated metadata item to be recalculated the next time it is accessed.
+     * @param owningPlugin
+     */
+    public void invalidateAll(Plugin owningPlugin);
+}

--- a/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
+++ b/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
@@ -11,8 +11,10 @@ public abstract class MetadataStoreBase<TSubject> {
     private Map<String, List<MetadataValue>> metadataMap = new HashMap<String, List<MetadataValue>>();
 
     /**
-     * Adds a metadata value to an object. If a plugin has already added a metadata value to an object, that value
-     * will be replaced with the value of {@code newMetadataValue}.
+     * Adds a metadata value to an object. Each metadata value is owned by a specific{@link Plugin}.
+     * If a plugin has already added a metadata value to an object, that value
+     * will be replaced with the value of {@code newMetadataValue}. Multiple plugins can set independent values for
+     * the same {@code metadataKey} without conflict.
      *
      * Implementation note: I considered using a {@link java.util.concurrent.locks.ReadWriteLock} for controlling
      * access to {@code metadataMap}, but decided that the added overhead wasn't worth the finer grained access control.
@@ -98,10 +100,12 @@ public abstract class MetadataStoreBase<TSubject> {
     }
 
     /**
-     * Creates a unique name for the object receiving metadata. Each concrete implementation of MetadataStoreBase
-     * must implement this method.
-     * @param subject
-     * @param metadataKey
+     * Creates a unique name for the object receiving metadata by combining unique data from the subject with a metadataKey.
+     * The name created must be globally unique for the given object and any two equivalent objects must generate the
+     * same unique name. For example, two Player objects must generate the same string if they represent the same player,
+     * even if the objects would fail a reference equality test.
+     * @param subject The object for which this key is being generated
+     * @param metadataKey The name identifying the metadata value
      * @return
      */
     protected abstract String Disambiguate(TSubject subject, String metadataKey);

--- a/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
+++ b/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
@@ -1,0 +1,77 @@
+package org.bukkit.metadata;
+
+import org.bukkit.plugin.Plugin;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class MetadataStoreBase<TSubject> {
+    private Map<String, List<MetadataValue>> metadataMap = new HashMap<String, List<MetadataValue>>();
+
+    /**
+     * Adds a metadata value to an object.
+     * @param subject The object receiving the metadata.
+     * @param metadataKey A unique key to identify this metadata.
+     * @param newMetadataValue
+     */
+    public synchronized void addMetadata(TSubject subject, String metadataKey, MetadataValue newMetadataValue) {
+        String key = Disambiguate(subject, metadataKey);
+        if(!metadataMap.containsKey(key)) {
+            metadataMap.put(key, new ArrayList<MetadataValue>());
+        }
+        metadataMap.get(key).add(newMetadataValue);
+    }
+
+    /**
+     * Returns all metadata values attached to an object. If multiple plugins have attached metadata, each will value
+     * will be included.
+     * @param subject
+     * @param metadataKey
+     * @return
+     */
+    public synchronized List<MetadataValue> getMetadata(TSubject subject, String metadataKey) {
+        String key = Disambiguate(subject, metadataKey);
+        if(metadataMap.containsKey(key)) {
+            return metadataMap.get(key);
+        } else {
+            return new ArrayList<MetadataValue>();
+        }
+    }
+
+    /**
+     * Tests to see if a metadata attribute has been set on an object.
+     * @param subject
+     * @param metadataKey
+     * @return
+     */
+    public boolean hasMetadata(TSubject subject, String metadataKey) {
+        String key = Disambiguate(subject, metadataKey);
+        return metadataMap.containsKey(key);
+    }
+
+    /**
+     * Invalidates all metadata in the metadata store that originates from the given plugin. Doing this will force
+     * each invalidated metadata item to be recalculated the next time it is accessed.
+     * @param owningPlugin
+     */
+    public void invalidateAll(Plugin owningPlugin) {
+        for(List<MetadataValue> values : metadataMap.values()) {
+            for(MetadataValue value : values) {
+                if(value.getOwningPlugin() == owningPlugin) {
+                    value.invalidate();
+                }
+            }
+        }
+    }
+
+    /**
+     * Creates a unique name for the object receiving metadata. Each concrete implementation of MetadataStoreBase
+     * must implement this method.
+     * @param subject
+     * @param metadataKey
+     * @return
+     */
+    protected abstract String Disambiguate(TSubject subject, String metadataKey);
+}

--- a/src/main/java/org/bukkit/metadata/MetadataValue.java
+++ b/src/main/java/org/bukkit/metadata/MetadataValue.java
@@ -1,0 +1,44 @@
+package org.bukkit.metadata;
+
+import org.bukkit.plugin.Plugin;
+
+public interface MetadataValue {
+
+    /**
+     * Attempts to convert this metadata value to an int and return it.
+     * @return
+     * @throws MetadataConversionException
+     */
+    public int asInt() throws MetadataConversionException;
+
+    /**
+     * Attempts to convert this metadata value to a double and return it.
+     * @return
+     * @throws MetadataConversionException
+     */
+    public double asDouble() throws MetadataConversionException;
+
+    /**
+     * Attempts to convert this metadata value to a boolean and return it.
+     * @return
+     * @throws MetadataConversionException
+     */
+    public boolean asBoolean() throws MetadataConversionException;
+
+    /**
+     * Returns the String representation of this metadata item.
+     * @return
+     */
+    public String asString();
+
+    /**
+     * Returns the {@link Plugin} that created this metadata item.
+     * @return
+     */
+    public Plugin getOwningPlugin();
+
+    /**
+     * Invalidates this metadata item, forcing it to recompute when next accessed.
+     */
+    public void invalidate();
+}

--- a/src/main/java/org/bukkit/metadata/Metadatable.java
+++ b/src/main/java/org/bukkit/metadata/Metadatable.java
@@ -1,12 +1,15 @@
 package org.bukkit.metadata;
 
+import org.bukkit.plugin.Plugin;
+
 import java.util.List;
 
 /**
  * This interface is implemented by all objects that can provide metadata about themselves.
  */
 public interface Metadatable {
-    public void addMetadata(String metadataKey, MetadataValue newMetadataValue);
+    public void setMetadata(String metadataKey, MetadataValue newMetadataValue);
     public List<MetadataValue> getMetadata(String metadataKey);
     public boolean hasMetadata(String metadataKey);
+    public void removeMetadata(String metadataKey, Plugin owningPlugin);
 }

--- a/src/main/java/org/bukkit/metadata/Metadatable.java
+++ b/src/main/java/org/bukkit/metadata/Metadatable.java
@@ -1,0 +1,12 @@
+package org.bukkit.metadata;
+
+import java.util.List;
+
+/**
+ * This interface is implemented by all objects that can provide metadata about themselves.
+ */
+public interface Metadatable {
+    public void addMetadata(String metadataKey, MetadataValue newMetadataValue);
+    public List<MetadataValue> getMetadata(String metadataKey);
+    public boolean hasMetadata(String metadataKey);
+}

--- a/src/main/java/org/bukkit/metadata/Metadatable.java
+++ b/src/main/java/org/bukkit/metadata/Metadatable.java
@@ -8,8 +8,31 @@ import java.util.List;
  * This interface is implemented by all objects that can provide metadata about themselves.
  */
 public interface Metadatable {
+    /**
+     * Sets a metadata value in the implementing object's metadata store.
+     * @param metadataKey
+     * @param newMetadataValue
+     */
     public void setMetadata(String metadataKey, MetadataValue newMetadataValue);
+
+    /**
+     * Returns a list of previously set metadata values from the implementing object's metadata store.
+     * @param metadataKey
+     * @return A list of values, one for each plugin that has set the requested value.
+     */
     public List<MetadataValue> getMetadata(String metadataKey);
+
+    /**
+     * Tests to see whether the implementing object contains the given metadata value in its metadata store.
+     * @param metadataKey
+     * @return
+     */
     public boolean hasMetadata(String metadataKey);
+
+    /**
+     * Removes the given metadata value from the implementing object's metadata store.
+     * @param metadataKey
+     * @param owningPlugin This plugin's metadata value will be removed. All other values will be left untouched.
+     */
     public void removeMetadata(String metadataKey, Plugin owningPlugin);
 }

--- a/src/main/java/org/bukkit/metadata/PlayerMetadataStore.java
+++ b/src/main/java/org/bukkit/metadata/PlayerMetadataStore.java
@@ -3,8 +3,17 @@ package org.bukkit.metadata;
 import org.bukkit.OfflinePlayer;
 
 /**
+ * A PlayerMetadataStore stores metadata for {@link org.bukkit.entity.Player} and {@link OfflinePlayer} objects.
  */
 public class PlayerMetadataStore extends MetadataStoreBase<OfflinePlayer> implements MetadataStore<OfflinePlayer> {
+    /**
+     * Generates a unique metadata key for {@link org.bukkit.entity.Player} and {@link OfflinePlayer} using the player
+     * name.
+     * @see MetadataStoreBase#Disambiguate(Object, String)
+     * @param player
+     * @param metadataKey The name identifying the metadata value
+     * @return
+     */
     @Override
     protected String Disambiguate(OfflinePlayer player, String metadataKey) {
         return player.getName().toLowerCase() + ":" + metadataKey;

--- a/src/main/java/org/bukkit/metadata/PlayerMetadataStore.java
+++ b/src/main/java/org/bukkit/metadata/PlayerMetadataStore.java
@@ -1,0 +1,12 @@
+package org.bukkit.metadata;
+
+import org.bukkit.OfflinePlayer;
+
+/**
+ */
+public class PlayerMetadataStore extends MetadataStoreBase<OfflinePlayer> implements MetadataStore<OfflinePlayer> {
+    @Override
+    protected String Disambiguate(OfflinePlayer player, String metadataKey) {
+        return player.getName().toLowerCase() + ":" + metadataKey;
+    }
+}

--- a/src/main/java/org/bukkit/metadata/WorldMetadataStore.java
+++ b/src/main/java/org/bukkit/metadata/WorldMetadataStore.java
@@ -3,9 +3,16 @@ package org.bukkit.metadata;
 import org.bukkit.World;
 
 /**
- * An EntityMetadataStore stores metadata values for all {@link org.bukkit.entity.Entity} classes an their descendants.
+ * An WorldMetadataStore stores metadata values for {@link World} objects.
  */
 public class WorldMetadataStore extends MetadataStoreBase<World> implements MetadataStore<World> {
+    /**
+     * Generates a unique metadata key for a {@link World} object based on the world UID.
+     * @see WorldMetadataStore#Disambiguate(Object, String)
+     * @param world
+     * @param metadataKey
+     * @return
+     */
     @Override
     protected String Disambiguate(World world, String metadataKey) {
         return world.getUID().toString() + ":" + metadataKey;

--- a/src/main/java/org/bukkit/metadata/WorldMetadataStore.java
+++ b/src/main/java/org/bukkit/metadata/WorldMetadataStore.java
@@ -1,0 +1,13 @@
+package org.bukkit.metadata;
+
+import org.bukkit.World;
+
+/**
+ * An EntityMetadataStore stores metadata values for all {@link org.bukkit.entity.Entity} classes an their descendants.
+ */
+public class WorldMetadataStore extends MetadataStoreBase<World> implements MetadataStore<World> {
+    @Override
+    protected String Disambiguate(World world, String metadataKey) {
+        return world.getUID().toString() + ":" + metadataKey;
+    }
+}

--- a/src/test/java/org/bukkit/metadata/FixedMetadataValueTest.java
+++ b/src/test/java/org/bukkit/metadata/FixedMetadataValueTest.java
@@ -1,0 +1,29 @@
+package org.bukkit.metadata;
+
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+
+import static org.junit.Assert.*;
+
+/**
+ */
+public class FixedMetadataValueTest {
+    @Test
+    public void fixedIntTest() {
+        FixedMetadataValue metadataValue = new FixedMetadataValue(null, 10);
+        assertEquals(metadataValue.asInt(), 10);
+    }
+
+    @Test
+    public void fixedDoubleTest() {
+        FixedMetadataValue metadataValue = new FixedMetadataValue(null, 10.5);
+        assertEquals(metadataValue.asDouble(), 10.5, 0.01);
+    }
+
+    @Test
+    public void fixedStringTest() {
+        FixedMetadataValue metadataValue = new FixedMetadataValue(null, "TEN");
+        assertEquals(metadataValue.asString(), "TEN");
+    }
+}

--- a/src/test/java/org/bukkit/metadata/LazyMetadataValueTest.java
+++ b/src/test/java/org/bukkit/metadata/LazyMetadataValueTest.java
@@ -1,0 +1,110 @@
+package org.bukkit.metadata;
+
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+
+import static org.junit.Assert.*;
+
+/**
+ */
+public class LazyMetadataValueTest {
+
+    @Test
+    public void testLazyInt() {
+        LazyMetadataValue metadataValue = new LazyMetadataValue(null, new Callable<Object>() {
+            public Object call() throws Exception {
+                return 10;
+            }
+        });
+
+        assertEquals(metadataValue.asInt(), 10);
+    }
+
+    @Test
+    public void testLazyDouble() {
+        LazyMetadataValue metadataValue = new LazyMetadataValue(null, new Callable<Object>() {
+            public Object call() throws Exception {
+                return 10.5;
+            }
+        });
+
+        assertEquals(metadataValue.asDouble(), 10.5, 0.01);
+    }
+
+    @Test
+    public void testLazyString() {
+        LazyMetadataValue metadataValue = new LazyMetadataValue(null, new Callable<Object>() {
+            public Object call() throws Exception {
+                return "TEN";
+            }
+        });
+
+        assertEquals(metadataValue.asString(), "TEN");
+    }
+
+    @Test
+    public void testCacheStrategyCacheAfterFirstEval() {
+        final Counter evals = new Counter();
+        LazyMetadataValue metadataValue = new LazyMetadataValue(null, LazyMetadataValue.CacheStrategy.CACHE_AFTER_FIRST_EVAL, new Callable<Object>() {
+            public Object call() throws Exception {
+                evals.increment();
+                return 10;
+            }
+        });
+
+        metadataValue.asInt();
+        metadataValue.asInt();
+        assertEquals(metadataValue.asInt(), 10);
+        assertEquals(evals.value(), 1);
+
+        metadataValue.invalidate();
+        metadataValue.asInt();
+        assertEquals(evals.value(), 2);
+    }
+
+    @Test
+    public void testCacheStrategyNeverCache() {
+        final Counter evals = new Counter();
+        LazyMetadataValue metadataValue = new LazyMetadataValue(null, LazyMetadataValue.CacheStrategy.NEVER_CACHE, new Callable<Object>() {
+            public Object call() throws Exception {
+                evals.increment();
+                return 10;
+            }
+        });
+
+        metadataValue.asInt();
+        metadataValue.asInt();
+        assertEquals(metadataValue.asInt(), 10);
+        assertEquals(evals.value(), 3);
+    }
+
+    @Test
+    public void testCacheStrategyEternally() {
+        final Counter evals = new Counter();
+        LazyMetadataValue metadataValue = new LazyMetadataValue(null, LazyMetadataValue.CacheStrategy.CACHE_ETERNALLY, new Callable<Object>() {
+            public Object call() throws Exception {
+                evals.increment();
+                return 10;
+            }
+        });
+
+        metadataValue.asInt();
+        metadataValue.asInt();
+        assertEquals(evals.value(), 1);
+
+        metadataValue.invalidate();
+        metadataValue.asInt();
+        assertEquals(evals.value(), 1);
+    }
+
+    private class Counter {
+        int c = 0;
+        public void increment() {
+            c++;
+        }
+        public int value() {
+            return c;
+        }
+    }
+}

--- a/src/test/java/org/bukkit/metadata/MetadataStoreTest.java
+++ b/src/test/java/org/bukkit/metadata/MetadataStoreTest.java
@@ -1,0 +1,70 @@
+package org.bukkit.metadata;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import static org.junit.Assert.*;
+
+/**
+ */
+public class MetadataStoreTest {
+
+    @Test
+    public void testMetadataStore() {
+        StringMetadataStore mds = new StringMetadataStore();
+        mds.addMetadata("subject", "key", new FixedMetadataValue(null, 10));
+
+        assertTrue(mds.hasMetadata("subject", "key"));
+        List<MetadataValue> values = mds.getMetadata("subject", "key");
+        assertEquals(values.get(0).asInt(), 10);
+    }
+
+    @Test
+    public void testMetadataNotPresent() {
+        StringMetadataStore mds = new StringMetadataStore();
+
+        assertFalse(mds.hasMetadata("subject", "key"));
+        List<MetadataValue> values = mds.getMetadata("subject", "key");
+        assertTrue(values.isEmpty());
+    }
+
+    @Test
+    public void testInvalidateAll() {
+        StringMetadataStore mds = new StringMetadataStore();
+        final Counter counter = new Counter();
+
+        mds.addMetadata("subject", "key", new LazyMetadataValue(null, new Callable<Object>() {
+            public Object call() throws Exception {
+                counter.increment();
+                return 10;
+            }
+        }));
+
+        assertTrue(mds.hasMetadata("subject", "key"));
+        mds.getMetadata("subject", "key").get(0).asInt();
+        mds.getMetadata("subject", "key").get(0).asInt();
+        mds.invalidateAll(null);
+        mds.getMetadata("subject", "key").get(0).asInt();
+        mds.getMetadata("subject", "key").get(0).asInt();
+        assertEquals(counter.value(), 2);
+    }
+
+    private class StringMetadataStore extends MetadataStoreBase<String> implements MetadataStore<String> {
+        @Override
+        protected String Disambiguate(String subject, String metadataKey) {
+            return subject + ":" + metadataKey;
+        }
+    }
+
+    private class Counter {
+        int c = 0;
+        public void increment() {
+            c++;
+        }
+        public int value() {
+            return c;
+        }
+    }
+}

--- a/src/test/java/org/bukkit/metadata/MetadataStoreTest.java
+++ b/src/test/java/org/bukkit/metadata/MetadataStoreTest.java
@@ -1,5 +1,6 @@
 package org.bukkit.metadata;
 
+import org.bukkit.plugin.Plugin;
 import org.junit.Test;
 
 import java.util.List;
@@ -14,7 +15,7 @@ public class MetadataStoreTest {
     @Test
     public void testMetadataStore() {
         StringMetadataStore mds = new StringMetadataStore();
-        mds.addMetadata("subject", "key", new FixedMetadataValue(null, 10));
+        mds.setMetadata("subject", "key", new FixedMetadataValue(new MockPlugin(), 10));
 
         assertTrue(mds.hasMetadata("subject", "key"));
         List<MetadataValue> values = mds.getMetadata("subject", "key");
@@ -35,7 +36,9 @@ public class MetadataStoreTest {
         StringMetadataStore mds = new StringMetadataStore();
         final Counter counter = new Counter();
 
-        mds.addMetadata("subject", "key", new LazyMetadataValue(null, new Callable<Object>() {
+        MockPlugin mockPlugin = new MockPlugin();
+
+        mds.setMetadata("subject", "key", new LazyMetadataValue(mockPlugin, new Callable<Object>() {
             public Object call() throws Exception {
                 counter.increment();
                 return 10;
@@ -45,10 +48,45 @@ public class MetadataStoreTest {
         assertTrue(mds.hasMetadata("subject", "key"));
         mds.getMetadata("subject", "key").get(0).asInt();
         mds.getMetadata("subject", "key").get(0).asInt();
-        mds.invalidateAll(null);
+        mds.invalidateAll(mockPlugin);
         mds.getMetadata("subject", "key").get(0).asInt();
         mds.getMetadata("subject", "key").get(0).asInt();
         assertEquals(counter.value(), 2);
+    }
+
+    @Test
+    public void testMetadataReplace() {
+        StringMetadataStore mds = new StringMetadataStore();
+        MockPlugin mockPlugin1 = new MockPlugin();
+        MockPlugin mockPlugin2 = new MockPlugin();
+
+        mds.setMetadata("subject", "key", new FixedMetadataValue(mockPlugin1, 10));
+        mds.setMetadata("subject", "key", new FixedMetadataValue(mockPlugin2, 10));
+        mds.setMetadata("subject", "key", new FixedMetadataValue(mockPlugin1, 20));
+
+        for(MetadataValue mv : mds.getMetadata("subject", "key")) {
+            if(mv.getOwningPlugin() == mockPlugin1) {
+                assertEquals(mv.asInt(), 20);
+            }
+            if(mv.getOwningPlugin() == mockPlugin2) {
+                assertEquals(mv.asInt(), 10);
+            }
+        }
+    }
+
+    @Test
+    public void testMetadataRemove() {
+        StringMetadataStore mds = new StringMetadataStore();
+        MockPlugin mockPlugin1 = new MockPlugin();
+        MockPlugin mockPlugin2 = new MockPlugin();
+
+        mds.setMetadata("subject", "key", new FixedMetadataValue(mockPlugin1, 10));
+        mds.setMetadata("subject", "key", new FixedMetadataValue(mockPlugin2, 20));
+        mds.removeMetadata("subject", "key", mockPlugin1);
+
+        assertTrue(mds.hasMetadata("subject", "key"));
+        assertEquals(mds.getMetadata("subject", "key").size(), 1);
+        assertEquals(mds.getMetadata("subject", "key").get(0).asInt(), 20);
     }
 
     private class StringMetadataStore extends MetadataStoreBase<String> implements MetadataStore<String> {

--- a/src/test/java/org/bukkit/metadata/MockPlugin.java
+++ b/src/test/java/org/bukkit/metadata/MockPlugin.java
@@ -1,0 +1,92 @@
+package org.bukkit.metadata;
+
+import com.avaje.ebean.EbeanServer;
+import org.bukkit.Server;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.generator.ChunkGenerator;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginDescriptionFile;
+import org.bukkit.plugin.PluginLoader;
+import org.bukkit.util.config.Configuration;
+
+import java.io.File;
+import java.io.InputStream;
+
+/**
+ * Including a mocking framework would be useful :)
+ */
+public class MockPlugin implements Plugin {
+    public File getDataFolder() {
+        return null;
+    }
+
+    public PluginDescriptionFile getDescription() {
+        return null;
+    }
+
+    public Configuration getConfiguration() {
+        return null;
+    }
+
+    public FileConfiguration getConfig() {
+        return null;
+    }
+
+    public InputStream getResource(String filename) {
+        return null;
+    }
+
+    public void saveConfig() {
+
+    }
+
+    public void reloadConfig() {
+
+    }
+
+    public PluginLoader getPluginLoader() {
+        return null;
+    }
+
+    public Server getServer() {
+        return null;
+    }
+
+    public boolean isEnabled() {
+        return false;
+    }
+
+    public void onDisable() {
+
+    }
+
+    public void onLoad() {
+
+    }
+
+    public void onEnable() {
+
+    }
+
+    public boolean isNaggable() {
+        return false;
+    }
+
+    public void setNaggable(boolean canNag) {
+
+    }
+
+    public EbeanServer getDatabase() {
+        return null;
+    }
+
+    public ChunkGenerator getDefaultWorldGenerator(String worldName, String id) {
+        return null;
+    }
+
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        return false;
+    }
+}


### PR DESCRIPTION
This metadata implementation has the following features:
1. All metadata is lazy. Metadata values are not actually computed
   until another plugin requests them. Memory and CPU are conserved by not
   computing and storing unnecessary metadata values.
2. All metadata is cached. Once a metadata value is computed its value
   is cached in the metadata store to prevent further unnecessary
   computation. An invalidation mechanism is provided to flush the cache
   and force recompilation of metadata values.
3. All metadata is stored in basic data types. Convenience methods in
   the MetadataValue class allow for the conversion of metadata data types
   when possible. Restricting metadata to basic data types prevents the
   accidental linking of large object graphs into metadata. Metadata is
   persistent across the lifetime of the application and adding large
   object graphs would damage garbage collector performance.
4. Metadata access is thread safe. Care has been taken to protect the
   internal data structures and access them in a thread safe manner.
5. Metadata is exposed for all objects that descend from Entity,
   Block, and World. All Entity and World metadata is stored at the Server 
   level and all Block metadata is stored at the World level.
6. Metadata is NOT keyed on references to original objects - instead
   metadata is keyed off of unique fields within those objects. Doing this
   allows metadata to exist for blocks that are in chunks not currently in
   memory. Additionally, Player objects are keyed off of player name so
   that Player metadata remains consistent between logins.
7. Metadata convenience methods have been added to all Entities,
   Blocks, BlockStates, and World allowing direct access to an individual
   instance's metadata.
8. Players and OfflinePlayers share a single metadata store, allowing player metadata to be manipulated regardless of the player's current online status.
