### PR TITLE
Fixed whitespace appearing at the top of .yml files on Windows

### DIFF
--- a/src/main/java/org/bukkit/configuration/MemorySection.java
+++ b/src/main/java/org/bukkit/configuration/MemorySection.java
@@ -289,7 +289,7 @@ public class MemorySection implements ConfigurationSection {
         }
 
         Object def = getDefault(path);
-        return getString(path, (def instanceof String) ? (String)def : null);
+        return getString(path, def != null ? def.toString() : null);
     }
 
     public String getString(String path, String def) {
@@ -298,7 +298,7 @@ public class MemorySection implements ConfigurationSection {
         }
 
         Object val = get(path, def);
-        return (val instanceof String) ? (String)val : def;
+        return (val != null) ? val.toString() : def;
     }
 
     public boolean isString(String path) {

--- a/src/main/java/org/bukkit/configuration/MemorySection.java
+++ b/src/main/java/org/bukkit/configuration/MemorySection.java
@@ -881,9 +881,13 @@ public class MemorySection implements ConfigurationSection {
         if (path == null) {
             throw new IllegalArgumentException("Path cannot be null");
         }
-
-        Object val = get(path, getDefault(path));
-        return (val instanceof ConfigurationSection) ? (ConfigurationSection)val : null;
+        
+        Object val = get(path, null);
+        if (val != null)
+            return (val instanceof ConfigurationSection) ? (ConfigurationSection)val : null;
+        
+        val = get(path, getDefault(path));
+        return (val instanceof ConfigurationSection) ? createSection(path) : null;
     }
 
     public boolean isConfigurationSection(String path) {

--- a/src/main/java/org/bukkit/configuration/file/YamlConfiguration.java
+++ b/src/main/java/org/bukkit/configuration/file/YamlConfiguration.java
@@ -159,7 +159,9 @@ public class YamlConfiguration extends FileConfiguration {
                     result.append(line.substring(COMMENT_PREFIX.length()));
                 }
             } else if (line.length() == 0) {
-                result.append("\n");
+                if (i > 0) {
+                    result.append("\n");
+                }
             } else {
                 readingHeader = false;
             }

--- a/src/test/java/org/bukkit/configuration/file/FileConfigurationTest.java
+++ b/src/test/java/org/bukkit/configuration/file/FileConfigurationTest.java
@@ -160,6 +160,10 @@ public abstract class FileConfigurationTest extends MemoryConfigurationTest {
         
         assertEquals(values.keySet(), config.getKeys(true));
         assertEquals(header + "\n" + saved, config.saveToString());
+        
+        config = getConfig();
+        config.loadFromString("\n" + saved);
+        assertEquals(saved, config.saveToString());
     }
 
     @Test


### PR DESCRIPTION
This was a PR against 1.9 (https://github.com/Bukkit/Bukkit/pull/407) which i thought resolved itself. Turns out i was wrong. Thanks @codename-b and @sleaker for pointing it out again!

The first and most important: _It doesn't occur in Linux!_ I can reproduce it now on Win 7 with Java 1.6 and 1.7.0_01 but not in Debian with 1.6.0_26!

All of the the following were tested with own builds of the current master of Bukkit and 2d430c131bac7697778a62baf2f09d5569187a00 and Craftbukkit: 1e6a083075616c006395724694a3f9c2360b1a37 and also with Jenkins' b1602 on Windows 7.

My code to reproduce the bug:

```
public class testplugin1 extends JavaPlugin {
    public void onEnable() {
        FileConfiguration config = getConfig();
        config.set("Key", "Value");
        saveConfig();
    }
}
```

I am starting with an empty config at first. With every server reload, onEnable is hit and rewrites the config.yml. I will check file size and look at its hexdump after every iteration.

After starting up CB: 13 bytes - some whitespace at the top of the file but no huge problem.
    $ dump config.yml
    config.yml:
    00000000  0a0a 4b65 793a 2056 616c 7565 0a        ..Key: Value.

After using "reload" command once in CB: 14 bytes - it added an LF (0x0a) to the beginning of the file.
    $ dump config.yml
    config.yml:
    00000000  0a0a 0a4b 6579 3a20 5661 6c75 650a      ...Key: Value.

After using "reload" once more: 15 bytes
    $ dump config.yml
    config.yml:
    00000000  0a0a 0a0a 4b65 793a 2056 616c 7565 0a   ....Key: Value.
