### PR TITLE
Add swamp tree generation

### DIFF
--- a/src/main/java/org/bukkit/BlockChangeDelegate.java
+++ b/src/main/java/org/bukkit/BlockChangeDelegate.java
@@ -31,6 +31,29 @@ public interface BlockChangeDelegate {
     public boolean setRawTypeIdAndData(int x, int y, int z, int typeId, int data);
 
     /**
+     * Set a block type at the specified coordinates.
+     *
+     * @param x X coordinate
+     * @param y Y coordinate
+     * @param z Z coordinate
+     * @param typeId New block ID
+     * @return true if the block was set successfully
+     */
+    public boolean setTypeId(int x, int y, int z, int typeId);
+
+    /**
+     * Set a block type and data at the specified coordinates.
+     *
+     * @param x X coordinate
+     * @param y Y coordinate
+     * @param z Z coordinate
+     * @param typeId New block ID
+     * @param data Block data
+     * @return true if the block was set successfully
+     */
+    public boolean setTypeIdAndData(int x, int y, int z, int typeId, int data);
+
+    /**
      * Get the block type at the location.
      * @param x X coordinate
      * @param y Y coordinate

--- a/src/main/java/org/bukkit/TreeType.java
+++ b/src/main/java/org/bukkit/TreeType.java
@@ -8,5 +8,6 @@ public enum TreeType {
     BIG_TREE,
     REDWOOD,
     TALL_REDWOOD,
-    BIRCH
+    BIRCH,
+    SWAMP_TREE
 }


### PR DESCRIPTION
This pull request will break plugins, because it makes changes to BlockChangeDelegate. Unfortunately, this is needs to be done because WorldGenSwampTrees uses setTypeIdAndData but BlockChangeDelegate only offers setRawTypeIdAndData. BlockSapling is also modified because it uses a BlockChangeDelegate and needs the new methods.

CraftBukkit pull: https://github.com/Bukkit/CraftBukkit/pull/547
