### PR TITLE
Call PluginDisableEvent before plugin.setEnabled(false)

### DIFF
--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -971,6 +971,8 @@ public class JavaPluginLoader implements PluginLoader {
         }
 
         if (plugin.isEnabled()) {
+            server.getPluginManager().callEvent(new PluginDisableEvent(plugin));
+            
             JavaPlugin jPlugin = (JavaPlugin) plugin;
             ClassLoader cloader = jPlugin.getClassLoader();
 
@@ -979,8 +981,6 @@ public class JavaPluginLoader implements PluginLoader {
             } catch (Throwable ex) {
                 server.getLogger().log(Level.SEVERE, "Error occurred while disabling " + plugin.getDescription().getFullName() + " (Is it up to date?): " + ex.getMessage(), ex);
             }
-
-            server.getPluginManager().callEvent(new PluginDisableEvent(plugin));
 
             loaders.remove(jPlugin.getDescription().getName());
 


### PR DESCRIPTION
Dependencies and load order are currently disregarded when disabling all plugins (i.e. `stop` console command). In addition to being more consistent in how events are called throughout Bukkit (pre-event, not post-event, unless named with past tense), this small change allows dependent plugins to listen for a dependency's disable event and do work before its `onDisable` method is called.

My current use case involves a database query plugin that depends on a database connection pooling plugin. The query plugin queues up queries to be run at an interval. On a `stop` command, the query plugin quickly tries to flush its queue to the database before disabling. The connection pooling plugin `onDisable` releases its pools and closes its connections. This is a problem when the connection pooling plugin sits above the query plugin in the plugin list and is disabled before the queue is flushed, leaving no pools/connections available. With this change, I can listen for the `PLUGIN_DISABLE` event of my dependency (connection pooling plugin) and flush the queue before its disabled.
