### PR TITLE
ItemStack: Now also checking durability in equals()

### DIFF
--- a/src/main/java/org/bukkit/inventory/ItemStack.java
+++ b/src/main/java/org/bukkit/inventory/ItemStack.java
@@ -196,7 +196,7 @@ public class ItemStack implements Serializable, ConfigurationSerializable {
 
         ItemStack item = (ItemStack) obj;
 
-        return item.getAmount() == getAmount() && item.getTypeId() == getTypeId();
+        return (item.getAmount() == getAmount()) && (item.getTypeId() == getTypeId()) && (item.getDurability() == getDurability());
     }
 
     @Override


### PR DESCRIPTION
`ItemStack.equals(Object)` shouldn't return true for two ItemStacks with different durability.
