### PR TITLE
2 new events and 1 fix

### DIFF
--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -363,6 +363,12 @@ public abstract class Event implements Serializable {
          * @see org.bukkit.event.player.PlayerChangedWorldEvent
          */
         PLAYER_CHANGED_WORLD(Category.PLAYER, PlayerChangedWorldEvent.class),
+        /**
+         * Called when a players level changes
+         *
+         * @see org.bukkit.event.player.PlayerLevelChangeEvent
+         */
+        PLAYER_LEVEL_CHANGE(Category.PLAYER, PlayerLevelChangeEvent.class),
 
         /**
          * BLOCK EVENTS

--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -369,6 +369,12 @@ public abstract class Event implements Serializable {
          * @see org.bukkit.event.player.PlayerLevelChangeEvent
          */
         PLAYER_LEVEL_CHANGE(Category.PLAYER, PlayerLevelChangeEvent.class),
+        /**
+         * Called when a players experience changes naturally
+         *
+         * @see org.bukkit.event.player.PlayerExpChangeEvent
+         */
+        PLAYER_EXP_CHANGE(Category.PLAYER, PlayerExpChangeEvent.class),
 
         /**
          * BLOCK EVENTS

--- a/src/main/java/org/bukkit/event/player/PlayerExpChangeEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerExpChangeEvent.java
@@ -1,0 +1,43 @@
+package org.bukkit.event.player;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Called when a players experience changes naturally
+ */
+public class PlayerExpChangeEvent extends PlayerEvent {
+    private static final HandlerList handlers = new HandlerList();
+    private int exp;
+
+    public PlayerExpChangeEvent(Player player, int expAmount) {
+         super(Type.PLAYER_EXP_CHANGE, player);
+         exp = expAmount;
+    }
+
+    /**
+     * Get the amount of experience the player will receive
+     *
+     * @return The amount of experience
+     */
+    public int getAmount() {
+        return exp;
+    }
+
+    /**
+     * Set the amount of experience the player will receive
+     *
+     * @param amount The amount of experience to set
+     */
+    public void setAmount(int amount) {
+        exp = amount;
+    }
+
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/org/bukkit/event/player/PlayerLevelChangeEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerLevelChangeEvent.java
@@ -1,0 +1,45 @@
+package org.bukkit.event.player;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Called when a players level changes
+ */
+public class PlayerLevelChangeEvent extends PlayerEvent {
+    private static final HandlerList handlers = new HandlerList();
+    private int oldLevel;
+    private int newLevel;
+
+    public PlayerLevelChangeEvent(Player player, int oldLevel, int newLevel) {
+         super(Type.PLAYER_LEVEL_CHANGE, player);
+         this.oldLevel = oldLevel;
+         this.newLevel = newLevel;
+    }
+
+    /**
+     * Gets the old level of the player
+     *
+     * @return The old level of the player
+     */
+    public int getOldLevel() {
+        return oldLevel;
+    }
+
+    /**
+     * Gets the new level of the player
+     *
+     * @return The new (current) level of the player
+     */
+    public int getNewLevel() {
+        return newLevel;
+    }
+
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/org/bukkit/event/player/PlayerListener.java
+++ b/src/main/java/org/bukkit/event/player/PlayerListener.java
@@ -220,4 +220,11 @@ public class PlayerListener implements Listener {
      * @param event Relevant event details
      */
     public void onPlayerLevelChange(PlayerLevelChangeEvent event) {}
+
+    /**
+     * Called when a players experience changes naturally
+     *
+     * @param event Relevant event details
+     */
+    public void onPlayerExpChange(PlayerExpChangeEvent event) {}
 }

--- a/src/main/java/org/bukkit/event/player/PlayerListener.java
+++ b/src/main/java/org/bukkit/event/player/PlayerListener.java
@@ -213,4 +213,11 @@ public class PlayerListener implements Listener {
      * @param event Relevant event details
      */
     public void onPlayerChangedWorld(PlayerChangedWorldEvent event) {}
+
+    /**
+     * Called when a players level changes
+     *
+     * @param event Relevant event details
+     */
+    public void onPlayerLevelChange(PlayerLevelChangeEvent event) {}
 }

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -476,6 +476,13 @@ public class JavaPluginLoader implements PluginLoader {
                 }
             };
 
+        case PLAYER_EXP_CHANGE:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((PlayerListener) listener).onPlayerExpChange((PlayerExpChangeEvent) event);
+                }
+            };
+
         // Block Events
         case BLOCK_PHYSICS:
             return new EventExecutor() {

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -830,6 +830,13 @@ public class JavaPluginLoader implements PluginLoader {
                 }
             };
 
+        case ENTITY_SHOOT_BOW:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((EntityListener) listener).onEntityShootBow((EntityShootBowEvent) event);
+                }
+            };
+
         case PROJECTILE_HIT:
             return new EventExecutor() {
                 public void execute(Listener listener, Event event) {

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -18,9 +18,6 @@ import org.bukkit.Server;
 
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.configuration.serialization.ConfigurationSerialization;
-import org.bukkit.event.CustomEventListener;
-import org.bukkit.event.Event;
-import org.bukkit.event.Listener;
 import org.bukkit.event.*;
 import org.bukkit.event.block.*;
 import org.bukkit.event.painting.*;
@@ -378,6 +375,13 @@ public class JavaPluginLoader implements PluginLoader {
             return new EventExecutor() {
                 public void execute(Listener listener, Event event) {
                     ((PlayerListener) listener).onPlayerAnimation((PlayerAnimationEvent) event);
+                }
+            };
+
+        case PLAYER_LEVEL_CHANGE:
+            return new EventExecutor() {
+                public void execute(Listener listener, Event event) {
+                    ((PlayerListener) listener).onPlayerLevelChange((PlayerLevelChangeEvent) event);
                 }
             };
 


### PR DESCRIPTION
PlayerLevelChangeEvent - Called when players level is modified in ANY way (plugins, natural)

PlayerExpChangeEvent - Called when players experience is modified naturally

Fixed backwards compatibility for EntityShootBowEvent

CraftBukkit: https://github.com/Bukkit/CraftBukkit/pull/647
