### PR TITLE
Fix getting leaf species for leaves with higher data values.

### DIFF
--- a/src/main/java/org/bukkit/material/Leaves.java
+++ b/src/main/java/org/bukkit/material/Leaves.java
@@ -38,7 +38,7 @@ public class Leaves extends MaterialData {
      * @return TreeSpecies of this leave
      */
     public TreeSpecies getSpecies() {
-        return TreeSpecies.getByData(getData());
+        return TreeSpecies.getByData((byte) (getData() & 3));
     }
 
     /**


### PR DESCRIPTION
With this fix, it will return the actual species of leaves instead of returning null.
