### PR TITLE
class-loader-of option in plugin.yml

### DIFF
--- a/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
+++ b/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
@@ -19,6 +19,7 @@ public final class PluginDescriptionFile {
     private static final Yaml yaml = new Yaml(new SafeConstructor());
     private String name = null;
     private String main = null;
+    private String classLoaderOf = null;
     private ArrayList<String> depend = null;
     private ArrayList<String> softDepend = null;
     private String version = null;
@@ -152,6 +153,10 @@ public final class PluginDescriptionFile {
     public PermissionDefault getPermissionDefault() {
         return defaultPerm;
     }
+    
+    public String getClassLoaderOf() {
+	return classLoaderOf;
+    }
 
     private void loadMap(Map<String, Object> map) throws InvalidDescriptionException {
         try {
@@ -193,6 +198,10 @@ public final class PluginDescriptionFile {
             }
         }
 
+        if (map.containsKey("class-loader-of")) {
+            classLoaderOf = map.get("class-loader-of").toString();
+        }
+        
         if (map.containsKey("depend")) {
             try {
                 depend = (ArrayList<String>) map.get("depend");
@@ -316,6 +325,10 @@ public final class PluginDescriptionFile {
             map.put("authors", authors);
         }
 
+        if (classLoaderOf != null) {
+            map.put("class-loader-of", classLoaderOf);
+        }
+        
         return map;
     }
 }

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -166,7 +166,13 @@ public class JavaPluginLoader implements PluginLoader {
             URL[] urls = new URL[1];
 
             urls[0] = file.toURI().toURL();
-            loader = new PluginClassLoader(this, urls, getClass().getClassLoader());
+            if (description.getClassLoaderOf() != null) {
+        	loader = loaders.get(description.getClassLoaderOf());
+        	loader.addURL(urls[0]);
+            } else {
+        	loader = new PluginClassLoader(this, urls, getClass().getClassLoader());
+            }
+            
             Class<?> jarClass = Class.forName(description.getMain(), true, loader);
             Class<? extends JavaPlugin> plugin = jarClass.asSubclass(JavaPlugin.class);
 

--- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
@@ -20,6 +20,11 @@ public class PluginClassLoader extends URLClassLoader {
     }
 
     @Override
+    public void addURL(URL url) {
+        super.addURL(url);
+    }
+    
+    @Override
     protected Class<?> findClass(String name) throws ClassNotFoundException {
         return findClass(name, true);
     }


### PR DESCRIPTION
Allow plugins to specify class-loader-of so that they can be loaded in the same classloader as a depend plugin (provide the single plugin name, same as depend, but not a list)

For my specific case, I'm implementing a way of writing plugins using clojure. Clojure really doesn't work well across classloaders. I had tried all sorts of alternatives, including overriding the getResourceAsInputStream (et al) in the PluginClassLoader, but that still gave all sorts of issues.

Out of everything I've tried, this is the only thing that really works cleanly - I tried with all sorts of different ways from my clojure plugin first, but I didn't have enough accessibility from the plugin itself in order to override the classloader correctly.

I hope that this makes it into the latest build so that I can at some stage make the Clojure plugin widely available - without this change (or something of similar nature), I don't think I can push this to anything other than a private hobby-horse since making plugins that extend from the Clojure plugin wouldn't work :/

Thank you for your time!
