### PR TITLE
Fix NullPointerException in saveConfig()

### DIFF
--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
@@ -139,7 +139,7 @@ public abstract class JavaPlugin implements Plugin {
 
     public void saveConfig() {
         try {
-            newConfig.save(configFile);
+            getConfig().save(configFile);
         } catch (IOException ex) {
             Logger.getLogger(JavaPlugin.class.getName()).log(Level.SEVERE, "Could not save config to " + configFile, ex);
         }


### PR DESCRIPTION
If saveConfig() is called before getConfig() or reloadConfig(), it will throw a NullPointerException.
This fix will attempt to get the config before attempting to save (therefor initializing it first).
