### PR TITLE
Fixed possible bug where durability is set to data in constructor. 

### DIFF
--- a/src/main/java/org/bukkit/inventory/ItemStack.java
+++ b/src/main/java/org/bukkit/inventory/ItemStack.java
@@ -46,7 +46,6 @@ public class ItemStack implements Serializable, ConfigurationSerializable {
         this.durability = damage;
         if (data != null) {
             createData(data);
-            this.durability = data;
         }
     }
 


### PR DESCRIPTION
This line seemed accidental, can't think of a case where durability needed to be the same as data.
