### PR TITLE
Fixed rare NPE in saveConfig

### DIFF
--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
@@ -139,6 +139,9 @@ public abstract class JavaPlugin implements Plugin {
     }
     
     public void saveConfig() {
+        if (newConfig == null) {
+            return;
+        }
         try {
             newConfig.save(configFile);
         } catch (IOException ex) {


### PR DESCRIPTION
Fixed NPE that occurs when saveConfig is called before getConfig. Added null check, do nothing if null.
