### PR TITLE
YamlConfiguration support for ConfigurationSerializable inside collections

### DIFF
--- a/src/main/java/org/bukkit/configuration/MemorySection.java
+++ b/src/main/java/org/bukkit/configuration/MemorySection.java
@@ -189,7 +189,7 @@ public class MemorySection implements ConfigurationSection {
             if (value == null) {
                 map.remove(key);
             } else {
-                map.put(key, prepForStorage(value));
+                map.put(key, value);
             }
         } else {
             section.set(key, value);
@@ -905,31 +905,11 @@ public class MemorySection implements ConfigurationSection {
         return val instanceof ConfigurationSection;
     }
 
-    protected Object prepForStorage(Object input) {
-        if (input == null) {
-            throw new IllegalArgumentException("Cannot store null");
-        }
-
-        if (isPrimitiveWrapper(input) || isNaturallyStorable(input)) {
-            return input;
-        } else if (input instanceof ConfigurationSerializable) {
-            return input;
-        }
-
-        throw new IllegalArgumentException("Cannot store " + input + " into " + this + ", unsupported class");
-    }
-
     protected boolean isPrimitiveWrapper(Object input) {
         return input instanceof Integer || input instanceof Boolean ||
                 input instanceof Character || input instanceof Byte ||
                 input instanceof Short || input instanceof Double ||
                 input instanceof Long || input instanceof Float;
-    }
-
-    protected boolean isNaturallyStorable(Object input) {
-        return input instanceof List || input instanceof Iterable ||
-                input instanceof String || input instanceof File ||
-                input instanceof Enum;
     }
 
     protected Object getDefault(String path) {

--- a/src/main/java/org/bukkit/configuration/file/YamlConstructor.java
+++ b/src/main/java/org/bukkit/configuration/file/YamlConstructor.java
@@ -1,0 +1,47 @@
+package org.bukkit.configuration.file;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.yaml.snakeyaml.nodes.Node;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.error.YAMLException;
+import org.yaml.snakeyaml.nodes.Tag;
+
+import org.bukkit.configuration.serialization.ConfigurationSerialization;
+
+public class YamlConstructor extends SafeConstructor {
+
+    public YamlConstructor() {
+        this.yamlConstructors.put(Tag.MAP, new ConstructCustomObject());
+    }
+
+    private class ConstructCustomObject extends ConstructYamlMap {
+        public Object construct(Node node) {
+            if (node.isTwoStepsConstruction()) {
+                throw new YAMLException("Unexpected referential mapping structure. Node: " + node);
+            }
+
+            Map<Object, Object> raw = (Map<Object, Object>) super.construct(node);
+
+            if (raw.containsKey(ConfigurationSerialization.SERIALIZED_TYPE_KEY)) {
+                Map<String, Object> typed = new LinkedHashMap<String, Object>(raw.size());
+                for (Map.Entry<Object, Object> entry : raw.entrySet()) {
+                    typed.put(entry.getKey().toString(), entry.getValue());
+                }
+
+                try {
+                    return ConfigurationSerialization.deserializeObject(typed);
+                } catch (IllegalArgumentException ex) {
+                    throw new YAMLException("Could not deserialize object", ex);
+                }
+            }
+
+            return raw;
+        }
+
+        public void construct2ndStep(Node node, Object object) {
+            throw new YAMLException("Unexpected referential mapping structure. Node: " + node);
+        }
+    }
+}

--- a/src/main/java/org/bukkit/configuration/file/YamlRepresenter.java
+++ b/src/main/java/org/bukkit/configuration/file/YamlRepresenter.java
@@ -1,0 +1,40 @@
+
+package org.bukkit.configuration.file;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.bukkit.configuration.serialization.ConfigurationSerialization;
+
+import org.yaml.snakeyaml.nodes.Node;
+import org.yaml.snakeyaml.representer.Represent;
+import org.yaml.snakeyaml.representer.Representer;
+
+public class YamlRepresenter extends Representer {
+
+    public YamlRepresenter() {
+        this.multiRepresenters.put(ConfigurationSection.class, new RepresentConfigurationSection());
+        this.multiRepresenters.put(ConfigurationSerializable.class, new RepresentConfigurationSerializable());
+    }
+
+    private class RepresentConfigurationSection extends RepresentMap {
+        @SuppressWarnings("unchecked")
+        public Node representData(Object data) {
+            return super.representData(((ConfigurationSection) data).getValues(false));
+        }
+    }
+
+    private class RepresentConfigurationSerializable extends RepresentMap {
+        @SuppressWarnings("unchecked")
+        public Node representData(Object data) {
+            ConfigurationSerializable serializable = (ConfigurationSerializable) data;
+            Map<String, Object> values = new LinkedHashMap<String, Object>();
+            values.put(ConfigurationSerialization.SERIALIZED_TYPE_KEY, ConfigurationSerialization.getAlias(serializable.getClass()));
+            values.putAll(serializable.serialize());
+
+            return super.representData(values);
+        }
+    }
+}

--- a/src/main/java/org/bukkit/configuration/serialization/ConfigurationSerialization.java
+++ b/src/main/java/org/bukkit/configuration/serialization/ConfigurationSerialization.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.BlockVector;
 import org.bukkit.util.Vector;
 
@@ -21,6 +22,7 @@ public class ConfigurationSerialization {
     static {
         registerClass(Vector.class);
         registerClass(BlockVector.class);
+        registerClass(ItemStack.class);
     }
 
     protected ConfigurationSerialization(Class<? extends ConfigurationSerializable> clazz) {

--- a/src/main/java/org/bukkit/inventory/ItemStack.java
+++ b/src/main/java/org/bukkit/inventory/ItemStack.java
@@ -323,7 +323,7 @@ public class ItemStack implements ConfigurationSerializable {
     public Map<String, Object> serialize() {
         Map<String, Object> result = new LinkedHashMap<String, Object>();
 
-        result.put("type", getType());
+        result.put("type", getType().name());
 
         if (durability != 0) {
             result.put("damage", durability);
@@ -350,18 +350,18 @@ public class ItemStack implements ConfigurationSerializable {
 
     public static ItemStack deserialize(Map<String, Object> args) {
         Material type = Material.getMaterial((String) args.get("type"));
-        short damage = 0;
+        int damage = 0;
         int amount = 1;
 
         if (args.containsKey("damage")) {
-            damage = (Short) args.get("damage");
+            damage = (Integer) args.get("damage");
         }
 
         if (args.containsKey("amount")) {
             amount = (Integer) args.get("amount");
         }
 
-        ItemStack result = new ItemStack(type, amount, damage);
+        ItemStack result = new ItemStack(type, amount, (short) damage);
 
         if (args.containsKey("enchantments")) {
             Object raw = args.get("enchantments");

--- a/src/test/java/org/bukkit/configuration/file/YamlConfigurationTest.java
+++ b/src/test/java/org/bukkit/configuration/file/YamlConfigurationTest.java
@@ -1,5 +1,12 @@
 package org.bukkit.configuration.file;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.serialization.ConfigurationSerialization;
+import org.bukkit.inventory.ItemStack;
+
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -51,5 +58,27 @@ public  class YamlConfigurationTest extends FileConfigurationTest {
         String expected = "section:\n         key: 1\n";
         
         assertEquals(expected, result);
+    }
+
+    @Test
+    public void testSaveRestoreCompositeList() throws InvalidConfigurationException {
+        YamlConfiguration out = getConfig();
+
+        List<ItemStack> stacks = new ArrayList<ItemStack>();
+        stacks.add(new ItemStack(1));
+        stacks.add(new ItemStack(2));
+        stacks.add(new ItemStack(3));
+
+        out.set("composite-list.abc.def", stacks);
+        String yaml = out.saveToString();
+
+        YamlConfiguration in = new YamlConfiguration();
+        in.loadFromString(yaml);
+        List<Object> raw = in.getList("composite-list.abc.def");
+
+        assertEquals(stacks.size(), raw.size());
+        assertEquals(stacks.get(0), raw.get(0));
+        assertEquals(stacks.get(1), raw.get(1));
+        assertEquals(stacks.get(2), raw.get(2));
     }
 }


### PR DESCRIPTION
For example, .set("foo", List<? extends ConfigurationSerializable>) is properly saved and loaded with this change.  This addresses https://bukkit.atlassian.net/browse/BUKKIT-425.

This also fixes a couple issues with ItemStack serialization.
