### PR TITLE
Fixed + improved ConfigurationSerialization

### DIFF
--- a/src/main/java/org/bukkit/configuration/serialization/ConfigurationSerialization.java
+++ b/src/main/java/org/bukkit/configuration/serialization/ConfigurationSerialization.java
@@ -163,11 +163,16 @@ public class ConfigurationSerialization {
         if (args.containsKey(SERIALIZED_TYPE_KEY)) {
             try {
                 String alias = (String) args.get(SERIALIZED_TYPE_KEY);
+                clazz = getClassByAlias(alias);
+                if (clazz == null) {
+                    try {
+                        clazz = Class.forName(alias).asSubclass(ConfigurationSerializable.class);
+                    } catch (Exception e) {
+                    }
+                }
 
-                if (alias == null) {
-                    throw new IllegalArgumentException("Specified class does not exist ('" + alias + ")'");
-                } else {
-                    clazz = getClassByAlias(alias);
+                if (clazz == null) {
+                    throw new IllegalArgumentException(String.format("Specified class does not exist ('%s')", alias));
                 }
             } catch (ClassCastException ex) {
                 ex.fillInStackTrace();


### PR DESCRIPTION
The fix: `ConfigurationSerialization.deserializeObject(Map<String, Object>)` was doing the null-check on `alias`, not on `clazz`. That resulted in NPEs if a plugin tried to deserialize a class from the config that was not registered.
# 

The improvement: The method now tries to get the class with `Class.forName()` if it wasn't in the alias-map ==> classes don't have to be registered, very useful.
