### PR TITLE
Enhance PlayerDeathEvent

### DIFF
--- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
+++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
@@ -11,10 +11,23 @@ import org.bukkit.inventory.ItemStack;
 public class PlayerDeathEvent extends EntityDeathEvent {
     private int newExp = 0;
     private String deathMessage = "";
+    private int newLevel = 0;
+    private int newTotalExp = 0;
+    private boolean keepLevel = false;
 
+    public PlayerDeathEvent(Player player, List<ItemStack> drops, int droppedExp, String deathMessage) {
+        this(player, drops, droppedExp, 0, deathMessage);
+    }
+    
     public PlayerDeathEvent(Player player, List<ItemStack> drops, int droppedExp, int newExp, String deathMessage) {
+        this(player, drops, droppedExp, newExp, 0, 0, deathMessage);
+    }
+    
+    public PlayerDeathEvent(Player player, List<ItemStack> drops, int droppedExp, int newExp, int newTotalExp, int newLevel, String deathMessage) {
         super(player, drops, droppedExp);
         this.newExp = newExp;
+        this.newTotalExp = newTotalExp;
+        this.newLevel = newLevel;
         this.deathMessage = deathMessage;
     }
 
@@ -33,7 +46,7 @@ public class PlayerDeathEvent extends EntityDeathEvent {
      * @return Message to appear to other players on the server.
      */
     public String getDeathMessage() {
-        return this.deathMessage;
+        return deathMessage;
     }
 
     /**
@@ -57,6 +70,64 @@ public class PlayerDeathEvent extends EntityDeathEvent {
      * @get exp New EXP of the respawned player
      */
     public void setNewExp(int exp) {
-        this.newExp = exp;
+        newExp = exp;
+    }
+    
+    /**
+     * Gets the Level the Player should have at respawn.
+     * 
+     * @return New Level of the respawned player
+     */
+    public int getNewLevel() {
+        return newLevel;
+    }
+    
+    /**
+     * Sets the Level the Player should have at respawn.
+     * 
+     * @get level New Level of the respawned player
+     */
+    public void setNewLevel(int level) {
+        newLevel = level;
+    }
+    
+    /**
+     * Gets the Total EXP the Player should have at respawn.
+     * 
+     * @return New Total EXP of the respawned player
+     */
+    public int getNewTotalExp() {
+        return newTotalExp;
+    }
+    
+    /**
+     * Sets the Total EXP the Player should have at respawn.
+     * 
+     * @get totalExp New Total EXP of the respawned player
+     */
+    public void setNewTotalExp(int totalExp) {
+        newTotalExp = totalExp;
+    }
+    
+    /**
+     * Gets if the Player should keep all EXP at respawn.
+     * <p>
+     * This flag overrides other EXP settings
+     * 
+     * @return True if Player should keep all pre-death exp
+     */
+    public boolean getKeepLevel() {
+        return keepLevel;
+    }
+    
+    /**
+     * Sets if the Player should keep all EXP at respawn.
+     * <p>
+     * This overrides all other EXP settings
+     * 
+     * @param keepLevel True to keep all current value levels
+     */
+    public void setKeepLevel(boolean keepLevel) {
+        this.keepLevel = keepLevel;
     }
 }


### PR DESCRIPTION
Adds the following:
- newLevel - Functions same as newExp
- newTotalExp - Functions same as newExp
- keepLevel - Overrides newLevel/newTotal/Exp and sets according to current player values.

CraftBukkit: https://github.com/Bukkit/CraftBukkit/pull/587
