### PR TITLE
Fixed NPE in getResource when the requested resource doesn't exist

### DIFF
--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
@@ -158,6 +158,8 @@ public abstract class JavaPlugin implements Plugin {
             return connection.getInputStream();
         } catch (IOException ex) {
             return null;
+        } catch (NullPointerException ex) {
+            return null;
         }
     }
 


### PR DESCRIPTION
I stumbled over an NPE back in 1.9pre while working through the plugin tuts in the Bukkit Wiki, especially: http://wiki.bukkit.org/Plugin_Tutorial#Getting_the_configuration_for_your_plugin

Could reproduce again in 1.0.0 with 1a67de21c61871e434b1fc317f4d9a591272f388

Demo plugin code to reproduce:

```
package de.qalanet.mc.tests.getResourceNPE;

import org.bukkit.configuration.file.FileConfiguration;
import org.bukkit.plugin.java.JavaPlugin;

public class getResourceNPE extends JavaPlugin {
    protected FileConfiguration config;

    public void onEnable() {
        config = getConfig();
    }
}
```
