### PR TITLE
Changed Material.getMaterial(int) to use an array instead of a HashMap for lookups

### DIFF
--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -2,11 +2,13 @@ package org.bukkit;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.bukkit.material.*;
+import org.bukkit.util.Java15Compat;
 
 /**
  * An enum of all material ids accepted by the official server + client
@@ -277,7 +279,7 @@ public enum Material {
 
     private final int id;
     private final Class<? extends MaterialData> data;
-    private static final Map<Integer, Material> lookupId = new HashMap<Integer, Material>();
+    private static Material[] lookupId = new Material[3200];
     private static final Map<String, Material> lookupName = new HashMap<String, Material>();
     private final int maxStack;
     private final short durability;
@@ -394,7 +396,11 @@ public enum Material {
      * @return Material if found, or null
      */
     public static Material getMaterial(final int id) {
-        return lookupId.get(id);
+        if (lookupId.length > id) {
+            return lookupId[id];
+        } else {
+            return null;
+        }
     }
 
     /**
@@ -436,7 +442,12 @@ public enum Material {
 
     static {
         for (Material material : values()) {
-            lookupId.put(material.getId(), material);
+            if (lookupId.length > material.id) {
+                lookupId[material.id] = material;
+            } else {
+                lookupId = Java15Compat.Arrays_copyOfRange(lookupId, 0, material.id + 2);
+                lookupId[material.id] = material;
+            }
             lookupName.put(material.name(), material);
         }
     }


### PR DESCRIPTION
This gives a massive speed improvement for everything that uses the method. I similarly changed Glowstone's by-id lookup methods to use this system (It looks up block information for every block in every loaded chunk) and got a massive actual speed boost.
