### PR TITLE
Partially fix Bukkit-230

### DIFF
--- a/src/main/java/org/bukkit/configuration/MemorySection.java
+++ b/src/main/java/org/bukkit/configuration/MemorySection.java
@@ -175,11 +175,12 @@ public class MemorySection implements ConfigurationSection {
 
         for (int i = 0; i < split.length - 1; i++) {
             ConfigurationSection last = section;
-
-            section = last.getConfigurationSection(split[i]);
-
-            if (section == null) {
+            
+            Object val = last.get(split[i], null);
+            if (val == null || !(val instanceof ConfigurationSection)) {
                 section = last.createSection(split[i]);
+            } else {
+                section = (ConfigurationSection) val;
             }
         }
 
@@ -216,10 +217,11 @@ public class MemorySection implements ConfigurationSection {
         ConfigurationSection section = this;
 
         for (int i = 0; i < split.length - 1; i++) {
-            section = section.getConfigurationSection(split[i]);
-
-            if (section == null) {
+            Object val = get(split[i]);
+            if (val == null || !(val instanceof ConfigurationSection)) {
                 return def;
+            } else {
+                section = (ConfigurationSection) val;
             }
         }
 
@@ -244,11 +246,12 @@ public class MemorySection implements ConfigurationSection {
 
         for (int i = 0; i < split.length - 1; i++) {
             ConfigurationSection last = section;
-
-            section = getConfigurationSection(split[i]);
-
-            if (section == null) {
+            
+            Object val = get(split[i], null);
+            if (val == null || !(val instanceof ConfigurationSection)) {
                 section = last.createSection(split[i]);
+            } else {
+                section = (ConfigurationSection) val;
             }
         }
 


### PR DESCRIPTION
When I pushed the fix for getConfigurationSection returning default values, I didn't realize it was called in get() and createSection - this was still causing very odd behaviour with sections being returned and getting or setting values.  This is now fixed.
