### PR TITLE
Fix NullPointerException in getResource/getConfig

### DIFF
--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
@@ -153,6 +153,11 @@ public abstract class JavaPlugin implements Plugin {
 
         try {
             URL url = getClassLoader().getResource(filename);
+            
+            if (url == null) {
+                return null;
+            }
+            
             URLConnection connection = url.openConnection();
             connection.setUseCaches(false);
             return connection.getInputStream();


### PR DESCRIPTION
Bukkit would throw a NPE while trying to load the configuration for a few plugins, such as LogBlock.

```
2011-11-20 18:34:23 [SEVERE] [LogBlock] Error while loading: null
2011-11-20 18:34:23 [SEVERE] java.lang.NullPointerException
2011-11-20 18:34:23 [SEVERE]    at org.bukkit.plugin.java.JavaPlugin.getResource(JavaPlugin.java:156)
2011-11-20 18:34:23 [SEVERE]    at org.bukkit.plugin.java.JavaPlugin.reloadConfig(JavaPlugin.java:133)
2011-11-20 18:34:23 [SEVERE]    at org.bukkit.plugin.java.JavaPlugin.getConfig(JavaPlugin.java:125)
```

This fixes it by checking to see if the URL in getResource() is null before trying to open a URLConnection. If it is, getResource will return null.
