### PR TITLE
Added toDimension property to PlayerPortalEvent.

### DIFF
--- a/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
@@ -13,9 +13,17 @@ public class PlayerPortalEvent extends PlayerTeleportEvent {
 
     protected Player player;
     protected TravelAgent travelAgent;
+    protected Integer toDimension = null;
 
-    public PlayerPortalEvent(Player player, Location from, Location to, TravelAgent pta) {
+    public PlayerPortalEvent(Player player, Location from, Location to, TravelAgent pta, Integer toDimension) {
         super(Type.PLAYER_PORTAL, player, from, to);
+        this.travelAgent = pta;
+        this.toDimension = toDimension;
+    }
+    
+    @Deprecated
+    public PlayerPortalEvent(Player player, Location from, Location to, TravelAgent pta) {
+    	super(Type.PLAYER_PORTAL, player, from, to);
         this.travelAgent = pta;
     }
 
@@ -33,5 +41,9 @@ public class PlayerPortalEvent extends PlayerTeleportEvent {
 
     public void setPortalTravelAgent(TravelAgent travelAgent) {
         this.travelAgent = travelAgent;
+    }
+    
+    public int getToDimension() {
+    	return this.toDimension;
     }
 }


### PR DESCRIPTION
I have added a "toDimension" property to PlayerPortalEvent as it is now impossible to find out to which dimension the player is travelling - previously (as there were two) it was just the opposite of the one the player was in.

Corresponding CraftBukkit pull: https://github.com/Bukkit/CraftBukkit/pull/554
