### PR TITLE
Fix default BanCommand to kick player upon ban.

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/BanCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/BanCommand.java
@@ -25,7 +25,7 @@ public class BanCommand extends VanillaCommand {
         Player player = Bukkit.getPlayerExact(args[0]);
         
         Bukkit.getOfflinePlayer(args[0]).setBanned(true);
-        if (Bukkit.getPlayer(args[0]) != null) 
+        if (player != null) 
             player.kickPlayer("Banned by admin.");
             Command.broadcastCommandMessage(sender, "Banning " + player.getName());
 

--- a/src/main/java/org/bukkit/command/defaults/BanCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/BanCommand.java
@@ -4,6 +4,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 
 public class BanCommand extends VanillaCommand {
     public BanCommand() {
@@ -20,10 +21,13 @@ public class BanCommand extends VanillaCommand {
             sender.sendMessage(ChatColor.RED + "Usage: " + usageMessage);
             return false;
         }
-
+        
+        Player player = Bukkit.getPlayerExact(args[0]);
+        
         Bukkit.getOfflinePlayer(args[0]).setBanned(true);
-        if (Bukkit.getPlayer(args[0]) != null) Bukkit.getPlayer(args[0]).kickPlayer("Banned by admin.");
-        Command.broadcastCommandMessage(sender, "Banning " + args[0]);
+        if (Bukkit.getPlayer(args[0]) != null) 
+            player.kickPlayer("Banned by admin.");
+            Command.broadcastCommandMessage(sender, "Banning " + player.getName());
 
         return true;
     }


### PR DESCRIPTION
The current default ban command will ban a player, but will not kick them upon ban. This fix kicks a player upon ban correctly. 

This is also a response to Leaky Bug #1492
http://leaky.bukkit.org/issues/1492
