### PR TITLE
Add swamp tree generation

### DIFF
--- a/src/main/java/org/bukkit/BlockChangeDelegate.java
+++ b/src/main/java/org/bukkit/BlockChangeDelegate.java
@@ -8,7 +8,8 @@ package org.bukkit;
 public interface BlockChangeDelegate {
 
     /**
-     * Set a block type at the specified coordinates.
+     * Set a block type at the specified coordinates without doing all world updates and notifications.
+     * It is safe to have this call World.setTypeId, but it may be slower than World.setRawTypeId.
      *
      * @param x X coordinate
      * @param y Y coordinate
@@ -19,7 +20,8 @@ public interface BlockChangeDelegate {
     public boolean setRawTypeId(int x, int y, int z, int typeId);
 
     /**
-     * Set a block type and data at the specified coordinates.
+     * Set a block type and data at the specified coordinates without doing all world updates and notifications.
+     * It is safe to have this call World.setTypeId, but it may be slower than World.setRawTypeId.
      *
      * @param x X coordinate
      * @param y Y coordinate
@@ -29,6 +31,31 @@ public interface BlockChangeDelegate {
      * @return true if the block was set successfully
      */
     public boolean setRawTypeIdAndData(int x, int y, int z, int typeId, int data);
+
+    /**
+     * Set a block type at the specified coordinates.
+     * This method cannot call World.setRawTypeId, a full update is needed.
+     *
+     * @param x X coordinate
+     * @param y Y coordinate
+     * @param z Z coordinate
+     * @param typeId New block ID
+     * @return true if the block was set successfully
+     */
+    public boolean setTypeId(int x, int y, int z, int typeId);
+
+    /**
+     * Set a block type and data at the specified coordinates.
+     * This method cannot call World.setRawTypeId, a full update is needed.
+     *
+     * @param x X coordinate
+     * @param y Y coordinate
+     * @param z Z coordinate
+     * @param typeId New block ID
+     * @param data Block data
+     * @return true if the block was set successfully
+     */
+    public boolean setTypeIdAndData(int x, int y, int z, int typeId, int data);
 
     /**
      * Get the block type at the location.

--- a/src/main/java/org/bukkit/TreeType.java
+++ b/src/main/java/org/bukkit/TreeType.java
@@ -9,6 +9,7 @@ public enum TreeType {
     REDWOOD,
     TALL_REDWOOD,
     BIRCH,
+    SWAMP_TREE,
     RED_MUSHROOM,
     BROWN_MUSHROOM
 }


### PR DESCRIPTION
This adds an API for generating swamp trees. It would have been a simple change, but the vine generation requires using World.setTypeIdAndData instead of World.setRawTypeIdAndData or else you will only see a few of the vines until you log out and back in again, which is a result of some weird quirk of the Minecraft server. So, I needed to add setTypeIdAndData to BlockChangeDelegate, which means that anyone implementing it will need to add an implementation for that method (I also added setTypeId so that it wouldn't feel left out).

I closed the last pull request because it's easier to update and I wanted it in a different branch than master.

CraftBukkit pull: https://github.com/Bukkit/CraftBukkit/pull/638
