### PR TITLE
Added ability for plugins to check permissions for players per-world.

### DIFF
--- a/src/main/java/org/bukkit/command/ConsoleCommandSender.java
+++ b/src/main/java/org/bukkit/command/ConsoleCommandSender.java
@@ -44,20 +44,40 @@ public class ConsoleCommandSender implements CommandSender {
         return perm.isPermissionSet(name);
     }
 
+    public boolean isPermissionSet(String name, String worldName) {
+        return perm.isPermissionSet(name, worldName);
+    }
+
     public boolean isPermissionSet(Permission perm) {
         return this.perm.isPermissionSet(perm);
+    }
+
+    public boolean isPermissionSet(Permission perm, String worldName) {
+        return this.perm.isPermissionSet(perm, worldName);
     }
 
     public boolean hasPermission(String name) {
         return perm.hasPermission(name);
     }
 
+    public boolean hasPermission(String name, String worldName) {
+        return perm.hasPermission(name, worldName);
+    }
+
     public boolean hasPermission(Permission perm) {
         return this.perm.hasPermission(perm);
     }
 
+    public boolean hasPermission(Permission perm, String worldName) {
+        return this.perm.hasPermission(perm, worldName);
+    }
+
     public PermissionAttachment addAttachment(Plugin plugin, String name, boolean value) {
         return perm.addAttachment(plugin, name, value);
+    }
+
+    public PermissionAttachment addAttachment(Plugin plugin, String name, boolean value, String worldName) {
+        return perm.addAttachment(plugin, name, value, worldName);
     }
 
     public PermissionAttachment addAttachment(Plugin plugin) {
@@ -66,6 +86,10 @@ public class ConsoleCommandSender implements CommandSender {
 
     public PermissionAttachment addAttachment(Plugin plugin, String name, boolean value, int ticks) {
         return perm.addAttachment(plugin, name, value, ticks);
+    }
+
+    public PermissionAttachment addAttachment(Plugin plugin, String name, boolean value, int ticks, String worldName) {
+        return perm.addAttachment(plugin, name, value, ticks, worldName);
     }
 
     public PermissionAttachment addAttachment(Plugin plugin, int ticks) {
@@ -82,6 +106,10 @@ public class ConsoleCommandSender implements CommandSender {
 
     public Set<PermissionAttachmentInfo> getEffectivePermissions() {
         return perm.getEffectivePermissions();
+    }
+
+    public Set<PermissionAttachmentInfo> getEffectivePermissions(String worldName) {
+        return perm.getEffectivePermissions(worldName);
     }
 
     public String getName() {

--- a/src/main/java/org/bukkit/permissions/Permissible.java
+++ b/src/main/java/org/bukkit/permissions/Permissible.java
@@ -17,12 +17,30 @@ public interface Permissible extends ServerOperator {
     public boolean isPermissionSet(String name);
 
     /**
+     * Checks if this object contains an override for the specified permission, by fully qualified name
+     *
+     * @param name Name of the permission
+     * @param worldName Name of the world this permission applies to
+     * @return true if the permission is set, otherwise false
+     */
+    public boolean isPermissionSet(String name, String worldName);
+
+    /**
      * Checks if this object contains an override for the specified {@link Permission}
      *
      * @param perm Permission to check
      * @return true if the permission is set, otherwise false
      */
     public boolean isPermissionSet(Permission perm);
+
+    /**
+     * Checks if this object contains an override for the specified {@link Permission}
+     *
+     * @param perm Permission to check
+     * @param worldName World to check
+     * @return true if the permission is set, otherwise false
+     */
+    public boolean isPermissionSet(Permission perm, String worldName);
 
     /**
      * Gets the value of the specified permission, if set.
@@ -37,12 +55,34 @@ public interface Permissible extends ServerOperator {
     /**
      * Gets the value of the specified permission, if set.
      *
+     * If a permission override is not set on this object, the default value of the permission will be returned.
+     *
+     * @param name Name of the permission
+     * @param worldName Name of the world this permission applies to
+     * @return Value of the permission
+     */
+    public boolean hasPermission(String name, String worldName);
+
+    /**
+     * Gets the value of the specified permission, if set.
+     *
      * If a permission override is not set on this object, the default value of the permission will be returned
      *
      * @param perm Permission to get
      * @return Value of the permission
      */
     public boolean hasPermission(Permission perm);
+
+    /**
+     * Gets the value of the specified permission, if set.
+     *
+     * If a permission override is not set on this object, the default value of the permission will be returned
+     *
+     * @param perm Permission to get
+     * @param worldName Name of the world this permissions applies to
+     * @return Value of the permission
+     */
+    public boolean hasPermission(Permission perm, String worldName);
 
     /**
      * Adds a new {@link PermissionAttachment} with a single permission by name and value
@@ -53,6 +93,17 @@ public interface Permissible extends ServerOperator {
      * @return The PermissionAttachment that was just created
      */
     public PermissionAttachment addAttachment(Plugin plugin, String name, boolean value);
+
+    /**
+     * Adds a new {@link PermissionAttachment} with a single permission by name and value
+     *
+     * @param plugin Plugin responsible for this attachment, may not be null or disabled
+     * @param name Name of the permission to attach
+     * @param value Value of the permission
+     * @param worldName The name of the world this permission should apply to.
+     * @return The PermissionAttachment that was just created
+     */
+    public PermissionAttachment addAttachment(Plugin plugin, String name, boolean value, String worldName);
 
     /**
      * Adds a new empty {@link PermissionAttachment} to this object
@@ -72,6 +123,18 @@ public interface Permissible extends ServerOperator {
      * @return The PermissionAttachment that was just created
      */
     public PermissionAttachment addAttachment(Plugin plugin, String name, boolean value, int ticks);
+
+    /**
+     * Temporarily adds a new {@link PermissionAttachment} with a single permission by name and value
+     *
+     * @param plugin Plugin responsible for this attachment, may not be null or disabled
+     * @param name Name of the permission to attach
+     * @param value Value of the permission
+     * @param ticks Amount of ticks to automatically remove this attachment after
+     * @param worldName Name of the world this permission should apply to.
+     * @return The PermissionAttachment that was just created
+     */
+    public PermissionAttachment addAttachment(Plugin plugin, String name, boolean value, int ticks, String worldName);
 
     /**
      * Temporarily adds a new empty {@link PermissionAttachment} to this object
@@ -103,4 +166,11 @@ public interface Permissible extends ServerOperator {
      * @return Set of currently effective permissions
      */
     public Set<PermissionAttachmentInfo> getEffectivePermissions();
+
+    /**
+     * Gets a set containing all of the permissions currently in effect by this object for a specific world.
+     *
+     * @return Set of currently effective permissions
+     */
+    public Set<PermissionAttachmentInfo> getEffectivePermissions(String worldName);
 }

--- a/src/main/java/org/bukkit/permissions/PermissibleBase.java
+++ b/src/main/java/org/bukkit/permissions/PermissibleBase.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Entity;
 import org.bukkit.plugin.Plugin;
 
 /**
@@ -16,8 +17,9 @@ import org.bukkit.plugin.Plugin;
 public class PermissibleBase implements Permissible {
     private ServerOperator opable = null;
     private Permissible parent = this;
+    private Entity entity = null;
     private final List<PermissionAttachment> attachments = new LinkedList<PermissionAttachment>();
-    private final Map<String, PermissionAttachmentInfo> permissions = new HashMap<String, PermissionAttachmentInfo>();
+    private final Map<String, Map<String, PermissionAttachmentInfo>> permissions = new HashMap<String, Map<String, PermissionAttachmentInfo>>();
 
     public PermissibleBase(ServerOperator opable) {
         this.opable = opable;
@@ -25,8 +27,20 @@ public class PermissibleBase implements Permissible {
         if (opable instanceof Permissible) {
             this.parent = (Permissible)opable;
         }
+        if (opable instanceof Entity) {
+            this.entity = (Entity)opable;
+        }
 
         recalculatePermissions();
+    }
+
+    private Map<String, PermissionAttachmentInfo> getPermissions(String worldName) {
+        Map<String, PermissionAttachmentInfo> ret = permissions.get(worldName);
+        if (ret == null) {
+            ret = new HashMap<String, PermissionAttachmentInfo>();
+            permissions.put(worldName, ret);
+        }
+        return ret;
     }
     
     public boolean isOp() {
@@ -50,26 +64,61 @@ public class PermissibleBase implements Permissible {
             throw new IllegalArgumentException("Permission name cannot be null");
         }
 
-        return permissions.containsKey(name.toLowerCase());
+        boolean set = isPermissionSet(name, null);
+        if (entity != null) {
+            set |= isPermissionSet(name, entity.getWorld().getName());
+        }
+        return set;
+    }
+
+    public boolean isPermissionSet(String name, String worldName) {
+        if (name == null) {
+            throw new IllegalArgumentException("Permission name cannot be null");
+        }
+
+        name = name.toLowerCase();
+        if (worldName != null) worldName = worldName.toLowerCase();
+        
+        if (!permissions.containsKey(worldName)) return false;
+        return getPermissions(worldName).containsKey(name);
     }
 
     public boolean isPermissionSet(Permission perm) {
         if (perm == null) {
             throw new IllegalArgumentException("Permission cannot be null");
         }
-
+        
         return isPermissionSet(perm.getName());
     }
 
+    public boolean isPermissionSet(Permission perm, String worldName) {
+        if (perm == null) {
+            throw new IllegalArgumentException("Permission cannot be null");
+        }
+        return isPermissionSet(perm.getName(), worldName);
+    }
+
     public boolean hasPermission(String inName) {
+        if (entity != null) {
+            return hasPermission(inName, entity.getWorld().getName());
+        } else {
+            return hasPermission(inName, null);
+        }
+    }
+
+    public boolean hasPermission(String inName, String worldName) {
         if (inName == null) {
             throw new IllegalArgumentException("Permission name cannot be null");
         }
 
         String name = inName.toLowerCase();
+        if (worldName != null) worldName = worldName.toLowerCase();
 
-        if (isPermissionSet(name)) {
-            return permissions.get(name).getValue();
+        // More specific overrides less specific
+        if (isPermissionSet(name, worldName)) {
+            return getPermissions(worldName).get(name).getValue();
+        } else if (worldName != null && isPermissionSet(name, null)) {
+            return getPermissions(null).get(name).getValue();
         } else {
             Permission perm = Bukkit.getServer().getPluginManager().getPermission(name);
 
@@ -82,14 +131,25 @@ public class PermissibleBase implements Permissible {
     }
 
     public boolean hasPermission(Permission perm) {
+        if (entity != null) {
+            return hasPermission(perm, entity.getWorld().getName());
+        } else {
+            return hasPermission(perm, null);
+        }
+    }
+
+    public boolean hasPermission(Permission perm, String worldName) {
         if (perm == null) {
             throw new IllegalArgumentException("Permission cannot be null");
         }
 
+        if (worldName != null) worldName = worldName.toLowerCase();
         String name = perm.getName().toLowerCase();
 
-        if (isPermissionSet(name)) {
-            return permissions.get(name).getValue();
+        if (isPermissionSet(name, worldName)) {
+            return getPermissions(worldName).get(name).getValue();
+        } else if (worldName != null && isPermissionSet(name, null)) {
+            return getPermissions(null).get(name).getValue();
         } else if (perm != null) {
             return perm.getDefault().getValue(isOp());
         } else {
@@ -108,6 +168,23 @@ public class PermissibleBase implements Permissible {
 
         PermissionAttachment result = addAttachment(plugin);
         result.setPermission(name, value);
+
+        recalculatePermissions();
+
+        return result;
+    }
+
+    public PermissionAttachment addAttachment(Plugin plugin, String name, boolean value, String worldName) {
+        if (name == null) {
+            throw new IllegalArgumentException("Permission name cannot be null");
+        } else if (plugin == null) {
+            throw new IllegalArgumentException("Plugin cannot be null");
+        } else if (!plugin.isEnabled()) {
+            throw new IllegalArgumentException("Plugin " + plugin.getDescription().getFullName() + " is disabled");
+        }
+
+        PermissionAttachment result = addAttachment(plugin);
+        result.setPermission(name, value, worldName);
 
         recalculatePermissions();
 
@@ -152,24 +229,27 @@ public class PermissibleBase implements Permissible {
         clearPermissions();
         Set<Permission> defaults = Bukkit.getServer().getPluginManager().getDefaultPermissions(isOp());
         Bukkit.getServer().getPluginManager().subscribeToDefaultPerms(isOp(), parent);
-
+        Map<String, PermissionAttachmentInfo> globalPerms = getPermissions(null);
         for (Permission perm : defaults) {
             String name = perm.getName().toLowerCase();
-            permissions.put(name, new PermissionAttachmentInfo(parent, name, null, true));
+            globalPerms.put(name, new PermissionAttachmentInfo(parent, name, null, true, null));
             Bukkit.getServer().getPluginManager().subscribeToPermission(name, parent);
-            calculateChildPermissions(perm.getChildren(), false, null);
+            calculateChildPermissions(perm.getChildren(), false, null, null);
         }
 
         for (PermissionAttachment attachment : attachments) {
-            calculateChildPermissions(attachment.getPermissions(), false, attachment);
+            Map<String, Map<String, Boolean>> perms = attachment.getPermissions();
+            for (Map.Entry<String, Map<String, Boolean>> entry : perms.entrySet()) {
+                calculateChildPermissions(entry.getValue(), false, attachment, entry.getKey());
+            }
         }
     }
 
     private synchronized void clearPermissions() {
-        Set<String> perms = permissions.keySet();
-
-        for (String name : perms) {
-            Bukkit.getServer().getPluginManager().unsubscribeFromPermission(name, parent);
+        for (Map.Entry<String, Map<String, PermissionAttachmentInfo>> entry : permissions.entrySet()) {
+            for (String name : entry.getValue().keySet()) {
+                Bukkit.getServer().getPluginManager().unsubscribeFromPermission(name, parent);
+            }
         }
 
         Bukkit.getServer().getPluginManager().unsubscribeFromDefaultPerms(false, parent);
@@ -178,19 +258,20 @@ public class PermissibleBase implements Permissible {
         permissions.clear();
     }
 
-    private void calculateChildPermissions(Map<String, Boolean> children, boolean invert, PermissionAttachment attachment) {
+    private void calculateChildPermissions(Map<String, Boolean> children, boolean invert, PermissionAttachment attachment, String worldName) {
         Set<String> keys = children.keySet();
+        Map<String, PermissionAttachmentInfo> worldPerms = getPermissions(worldName);
 
         for (String name : keys) {
             Permission perm = Bukkit.getServer().getPluginManager().getPermission(name);
             boolean value = children.get(name) ^ invert;
             String lname = name.toLowerCase();
 
-            permissions.put(lname, new PermissionAttachmentInfo(parent, lname, attachment, value));
+            worldPerms.put(lname, new PermissionAttachmentInfo(parent, lname, attachment, value, worldName));
             Bukkit.getServer().getPluginManager().subscribeToPermission(name, parent);
 
             if (perm != null) {
-                calculateChildPermissions(perm.getChildren(), !value, attachment);
+                calculateChildPermissions(perm.getChildren(), !value, attachment, worldName);
             }
         }
     }
@@ -208,6 +289,24 @@ public class PermissibleBase implements Permissible {
 
         if (result != null) {
             result.setPermission(name, value);
+        }
+
+        return result;
+    }
+
+    public PermissionAttachment addAttachment(Plugin plugin, String name, boolean value, int ticks, String worldName) {
+        if (name == null) {
+            throw new IllegalArgumentException("Permission name cannot be null");
+        } else if (plugin == null) {
+            throw new IllegalArgumentException("Plugin cannot be null");
+        } else if (!plugin.isEnabled()) {
+            throw new IllegalArgumentException("Plugin " + plugin.getDescription().getFullName() + " is disabled");
+        }
+
+        PermissionAttachment result = addAttachment(plugin, ticks);
+
+        if (result != null) {
+            result.setPermission(name, value, worldName);
         }
 
         return result;
@@ -232,7 +331,15 @@ public class PermissibleBase implements Permissible {
     }
 
     public Set<PermissionAttachmentInfo> getEffectivePermissions() {
-        return new HashSet<PermissionAttachmentInfo>(permissions.values());
+        Set<PermissionAttachmentInfo> ret = getEffectivePermissions(null);
+        if (entity != null) {
+            ret.addAll(getEffectivePermissions(entity.getWorld().getName()));
+        }
+        return ret;
+    }
+
+    public Set<PermissionAttachmentInfo> getEffectivePermissions(String worldName) {
+        return new HashSet<PermissionAttachmentInfo>(getPermissions(worldName).values());
     }
 
     private class RemoveAttachmentRunnable implements Runnable {

--- a/src/main/java/org/bukkit/permissions/PermissionAttachmentInfo.java
+++ b/src/main/java/org/bukkit/permissions/PermissionAttachmentInfo.java
@@ -9,8 +9,9 @@ public class PermissionAttachmentInfo {
     private final String permission;
     private final PermissionAttachment attachment;
     private final boolean value;
+    private final String worldName;
 
-    public PermissionAttachmentInfo(Permissible permissible, String permission, PermissionAttachment attachment, boolean value) {
+    public PermissionAttachmentInfo(Permissible permissible, String permission, PermissionAttachment attachment, boolean value, String worldName) {
         if (permissible == null) {
             throw new IllegalArgumentException("Permissible may not be null");
         } else if (permission == null) {
@@ -21,6 +22,7 @@ public class PermissionAttachmentInfo {
         this.permission = permission;
         this.attachment = attachment;
         this.value = value;
+        this.worldName = worldName;
     }
 
     /**
@@ -58,5 +60,14 @@ public class PermissionAttachmentInfo {
      */
     public boolean getValue() {
         return value;
+    }
+
+    /**
+     * Gets the name of the world this permission applies to, or null for all worlds
+     *
+     * @return Name of the world this permission applies to.
+     */
+    public String getWorldName() {
+        return worldName;
     }
 }

--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -437,7 +437,7 @@ public final class SimplePluginManager implements PluginManager {
     }
 
     public void removePermission(String name) {
-        permissions.remove(name);
+        permissions.remove(name.toLowerCase()).recalculatePermissibles();
     }
 
     public void recalculatePermissionDefaults(Permission perm) {


### PR DESCRIPTION
   Permissions can be registered in the global context (null world), but are overridden by world-specific permissions. Permissible.hasPermission() first checks the world, if the permissible is an Entity, and then checks globally. I also removed some unnecessary and expensive recalculatePermissions() calls.
   This change to allow permissions to be registered for all worlds at once, even unloaded worlds, so that permissions managers have to listen to fewer events and only have to update permissions when they are actually changed and when the player joins, reducing load when players are switching worlds. Plugins can also check permissions for specific worlds, which is used in, as an example, CommandBook, to check whether a player can teleport in their target world, not just the world they currently reside in.

CraftBukkit pull request: https://github.com/Bukkit/CraftBukkit/pull/546
