### PR TITLE
Adds Location.getChunk()

### DIFF
--- a/src/main/java/org/bukkit/Location.java
+++ b/src/main/java/org/bukkit/Location.java
@@ -64,6 +64,15 @@ public class Location implements Cloneable {
     }
 
     /**
+     * Gets the chunk at the represented location
+     *
+     * @return Chunk at the represented location
+     */
+    public Chunk getChunk() {
+        return world.getChunkAt(this);
+    }
+
+    /**
      * Gets the block at the represented location
      *
      * @return Block at the represented location


### PR DESCRIPTION
This is a very simple and straightforward change. Needed a way to get the chunk of a location without forcing the chunk to load (i.e. `Location.getBlock().getChunk()`). Currently, the best way to do this seems to be `Location.getWorld().getChunkAt(Location)`, which is a bit messy, so this pull adds a `Location.getChunk()`.
