### PR TITLE
Add EnderPortalEvent

### DIFF
--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -727,6 +727,12 @@ public abstract class Event implements Serializable {
          */
         ENDERMAN_PLACE (Category.LIVING_ENTITY),
         /**
+         * Called when an EnderDragons places a portal
+         *
+         * @see org.bukkit.event.entity.EnderPortalEvent
+         */
+        ENDER_PORTAL (Category.LIVING_ENTITY),
+        /**
          * Called when a human entity's food level changes
          *
          * @see org.bukkit.event.entity.FoodLevelChangeEvent

--- a/src/main/java/org/bukkit/event/entity/EnderPortalEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EnderPortalEvent.java
@@ -1,0 +1,34 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Cancellable;
+
+public class EnderPortalEvent extends EntityEvent implements Cancellable {
+
+    private boolean cancel;
+    private Location location;
+
+    public EnderPortalEvent(Entity what, Location location) {
+        super(Type.ENDER_PORTAL, what);
+        this.location = location;
+        this.cancel = false;
+    }
+
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+
+    /**
+     * Get the location that the Ender Portal is going to start at.
+     *
+     * @return location the ender portal is going to start at
+     */
+    public Location getLocation() {
+        return location;
+    }
+}


### PR DESCRIPTION
This is to add an event for when EnderDragons create their EnderPortal on death.  They are messy and can grief horribly if more than one dragon is spawned, as to be expected with SMP.

This provides the starting Location of the portal.
