### PR TITLE
Add Block API for getting sky light and emitted light levels 

### DIFF
--- a/src/main/java/org/bukkit/block/Block.java
+++ b/src/main/java/org/bukkit/block/Block.java
@@ -89,6 +89,20 @@ public interface Block {
      */
     byte getLightLevel();
 
+    /** 
+     * Get the sky light level between 0-15
+     * 
+     * @return sky light level
+     */
+    byte getSkyLightLevel();
+    
+    /**
+     * Get the emitted light level between 0-15
+     * 
+     * @return emitted light level
+     */
+    byte getEmittedLightLevel();
+    
     /**
      * Gets the world which contains this Block
      *


### PR DESCRIPTION
These allow access to the lower-level lighting data, which can be used for both light color sensitivity (redder emitted light vs bluer sky light), as well as other light-type-sensitive functions (sky light level approximates visibility of the location from above, predicting light levels after dark or during storms, etc).

(Accidentally closed first request - see https://github.com/Bukkit/Bukkit/pull/390 for previous discussion)

Corresponding pull in Craftbukkit - https://github.com/Bukkit/CraftBukkit/pull/515
