### PR TITLE
Allow sending custom packets through Bukkit.

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -466,4 +466,6 @@ public interface Player extends HumanEntity, CommandSender, OfflinePlayer {
      * @return Bed Spawn Location if bed exists, otherwise null.
      */
     public Location getBedSpawnLocation();
+    
+    public void sendRawPacket(int packetId, byte[] data, boolean lowPriority);
 }


### PR DESCRIPTION
The format matches the wire format of minecraft packets and it should thus be possible to implement this on any server that uses the same protocol.
It is useful for plugins that want to communicate with client-side addons.
In particular, WorldEdit plans to use this to communicate with the WorldEdit CUI client-side addon.

Click [here](https://github.com/Bukkit/CraftBukkit/pull/565) for an according CraftBukkit patch.
Click [here](https://bukkit.atlassian.net/browse/BUKKIT-161) for the according JIRA ticket.
