### PR TITLE
Add BlockState.applyPhysics()

### DIFF
--- a/src/main/java/org/bukkit/block/BlockState.java
+++ b/src/main/java/org/bukkit/block/BlockState.java
@@ -120,7 +120,7 @@ public interface BlockState {
      * @see #update(boolean)
      */
     boolean update();
-
+    
     /**
      * Attempts to update the block represented by this state, setting it to the
      * new values as defined by this state. <br />
@@ -137,5 +137,10 @@ public interface BlockState {
      */
     boolean update(boolean force);
 
+    /**
+     * Force apply physics around this block.
+     */
+    void applyPhysics();
+    
     public byte getRawData();
 }


### PR DESCRIPTION
When changing a lever on/off state by updating its block data, applyPhysics() is not called as it does when interacting with the lever. This can cause some blocks around the lever to not react to the change. It would be useful to have this method available.

Implementation: https://github.com/Bukkit/CraftBukkit/pull/618
