### PR TITLE
Makes the error for "No player by that name" more descriptive

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/TellCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/TellCommand.java
@@ -25,7 +25,7 @@ public class TellCommand extends VanillaCommand {
         Player player = Bukkit.getPlayerExact(args[0]);
 
         if (player == null) {
-            sender.sendMessage("There's no player by the name \"" args[0] "\" online.");
+            sender.sendMessage("There's no player by the name \"" + args[0] + "\" online.");
         } else {
             StringBuilder message = new StringBuilder();
 

--- a/src/main/java/org/bukkit/command/defaults/TellCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/TellCommand.java
@@ -25,7 +25,7 @@ public class TellCommand extends VanillaCommand {
         Player player = Bukkit.getPlayerExact(args[0]);
 
         if (player == null) {
-            sender.sendMessage("There's no player by the name \"" player.getName() "\" online.");
+            sender.sendMessage("There's no player by the name \"" args[0] "\" online.");
         } else {
             StringBuilder message = new StringBuilder();
 

--- a/src/main/java/org/bukkit/command/defaults/TellCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/TellCommand.java
@@ -25,7 +25,7 @@ public class TellCommand extends VanillaCommand {
         Player player = Bukkit.getPlayerExact(args[0]);
 
         if (player == null) {
-            sender.sendMessage("There's no player by that name online.");
+            sender.sendMessage("There's no player by the name \"" player.getName() "\" online.");
         } else {
             StringBuilder message = new StringBuilder();
 


### PR DESCRIPTION
Makes the error for "No player by that name" more descriptive by telling you what name you typed.  This can be helpful so that you know if they aren't online, or if you typed their name wrong.  Also, sometimes, I have wondered "What exactly did I type, anyways?"
