### PR TITLE
Add the missing effects to the Effect enum

### DIFF
--- a/src/main/java/org/bukkit/Effect.java
+++ b/src/main/java/org/bukkit/Effect.java
@@ -10,8 +10,14 @@ public enum Effect {
     DOOR_TOGGLE(1003),
     EXTINGUISH(1004),
     RECORD_PLAY(1005),
+    GHAST_SHRIEK(1007),
+    GHAST_SHOOT(1008),
+    BLAZE_SHOOT(1009),
     SMOKE(2000),
-    STEP_SOUND(2001);
+    STEP_SOUND(2001),
+    POTION_BREAK(2002),
+    ENDER_SIGNAL(2003),
+    MOBSPAWNER_FLAMES(2004);
 
     private final int id;
 


### PR DESCRIPTION
The title says it all.

A way to use effects by their ID, instead of having to specify an enum constant, would be nice too.
