### PR TITLE
Don't unnecessarily recalculate permissions

### DIFF
--- a/src/main/java/org/bukkit/permissions/PermissibleBase.java
+++ b/src/main/java/org/bukkit/permissions/PermissibleBase.java
@@ -106,8 +106,6 @@ public class PermissibleBase implements Permissible {
         PermissionAttachment result = addAttachment(plugin);
         result.setPermission(name, value);
 
-        recalculatePermissions();
-
         return result;
     }
 
@@ -121,7 +119,6 @@ public class PermissibleBase implements Permissible {
         PermissionAttachment result = new PermissionAttachment(plugin, parent);
 
         attachments.add(result);
-        recalculatePermissions();
 
         return result;
     }

--- a/src/main/java/org/bukkit/permissions/PermissionAttachment.java
+++ b/src/main/java/org/bukkit/permissions/PermissionAttachment.java
@@ -1,7 +1,9 @@
 package org.bukkit.permissions;
 
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import org.bukkit.plugin.Plugin;
 
 /**
@@ -13,14 +15,14 @@ public class PermissionAttachment {
     private final Permissible permissible;
     private final Plugin plugin;
 
-    public PermissionAttachment(Plugin plugin, Permissible Permissible) {
+    public PermissionAttachment(Plugin plugin, Permissible permissible) {
         if (plugin == null) {
             throw new IllegalArgumentException("Plugin cannot be null");
         } else if (!plugin.isEnabled()) {
             throw new IllegalArgumentException("Plugin " + plugin.getDescription().getFullName() + " is disabled");
         }
 
-        this.permissible = Permissible;
+        this.permissible = permissible;
         this.plugin = plugin;
     }
 
@@ -89,7 +91,19 @@ public class PermissionAttachment {
      * @param value New value of the permission
      */
     public void setPermission(Permission perm, boolean value) {
-        setPermission(perm.getName(), value);
+        permissions.put(perm.getName().toLowerCase(), value);
+        permissible.recalculatePermissions();
+    }
+
+    /**
+     * Sets permissions to given values, by their fully qualified names
+     * 
+     * @param permissions The permission and value pairs
+     */
+    public void setPermissions(Map<String, Boolean> permissions) {
+        for(Entry<String, Boolean> entry : permissions.entrySet()) {
+            permissions.put(entry.getKey().toLowerCase(), entry.getValue());
+        }
         permissible.recalculatePermissions();
     }
 
@@ -113,7 +127,21 @@ public class PermissionAttachment {
      * @param perm Permission to remove
      */
     public void unsetPermission(Permission perm) {
-        unsetPermission(perm.getName());
+        permissions.remove(perm.getName().toLowerCase());
+        permissible.recalculatePermissions();
+    }
+
+    /**
+     * Removes the specified permissions from this attachment.
+     * 
+     * If a permission does not exist in this attachment, nothing will happen.
+     * 
+     * @param permissions Permissions to remove
+     */
+    public void unsetPermissions(Collection<String> permissions) {
+        for(String name : permissions) {
+            permissions.remove(name.toLowerCase());
+        }
         permissible.recalculatePermissions();
     }
 


### PR DESCRIPTION
At this code location, the only change made to permissions is that we added an empty attachment. We know that it is empty because it gets created empty just 2 lines above.

Yet we still do recalculate all permissions afterwards (very expensive operation!) for no reason, as nothing could have changed. This is especially wasteful, because shortly afterwards another recalculation will take place anyway, when the plugin that added the attachment (or the calling method - this method is used by many others in this class) starts to fill it with permissions.

Just stumbled upon this and found that it's a very simple way to cut the time it takes to add a permission attachment to a player in half.
