### PR TITLE
Add the number of calls for each event to the timings command output.

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/TimingsCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/TimingsCommand.java
@@ -55,9 +55,10 @@ public class TimingsCommand extends Command {
                     else fileTimings.println(plugin.getDescription().getFullName());
                     for (Event.Type type : Event.Type.values()) {
                         long time = plugin.getTiming(type);
+                        long calls = plugin.getEventCalls(type);
                         totalTime += time;
                         if (time > 0) {
-                            fileTimings.println("    " + type.name() + " " + time);
+                            fileTimings.println("    " + type.name() + " " + time + " " + calls + " " + time / calls);
                         }
                     }
                     fileTimings.println("    Total time " + totalTime + " (" + totalTime / 1000000000 + "s)");

--- a/src/main/java/org/bukkit/plugin/Plugin.java
+++ b/src/main/java/org/bukkit/plugin/Plugin.java
@@ -160,6 +160,8 @@ public interface Plugin extends CommandExecutor {
     public Logger getLogger();
 
     public long getTiming(Event.Type type);
+    
+    public long getEventCalls(Event.Type type);
 
     public void incTiming(Event.Type type, long delta);
 

--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
@@ -46,6 +46,7 @@ public abstract class JavaPlugin implements Plugin {
     private FileConfiguration newConfig = null;
     private File configFile = null;
     private long[] timings = new long[Event.Type.values().length];
+    private long[] eventcalls = new long[Event.Type.values().length];
     private PluginLogger logger = null;
 
     public JavaPlugin() {}
@@ -377,13 +378,19 @@ public abstract class JavaPlugin implements Plugin {
     public long getTiming(Event.Type type) {
         return timings[type.ordinal()];
     }
+    
+    public long getEventCalls(Event.Type type) {
+        return eventcalls[type.ordinal()];
+    }
 
     public void incTiming(Event.Type type, long delta) {
         timings[type.ordinal()] += delta;
+        eventcalls[type.ordinal()]++;
     }
 
     public void resetTimings() {
         timings = new long[Event.Type.values().length];
+        eventcalls = new long[Event.Type.values().length];
     }
 
     @Override


### PR DESCRIPTION
The average time for each event call can be output that way. If this is not added, two outputs of the timings command can't be compared.
