### PR TITLE
Potions (and water bottles) don't stack.

### DIFF
--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -253,7 +253,7 @@ public enum Material {
     GHAST_TEAR(370),
     GOLD_NUGGET(371),
     NETHER_STALK(372),
-    POTION(373),
+    POTION(373, 1),
     GLASS_BOTTLE(374),
     SPIDER_EYE(375),
     FERMENTED_SPIDER_EYE(376),


### PR DESCRIPTION
Well - that's it. Potions and water bottles don't stack in Minecraft.
