### PR TITLE
Add methods to set and retrieve per-player permission to fly

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -470,7 +470,7 @@ public interface Player extends HumanEntity, CommandSender, OfflinePlayer {
     /**
      * Determines if the Player is allowed to fly via jump key double-tap like in creative mode.
      * 
-     * @return Boolean
+     * @return True if the player is allowed to fly
      */
     public boolean getAllowFlight();
     

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -466,4 +466,19 @@ public interface Player extends HumanEntity, CommandSender, OfflinePlayer {
      * @return Bed Spawn Location if bed exists, otherwise null.
      */
     public Location getBedSpawnLocation();
+    
+    /**
+     * Determines if the Player is allowed to fly via jump key double-tap like in creative mode.
+     * 
+     * @return Boolean
+     */
+    public boolean getAllowFlight();
+    
+    /**
+     * Sets if the Player is allowed to fly via jump key double-tap like in creative mode.
+     * 
+     * @param flight If flight should be allowed
+     */
+    public void setAllowFlight(boolean flight);
+    
 }


### PR DESCRIPTION
I plan on using these methods in a plugin i am developing.

I already have a modded client prototype in which the player can natively fly in survival mode. It needs some reworking, but once done, this could be useful for numerous role-playing scenarios.

This goes together with PR 582 against CraftBukkit: https://github.com/Bukkit/CraftBukkit/pull/582
