### PR TITLE
Minor fixes to events system

### DIFF
--- a/src/main/java/org/bukkit/event/EventHandler.java
+++ b/src/main/java/org/bukkit/event/EventHandler.java
@@ -11,5 +11,5 @@ public @interface EventHandler {
 
     Class<? extends Event> event();
 
-    EventPriority priority();
+    EventPriority priority() default EventPriority.NORMAL;
 }

--- a/src/main/java/org/bukkit/event/HandlerList.java
+++ b/src/main/java/org/bukkit/event/HandlerList.java
@@ -50,7 +50,9 @@ public class HandlerList {
 
     public static void unregisterAll() {
         for (HandlerList h : alllists) {
-            h.handlerslots.clear();
+            for (List<RegisteredListener> list : h.handlerslots.values()) {
+                list.clear();
+            }
             h.baked = false;
         }
     }

--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -471,7 +471,7 @@ public final class SimplePluginManager implements PluginManager {
         } catch (NoSuchMethodException e) {
             if (clazz.getSuperclass() != null
                     && !clazz.getSuperclass().equals(Event.class)
-                    && clazz.getSuperclass().isAssignableFrom(Event.class)) {
+                    && Event.class.isAssignableFrom(clazz.getSuperclass())) {
                 return getRegistrationClass(clazz.getSuperclass().asSubclass(Event.class));
             } else {
                 throw new IllegalPluginAccessException("Unable to find handler list for event " + clazz.getName());


### PR DESCRIPTION
Quick update to the events system. This was annoying me while I was updating my plugins and I forgot to add it in the first pull request
- Added a default to EventHandler.priority()
- Fixed reloads
- Fixed incorrect isAssignableFrom check in SimplePluginManager.getRegistrationClass()
