### PR TITLE
Fixed plugin loader

### DIFF
--- a/src/main/java/org/bukkit/plugin/PluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/PluginLoader.java
@@ -29,6 +29,7 @@ public interface PluginLoader {
     /**
      * Loads the plugin contained in the specified file
      *
+     * @deprecated SoftDependencies are always ignored
      * @param file File to attempt to load
      * @param ignoreSoftDependencies Loader will ignore soft dependencies if this flag is set to true
      * @return Plugin that was contained in the specified file, or null if
@@ -37,7 +38,18 @@ public interface PluginLoader {
      * @throws InvalidDescriptionException If the plugin description file was invalid
      * @throws UnknownDependencyException If a required dependency could not be found
      */
+    @Deprecated
     public Plugin loadPlugin(File file, boolean ignoreSoftDependencies) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException;
+
+    /**
+     * Loads a PluginDescriptionFile from the specified file
+     *
+     * @param file File to attempt to load from
+     * @return A new PluginDescriptionFile loaded from the plugin.yml in the specified file
+     * @throws InvalidPluginException If when the specified file does not contain a plugin description file
+     * @throws InvalidDescriptionException If the plugin description file could not be created
+     */
+    public PluginDescriptionFile getPluginDescription(File file) throws InvalidPluginException, InvalidDescriptionException;
 
     /**
      * Returns a list of all filename filters expected by this PluginLoader

--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -85,54 +85,156 @@ public final class SimplePluginManager implements PluginManager {
      * @return A list of all plugins loaded
      */
     public Plugin[] loadPlugins(File directory) {
+        if(directory == null) {
+            throw new IllegalArgumentException("Directory cannot be null");
+        }
+        if(!directory.isDirectory()) {
+            throw new IllegalArgumentException("Directory must be a directory");
+        }
+
         List<Plugin> result = new ArrayList<Plugin>();
-        File[] files = directory.listFiles();
-
-        boolean allFailed = false;
-        boolean finalPass = false;
-
-        LinkedList<File> filesList = new LinkedList<File>(Arrays.asList(files));
+        Set<Pattern> filters = fileAssociations.keySet();
 
         if (!(server.getUpdateFolder().equals(""))) {
             updateDirectory = new File(directory, server.getUpdateFolder());
         }
 
-        while (!allFailed || finalPass) {
-            allFailed = true;
-            Iterator<File> itr = filesList.iterator();
+        Map<String, File> plugins = new HashMap<String, File>();
+        Set<String> loadedPlugins = new HashSet<String>();
+        Map<String, Collection<String>> dependencies = new HashMap<String, Collection<String>>();
+        Map<String, Collection<String>> softDependencies = new HashMap<String, Collection<String>>();
 
-            while (itr.hasNext()) {
-                File file = itr.next();
-                Plugin plugin = null;
-
-                try {
-                    plugin = loadPlugin(file, finalPass);
-                } catch (UnknownDependencyException ex) {
-                    if (finalPass) {
-                        server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + directory.getPath() + "': " + ex.getMessage(), ex);
-                        itr.remove();
-                    } else {
-                        plugin = null;
-                    }
-                } catch (InvalidPluginException ex) {
-                    server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + directory.getPath() + "': ", ex.getCause());
-                    itr.remove();
-                } catch (InvalidDescriptionException ex) {
-                    server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + directory.getPath() + "': " + ex.getMessage(), ex);
-                    itr.remove();
-                }
-
-                if (plugin != null) {
-                    result.add(plugin);
-                    allFailed = false;
-                    finalPass = false;
-                    itr.remove();
+        // This is where it figures out all possible plugins
+        for(File file : directory.listFiles()) {
+            PluginLoader loader = null;
+            for (Pattern filter : filters) {
+                Matcher match = filter.matcher(file.getName());
+                if (match.find()) {
+                    loader = fileAssociations.get(filter);
                 }
             }
-            if (finalPass) {
-                break;
-            } else if (allFailed) {
-                finalPass = true;
+            if(loader == null) continue;
+            PluginDescriptionFile description = null;
+            try {
+                description = loader.getPluginDescription(file);
+            } catch (InvalidPluginException ex) {
+                server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + directory.getPath() + "': " + ex.getMessage(), ex);
+                continue;
+            } catch (InvalidDescriptionException ex) {
+                server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + directory.getPath() + "': " + ex.getMessage(), ex);
+                continue;
+            }
+
+            plugins.put(description.getName(), file);
+
+            Collection<? extends String> softDependencySet = (Collection<? extends String>) description.getSoftDepend();
+            if(softDependencySet != null) {
+                softDependencies.put(description.getName(), new LinkedList<String>(softDependencySet));
+            }
+
+            Collection<? extends String> dependencySet = (Collection<? extends String>) description.getDepend();
+            if(dependencySet != null) {
+                dependencies.put(description.getName(), new LinkedList<String>(dependencySet));
+            }
+        }
+
+        while(!plugins.isEmpty()) {
+            boolean missingDependency = true;
+            Iterator<String> pluginIterator = plugins.keySet().iterator();
+            while(pluginIterator.hasNext()) {
+                String plugin = pluginIterator.next();
+                if(dependencies.containsKey(plugin)) {
+                    Iterator<String> dependencyIterator = dependencies.get(plugin).iterator();
+                    while(dependencyIterator.hasNext()) {
+                        String dependency = dependencyIterator.next();
+                        if(loadedPlugins.contains(dependency)) {
+                            // Dependency loaded
+                            dependencyIterator.remove();
+                        } else if(!plugins.containsKey(dependency)) {
+                            // We have a dependency not found
+                            missingDependency = false;
+                            File file = plugins.get(plugin);
+                            pluginIterator.remove();
+                            softDependencies.remove(plugin);
+                            dependencies.remove(plugin);
+                            server.getLogger().log(
+                                Level.SEVERE,
+                                "Could not load '" + file.getPath() + "' in folder '" + directory.getPath() + "': ",
+                                new UnknownDependencyException(dependency));
+                            break;
+                        }
+                    }
+                    if(dependencies.containsKey(plugin) && dependencies.get(plugin).isEmpty()) {
+                        dependencies.remove(plugin);
+                    }
+                }
+                if(softDependencies.containsKey(plugin)) {
+                    Iterator<String> softDependencyIterator = softDependencies.get(plugin).iterator();
+                    while(softDependencyIterator.hasNext()) {
+                        String softDependency = softDependencyIterator.next();
+                        if(!plugins.containsKey(softDependency)) {
+                            // Soft depend is no longer around
+                            softDependencyIterator.remove();
+                        }
+                    }
+                    if(softDependencies.get(plugin).isEmpty()) {
+                        softDependencies.remove(plugin);
+                    }
+                }
+                if(!(dependencies.containsKey(plugin) || softDependencies.containsKey(plugin)) && plugins.containsKey(plugin)) {
+                    // We're clear to load, no more soft or hard dependencies left
+                    File file = plugins.get(plugin);
+                    pluginIterator.remove();
+                    missingDependency = false;
+                    try {
+                        result.add(loadPlugin(file));
+                        loadedPlugins.add(plugin);
+                        continue;
+                    } catch (InvalidPluginException ex) {
+                        server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + directory.getPath() + "': ", ex.getCause());
+                    } catch (InvalidDescriptionException ex) {
+                        server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + directory.getPath() + "': " + ex.getMessage(), ex);
+                    } catch (UnknownDependencyException ex) {
+                        server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + directory.getPath() + "': " + ex.getMessage(), ex);
+                    }
+                }
+            }
+            if(missingDependency) {
+                // We now iterate over plugins until something loads
+                // This loop will ignore soft dependencies
+                pluginIterator = plugins.keySet().iterator();
+                while(pluginIterator.hasNext()) {
+                    String plugin = pluginIterator.next();
+                    if(!dependencies.containsKey(plugin)) {
+                        softDependencies.remove(plugin);
+                        dependencies.remove(plugin);
+                        missingDependency = false;
+                        File file = plugins.get(plugin);
+                        pluginIterator.remove();
+                        try {
+                            result.add(loadPlugin(file));
+                            loadedPlugins.add(plugin);
+                            break;
+                        } catch (InvalidPluginException ex) {
+                            server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + directory.getPath() + "': ", ex.getCause());
+                        } catch (InvalidDescriptionException ex) {
+                            server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + directory.getPath() + "': " + ex.getMessage(), ex);
+                        } catch (UnknownDependencyException ex) {
+                            server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + directory.getPath() + "': " + ex.getMessage(), ex);
+                        }
+                    }
+                }
+                // We have no plugins left without a depend
+                if(missingDependency) {
+                    softDependencies.clear();
+                    dependencies.clear();
+                    Iterator<File> failedPluginIterator = plugins.values().iterator();
+                    while(failedPluginIterator.hasNext()) {
+                        File file = failedPluginIterator.next();
+                        failedPluginIterator.remove();
+                        server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + directory.getPath() + "': circular dependency detected");
+                    }
+                }
             }
         }
 
