### PR TITLE
Fixed documentation for getNearbyEntities.

### DIFF
--- a/src/main/java/org/bukkit/entity/Entity.java
+++ b/src/main/java/org/bukkit/entity/Entity.java
@@ -59,11 +59,11 @@ public interface Entity {
     public boolean teleport(Entity destination);
 
     /**
-     * Returns a list of entities within a bounding box defined by x,y,z centered around player
+     * Returns a list of entities within a bounding box centered around player
      *
-     * @param x Size of the box along x axis
-     * @param y Size of the box along y axis
-     * @param z Size of the box along z axis
+     * @param x 1/2 the size of the box along x axis
+     * @param y 1/2 the size of the box along y axis
+     * @param z 1/2 the size of the box along z axis
      * @return List<Entity> List of entities nearby
      */
     public List<org.bukkit.entity.Entity> getNearbyEntities(double x, double y, double z);


### PR DESCRIPTION
The bounding box ends up getting defined by this:

public AxisAlignedBB b(double d0, double d1, double d2) {
    double d3 = this.a - d0;
    double d4 = this.b - d1;
    double d5 = this.c - d2;
    double d6 = this.d + d0;
    double d7 = this.e + d1;
    double d8 = this.f + d2;

```
return b(d3, d4, d5, d6, d7, d8);
```

}
