### PR TITLE
Allow bulk set/unset of attachment permissions and avoid many useless

### DIFF
--- a/src/main/java/org/bukkit/permissions/PermissibleBase.java
+++ b/src/main/java/org/bukkit/permissions/PermissibleBase.java
@@ -106,8 +106,6 @@ public class PermissibleBase implements Permissible {
         PermissionAttachment result = addAttachment(plugin);
         result.setPermission(name, value);
 
-        recalculatePermissions();
-
         return result;
     }
 
@@ -121,7 +119,6 @@ public class PermissibleBase implements Permissible {
         PermissionAttachment result = new PermissionAttachment(plugin, parent);
 
         attachments.add(result);
-        recalculatePermissions();
 
         return result;
     }

--- a/src/main/java/org/bukkit/permissions/PermissionAttachment.java
+++ b/src/main/java/org/bukkit/permissions/PermissionAttachment.java
@@ -1,7 +1,9 @@
 package org.bukkit.permissions;
 
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import org.bukkit.plugin.Plugin;
 
 /**
@@ -13,14 +15,14 @@ public class PermissionAttachment {
     private final Permissible permissible;
     private final Plugin plugin;
 
-    public PermissionAttachment(Plugin plugin, Permissible Permissible) {
+    public PermissionAttachment(Plugin plugin, Permissible permissible) {
         if (plugin == null) {
             throw new IllegalArgumentException("Plugin cannot be null");
         } else if (!plugin.isEnabled()) {
             throw new IllegalArgumentException("Plugin " + plugin.getDescription().getFullName() + " is disabled");
         }
 
-        this.permissible = Permissible;
+        this.permissible = permissible;
         this.plugin = plugin;
     }
 
@@ -89,7 +91,19 @@ public class PermissionAttachment {
      * @param value New value of the permission
      */
     public void setPermission(Permission perm, boolean value) {
-        setPermission(perm.getName(), value);
+        permissions.put(perm.getName().toLowerCase(), value);
+        permissible.recalculatePermissions();
+    }
+
+    /**
+     * Sets permissions to given values, by their fully qualified names
+     * 
+     * @param permissions The permission and value pairs
+     */
+    public void setPermissions(Map<String, Boolean> permissions) {
+        for(Entry<String, Boolean> entry : permissions.entrySet()) {
+            permissions.put(entry.getKey().toLowerCase(), entry.getValue());
+        }
         permissible.recalculatePermissions();
     }
 
@@ -113,7 +127,21 @@ public class PermissionAttachment {
      * @param perm Permission to remove
      */
     public void unsetPermission(Permission perm) {
-        unsetPermission(perm.getName());
+        permissions.remove(perm.getName().toLowerCase());
+        permissible.recalculatePermissions();
+    }
+
+    /**
+     * Removes the specified permissions from this attachment.
+     * 
+     * If a permission does not exist in this attachment, nothing will happen.
+     * 
+     * @param permissions Permissions to remove
+     */
+    public void unsetPermissions(Collection<String> permissions) {
+        for(String name : permissions) {
+            permissions.remove(name.toLowerCase());
+        }
         permissible.recalculatePermissions();
     }
 


### PR DESCRIPTION
recalculations of permissions for higher performance.

I'm currently working on a permissions related plugin (set/unset PermissionAttachment based on player locations) and need to be able to efficiently add/remove permissions in form of PermissionAttachments. The current implementation of these is very inefficient because it recalculates all permissions of a Permissible whenever a single permission of the attachment changes (sometimes even if nothing changes at all). Especially when there are thousands of permissions registered on the server, it may take up to several seconds if a lot of single permissions have to be added to an permission attachment.

This commit will highly improve performance and allow to add/remove multiple permissions at once. I'll comment the single code changes in the "commit" tab in detail. It will NOT break any existing functionality of Permissions or PermissionAttachments.

I'd highly appreciate to get feedback on this asap, because this is the only remaining block on the road for me.
