### PR TITLE
Add a reason code to PortalCreateEvent.

### DIFF
--- a/src/main/java/org/bukkit/event/world/PortalCreateEvent.java
+++ b/src/main/java/org/bukkit/event/world/PortalCreateEvent.java
@@ -13,10 +13,12 @@ import java.util.Collection;
 public class PortalCreateEvent extends WorldEvent implements Cancellable {
     private boolean cancel = false;
     private ArrayList<Block> blocks = new ArrayList<Block>();
+    private Reason reason = Reason.FIRE;
 
-    public PortalCreateEvent(final Collection<Block> blocks, final World world) {
+    public PortalCreateEvent(final Collection<Block> blocks, final World world, Reason reason) {
         super(Type.PORTAL_CREATE, world);
         this.blocks.addAll(blocks);
+        this.reason = reason;
     }
 
     /**
@@ -34,5 +36,14 @@ public class PortalCreateEvent extends WorldEvent implements Cancellable {
 
     public void setCancelled(boolean cancel) {
         this.cancel = cancel;
+    }
+    
+    public Reason getReason() {
+        return reason;
+    }
+    
+    public enum Reason {
+        FIRE,
+        FAR_END
     }
 }


### PR DESCRIPTION
Plugins have no way to distinguish a portal that is being created by a
player setting fire to an obsidian frame and a portal that is created
because a player goes through an existing portal and needs somewhere
to come out.  This commit adds:
1. a enum PortalCreateEvent.Reason, with two values: FIRE (for when a
frame is set fire) and FAR_END (for when a portal is created as a
destination for an existing portal).
2. PortalCreateEvent.reason, a field of type Reason, to hold the
reason for the event.
3. PortalCreateEvent.getReason(), so plugins can get the reason.
