### PR TITLE
Add a PortalType property to PlayerPortalEvent

### DIFF
--- a/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
@@ -14,10 +14,18 @@ public class PlayerPortalEvent extends PlayerTeleportEvent {
 
     protected Player player;
     protected TravelAgent travelAgent;
+    
+    private PortalType portalType = PortalType.UNKNOWN; 
 
     public PlayerPortalEvent(Player player, Location from, Location to, TravelAgent pta) {
         super(Type.PLAYER_PORTAL, player, from, to);
         this.travelAgent = pta;
+    }
+    
+    public PlayerPortalEvent(Player player, Location from, Location to, TravelAgent pta, PortalType portalType) {
+        super(Type.PLAYER_PORTAL, player, from, to);
+        this.travelAgent = pta;
+        this.portalType = portalType;
     }
 
     public void useTravelAgent(boolean useTravelAgent) {
@@ -34,5 +42,33 @@ public class PlayerPortalEvent extends PlayerTeleportEvent {
 
     public void setPortalTravelAgent(TravelAgent travelAgent) {
         this.travelAgent = travelAgent;
+    }
+    
+    /**
+     * Gets the portal type of this portaling event
+     *
+     * @return Portal type of the event
+     */
+    public PortalType getPortalType() {
+        return portalType;
+    }
+    
+    public enum PortalType {
+        /**
+         * Indicates the portaling event was caused by a player entering a nether portal
+         */
+        NETHER_PORTAL,
+        /**
+         * Indicates the portaling event was caused by a player entering an end portal
+         */
+        END_PORTAL,
+        /**
+         * Indicates the portaling event was caused by a plugin
+         */
+        PLUGIN,
+        /**
+         * Indicates the portaling event was caused by an event not covered by this enum
+         */
+        UNKNOWN;
     }
 }


### PR DESCRIPTION
The new PortalType property allows plugins to always be able to tell what type of portal caused the event. Currently the dimension to which the player will travel can only be obtained by a plugin if the dimension of the world they are coming from is less than 10 (i.e. not a Bukkit multiworld). This is a better implementation of an old pull request, https://github.com/Bukkit/CraftBukkit/pull/554.

Corresponding CraftBukkit pull request: https://github.com/Bukkit/CraftBukkit/pull/629
