### PR TITLE
Fixed blank lines appearing at the top of .yml files when no config file header is used.

### DIFF
--- a/src/main/java/org/bukkit/configuration/file/YamlConfiguration.java
+++ b/src/main/java/org/bukkit/configuration/file/YamlConfiguration.java
@@ -159,7 +159,9 @@ public class YamlConfiguration extends FileConfiguration {
                     result.append(line.substring(COMMENT_PREFIX.length()));
                 }
             } else if (line.length() == 0) {
-                result.append("\n");
+            	if (i > 0) {
+                    result.append("\n");
+            	}
             } else {
                 readingHeader = false;
             }


### PR DESCRIPTION
This fixes the bug described here:
http://forums.bukkit.org/threads/white-space-at-the-start-of-configs.43624/
http://forums.bukkit.org/threads/unsolved-fileconfiguration-creating-white-space.43462/
