### PR TITLE
No longer using event parameter in EventHandler, some javadoc improvements

### DIFF
--- a/src/main/java/org/bukkit/event/CustomEventListener.java
+++ b/src/main/java/org/bukkit/event/CustomEventListener.java
@@ -1,7 +1,5 @@
 package org.bukkit.event;
 
-import org.bukkit.event.Listener;
-
 /**
  * Handles all custom events
  */

--- a/src/main/java/org/bukkit/event/EventHandler.java
+++ b/src/main/java/org/bukkit/event/EventHandler.java
@@ -1,15 +1,22 @@
 package org.bukkit.event;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * An annotation to mark methods as being event handler methods
  */
+@Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface EventHandler {
 
-    Class<? extends Event> event();
+    /**
+     * This field is now fetched from the event handler method's parameter
+     * @return
+     */
+    @Deprecated Class<? extends Event> event() default Event.class;
 
     EventPriority priority() default EventPriority.NORMAL;
 }

--- a/src/main/java/org/bukkit/plugin/PluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/PluginLoader.java
@@ -52,6 +52,7 @@ public interface PluginLoader {
      * @param type Type of the event executor to create
      * @param listener the object that will handle the eventual call back
      * @return The new executor
+     * @deprecated see PluginLoader#createRegisteredListeners
      */
     @Deprecated
     public EventExecutor createExecutor(Event.Type type, Listener listener);

--- a/src/main/java/org/bukkit/plugin/PluginManager.java
+++ b/src/main/java/org/bukkit/plugin/PluginManager.java
@@ -103,6 +103,7 @@ public interface PluginManager {
      * @param listener Listener to register
      * @param priority Priority of this event
      * @param plugin Plugin to register
+     * @deprecated see PluginManager#registerEvents
      */
     @Deprecated
     public void registerEvent(Event.Type type, Listener listener, Priority priority, Plugin plugin);
@@ -115,6 +116,7 @@ public interface PluginManager {
      * @param executor EventExecutor to register
      * @param priority Priority of this event
      * @param plugin Plugin to register
+     * @deprecated see PluginManager#registerEvent(Class, Listener, EventPriority, EventExecutor, Plugin)
      */
     @Deprecated
     public void registerEvent(Event.Type type, Listener listener, EventExecutor executor, Priority priority, Plugin plugin);

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -987,20 +987,21 @@ public class JavaPluginLoader implements PluginLoader {
             final EventHandler eh = method.getAnnotation(EventHandler.class);
             if (eh == null) continue;
             final Class<?> checkClass = method.getParameterTypes()[0];
-            if (!checkClass.isAssignableFrom(eh.event()) || method.getParameterTypes().length != 1) {
+            if (!Event.class.isAssignableFrom(checkClass) || method.getParameterTypes().length != 1) {
                 plugin.getServer().getLogger().severe("Wrong method arguments used for event type registered");
                 continue;
             }
+            final Class<? extends Event> eventClass = checkClass.asSubclass(Event.class);
             method.setAccessible(true);
-            Set<RegisteredListener> eventSet = ret.get(eh.event());
+            Set<RegisteredListener> eventSet = ret.get(eventClass);
             if (eventSet == null) {
                 eventSet = new HashSet<RegisteredListener>();
-                ret.put(eh.event(), eventSet);
+                ret.put(eventClass, eventSet);
             }
             eventSet.add(new RegisteredListener(listener, new EventExecutor() {
                 public void execute(Listener listener, Event event) throws EventException {
                     try {
-                        if (!checkClass.isAssignableFrom(event.getClass())) {
+                        if (!eventClass.isAssignableFrom(event.getClass())) {
                             throw new EventException("Wrong event type passed to registered method");
                         }
                         method.invoke(listener, event);


### PR DESCRIPTION
The event registration system now uses the event's first parameter as the event class. Less to mess up in plugins now. This was from a suggestion by @TomyLobo
