### PR TITLE
Fixed typo in Javadoc.

### DIFF
--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -596,7 +596,7 @@ public abstract class Event implements Serializable {
         /**
          * Called when an organic structure attempts to grow (Sapling -> Tree), (Mushroom -> Huge Mushroom), naturally or using bonemeal.
          *
-+        * @see org.bukkit.event.world.TreeGrowEvent
++        * @see org.bukkit.event.world.StructureGrowEvent
          */
         STRUCTURE_GROW (Category.WORLD),
 


### PR DESCRIPTION
Changed "TreeGrowEvent" in "StructureGrowEvent".
No corresponding CraftBukkit pull.
