### PR TITLE
EntityBlockFormEvent was not using the new event system

### DIFF
--- a/src/main/java/org/bukkit/event/block/EntityBlockFormEvent.java
+++ b/src/main/java/org/bukkit/event/block/EntityBlockFormEvent.java
@@ -3,6 +3,7 @@ package org.bukkit.event.block;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.HandlerList;
 
 /**
  * Called when a block is formed by entities.
@@ -14,6 +15,7 @@ import org.bukkit.entity.Entity;
  */
 @SuppressWarnings("serial")
 public class EntityBlockFormEvent extends BlockFormEvent {
+    private static final HandlerList handlers = new HandlerList();
     private Entity entity;
 
     public EntityBlockFormEvent(Entity entity, Block block, BlockState blockstate) {
@@ -29,5 +31,14 @@ public class EntityBlockFormEvent extends BlockFormEvent {
      */
     public Entity getEntity() {
         return entity;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
     }
 }

--- a/src/main/java/org/bukkit/event/entity/PotionSplashEvent.java
+++ b/src/main/java/org/bukkit/event/entity/PotionSplashEvent.java
@@ -1,7 +1,5 @@
 package org.bukkit.event.entity;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Map;
 
 import org.apache.commons.lang.Validate;
@@ -39,8 +37,8 @@ public class PotionSplashEvent extends ProjectileHitEvent implements Cancellable
      *
      * @return A fresh copy of the affected entity list
      */
-    public Collection<LivingEntity> getAffectedEntities() {
-        return new ArrayList<LivingEntity>(affectedEntities.keySet());
+    public Map<LivingEntity, Double> getAffectedEntities() {
+        return affectedEntities;
     }
 
     /**


### PR DESCRIPTION
When trying to use this event, CraftBukkit would say you needed to use BlockFormEvent instead
