### PR TITLE
Don't let child permissions overwrite directly set permissions.

### DIFF
--- a/src/main/java/org/bukkit/permissions/PermissibleBase.java
+++ b/src/main/java/org/bukkit/permissions/PermissibleBase.java
@@ -185,6 +185,7 @@ public class PermissibleBase implements Permissible {
             Permission perm = Bukkit.getServer().getPluginManager().getPermission(name);
             boolean value = children.get(name) ^ invert;
             String lname = name.toLowerCase();
+            if (permissions.contains(lname)) continue;
 
             permissions.put(lname, new PermissionAttachmentInfo(parent, lname, attachment, value));
             Bukkit.getServer().getPluginManager().subscribeToPermission(name, parent);


### PR DESCRIPTION
Might be nice to give for example moderators foobar.kit.admin (has some child permissions, inclulding foobar.config) but not foobar.config.
