### PR TITLE
Added Plugin.saveDefaultConfig() method

### DIFF
--- a/src/main/java/org/bukkit/plugin/Plugin.java
+++ b/src/main/java/org/bukkit/plugin/Plugin.java
@@ -58,6 +58,12 @@ public interface Plugin extends CommandExecutor {
      * Saves the {@link FileConfiguration} retrievable by {@link #getConfig()}.
      */
     public void saveConfig();
+
+    /**
+     * Saves the raw contents of the default config.yml file to the location retrievable by {@link #getConfig()}.
+     * If there is no default config.yml embedded in the plugin, an empty config.yml file is saved.
+     */
+    public void saveDefaultConfig();
     
     /**
      * Discards any data in {@link #getConfig()} and reloads from disk.

--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
@@ -6,9 +6,8 @@ import com.avaje.ebean.config.DataSourceConfig;
 import com.avaje.ebean.config.ServerConfig;
 import com.avaje.ebeaninternal.api.SpiEbeanServer;
 import com.avaje.ebeaninternal.server.ddl.DdlGenerator;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
+
+import java.io.*;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
@@ -143,6 +142,36 @@ public abstract class JavaPlugin implements Plugin {
             newConfig.save(configFile);
         } catch (IOException ex) {
             Logger.getLogger(JavaPlugin.class.getName()).log(Level.SEVERE, "Could not save config to " + configFile, ex);
+        }
+    }
+
+    public void saveDefaultConfig() {
+        File outFile = new File(getDataFolder(), "config.yml");
+        InputStream in = getResource("config.yml");
+
+        if(!getDataFolder().exists()) {
+            getDataFolder().mkdir();
+        }
+
+        if(in == null) {
+            in = new ByteArrayInputStream(new byte[0]);
+        }
+
+        try {
+            if(!outFile.exists()) {
+                OutputStream out = new FileOutputStream(outFile);
+                byte[] buf = new byte[1024];
+                int len;
+                while((len=in.read(buf))>0) {
+                    out.write(buf,0,len);
+                }
+                out.close();
+                in.close();
+            } else {
+                Logger.getLogger(JavaPlugin.class.getName()).log(Level.WARNING, "Could not save default config to " + outFile + " because " + outFile.getName() + " already exists.");
+            }
+        } catch (IOException ex) {
+            Logger.getLogger(JavaPlugin.class.getName()).log(Level.SEVERE, "Could not save default config to " + outFile, ex);
         }
     }
     


### PR DESCRIPTION
Turning on options.copyDefaults(true) and then calling Plugin.saveConfig() is the existing method for saving the embedded config.yml file to disk, but in the process all formatting, spacing, and comments are stripped from the file. The Plugin.SaveDefaultConfig() method writes the contents of the default config.yml file to the default configuration location verbatim. The result is a default config.yml file with all formatting and comments preserved.
- If the default configuration directory is absent, SaveDefaultConfig() will create it.
- It the default config.yml is missing from the plugin, SaveDefaultConfig() will write out a blank file.
- If a config.yml file already exists in the target directory, SaveDefaultConfig() will not overwrite it and will write a warning in the log.