@@ -151,29 +253,11 @@ public final class SimplePluginManager implements PluginManager {
      * @throws UnknownDependencyException If a required dependency could not be found
      */
     public synchronized Plugin loadPlugin(File file) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException {
-        return loadPlugin(file, true);
-    }
-
-    /**
-     * Loads the plugin in the specified file
-     * <p />
-     * File must be valid according to the current enabled Plugin interfaces
-     *
-     * @param file File containing the plugin to load
-     * @param ignoreSoftDependencies Loader will ignore soft dependencies if this flag is set to true
-     * @return The Plugin loaded, or null if it was invalid
-     * @throws InvalidPluginException Thrown when the specified file is not a valid plugin
-     * @throws InvalidDescriptionException Thrown when the specified file contains an invalid description
-     * @throws UnknownDependencyException If a required dependency could not be found
-     */
-    public synchronized Plugin loadPlugin(File file, boolean ignoreSoftDependencies) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException {
-        File updateFile = null;
-
-        if (updateDirectory != null && updateDirectory.isDirectory() && (updateFile = new File(updateDirectory, file.getName())).isFile()) {
-            if (FileUtil.copy(updateFile, file)) {
-                updateFile.delete();
-            }
+        if(file == null) {
+            throw new IllegalArgumentException("File cannot be null");
         }
+
+        checkUpdate(file);
 
         Set<Pattern> filters = fileAssociations.keySet();
         Plugin result = null;
@@ -185,7 +269,7 @@ public final class SimplePluginManager implements PluginManager {
             if (match.find()) {
                 PluginLoader loader = fileAssociations.get(filter);
 
-                result = loader.loadPlugin(file, ignoreSoftDependencies);
+                result = loader.loadPlugin(file);
             }
         }
 
@@ -195,6 +279,34 @@ public final class SimplePluginManager implements PluginManager {
         }
 
         return result;
+    }
+
+    private void checkUpdate(File file) {
+        File updateFile = null;
+
+        if (updateDirectory != null && updateDirectory.isDirectory() && (updateFile = new File(updateDirectory, file.getName())).isFile()) {
+            if (FileUtil.copy(updateFile, file)) {
+                updateFile.delete();
+            }
+        }
+    }
+
+    /**
+     * Loads the plugin in the specified file
+     * <p />
+     * File must be valid according to the current enabled Plugin interfaces
+     *
+     * @deprecated soft-dependencies are now ignored
+     * @param file File containing the plugin to load
+     * @param ignoreSoftDependencies Loader will ignore soft dependencies if this flag is set to true
+     * @return The Plugin loaded, or null if it was invalid
+     * @throws InvalidPluginException Thrown when the specified file is not a valid plugin
+     * @throws InvalidDescriptionException Thrown when the specified file contains an invalid description
+     * @throws UnknownDependencyException If a required dependency could not be found
+     */
+    @Deprecated
+    public synchronized Plugin loadPlugin(File file, boolean ignoreSoftDependencies) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException {
+        return loadPlugin(file);
     }
 
     /**

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -45,36 +45,18 @@ public class JavaPluginLoader implements PluginLoader {
     }
 
     public Plugin loadPlugin(File file) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException {
-        return loadPlugin(file, false);
-    }
-
-    @SuppressWarnings("unchecked")
-    public Plugin loadPlugin(File file, boolean ignoreSoftDependencies) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException {
         JavaPlugin result = null;
         PluginDescriptionFile description = null;
+
+        if(file == null) {
+            throw new IllegalArgumentException("File cannot be null");
+        }
 
         if (!file.exists()) {
             throw new InvalidPluginException(new FileNotFoundException(String.format("%s does not exist", file.getPath())));
         }
-        try {
-            JarFile jar = new JarFile(file);
-            JarEntry entry = jar.getJarEntry("plugin.yml");
 
-            if (entry == null) {
-                throw new InvalidPluginException(new FileNotFoundException("Jar does not contain plugin.yml"));
-            }
-
-            InputStream stream = jar.getInputStream(entry);
-
-            description = new PluginDescriptionFile(stream);
-
-            stream.close();
-            jar.close();
-        } catch (IOException ex) {
-            throw new InvalidPluginException(ex);
-        } catch (YAMLException ex) {
-            throw new InvalidPluginException(ex);
-        }
+        description = getPluginDescription(file);
 
         File dataFolder = new File(file.getParentFile(), description.getName());
         File oldDataFolder = getDataFolder(file);
@@ -134,30 +116,6 @@ public class JavaPluginLoader implements PluginLoader {
             }
         }
 
-        if (!ignoreSoftDependencies) {
-            ArrayList<String> softDepend;
-
-            try {
-                softDepend = (ArrayList<String>) description.getSoftDepend();
-                if (softDepend == null) {
-                    softDepend = new ArrayList<String>();
-                }
-            } catch (ClassCastException ex) {
-                throw new InvalidPluginException(ex);
-            }
-
-            for (String pluginName : softDepend) {
-                if (loaders == null) {
-                    throw new UnknownSoftDependencyException(pluginName);
-                }
-                PluginClassLoader current = loaders.get(pluginName);
-
-                if (current == null) {
-                    throw new UnknownSoftDependencyException(pluginName);
-                }
-            }
-        }
-
         PluginClassLoader loader = null;
 
         try {
@@ -189,6 +147,10 @@ public class JavaPluginLoader implements PluginLoader {
         return result;
     }
 
+    public Plugin loadPlugin(File file, boolean ignoreSoftDependencies) throws InvalidPluginException, InvalidDescriptionException, UnknownDependencyException {
+        return loadPlugin(file);
+    }
+
     protected File getDataFolder(File file) {
         File dataFolder = null;
 
@@ -207,6 +169,47 @@ public class JavaPluginLoader implements PluginLoader {
         }
 
         return dataFolder;
+    }
+
+    public PluginDescriptionFile getPluginDescription(File file) throws InvalidDescriptionException, InvalidPluginException {
+
+        if(file == null) {
+            throw new IllegalArgumentException("File cannot be null");
+        }
+
+        JarFile jar = null;
+        InputStream stream = null;
+
+        try {
+            jar = new JarFile(file);
+            JarEntry entry = jar.getJarEntry("plugin.yml");
+
+            if (entry == null) {
+                throw new InvalidPluginException(new FileNotFoundException("Jar does not contain plugin.yml"));
+            }
+
+            stream = jar.getInputStream(entry);
+
+            return new PluginDescriptionFile(stream);
+
+        } catch (IOException ex) {
+            throw new InvalidPluginException(ex);
+        } catch (YAMLException ex) {
+            throw new InvalidDescriptionException(ex);
+        } finally {
+            if(jar != null) {
+                try {
+                    jar.close();
+                } catch (IOException e) {
+                }
+            }
+            if(stream != null) {
+                try {
+                    stream.close();
+                } catch (IOException e) {
+                }
+            }
+        }
     }
 
     public Pattern[] getPluginFileFilters() {


### PR DESCRIPTION
This makes the plugin loader dynamic, and handle dependencies and soft dependencies perfectly. Nothing breaks with this change; circular hard dependencies never worked in the first place.

Consistent new load priority:
Plugin with no dependencies or soft dependencies remaining to load
Arbitrary plugin involved with circular soft dependency

Any soft-depend that will not be fulfilled will be ignored.
Any plugin with a hard-depend that will not be fulfilled will outright fail.
Any plugin that has a circular hard depend (that is, of the set they all have another dependency in the set) will outright fail to load at end.

Fixes BUKKIT-243
