### PR TITLE
Added priorities for PermissionAttachments

### DIFF
--- a/src/main/java/org/bukkit/permissions/Permissible.java
+++ b/src/main/java/org/bukkit/permissions/Permissible.java
@@ -44,6 +44,27 @@ public interface Permissible extends ServerOperator {
     public boolean hasPermission(Permission perm);
 
     /**
+     * Adds a new {@link PermissionAttachment} with a single permission by name and value,
+     * and with a set priority
+     *
+     * @param plugin Plugin responsible for this attachment, may not be null or disabled
+     * @param name Name of the permission to attach
+     * @param value Value of the permission
+     * @param priority Priority of the attachment
+     * @return The PermissionAttachment that was just created
+     */
+    public PermissionAttachment addAttachment(Plugin plugin, String name, boolean value, float priority);
+
+    /**
+     * Adds a new {@link PermissionAttachment} to this object with a set priority
+     *
+     * @param plugin Plugin responsible for this attachment, may not be null or disabled
+     * @param priority Priority of the attachment
+     * @return The PermissionAttachment that was just created
+     */
+    public PermissionAttachment addAttachment(Plugin plugin, float priority);
+
+    /**
      * Adds a new {@link PermissionAttachment} with a single permission by name and value
      *
      * @param plugin Plugin responsible for this attachment, may not be null or disabled
@@ -60,6 +81,29 @@ public interface Permissible extends ServerOperator {
      * @return The PermissionAttachment that was just created
      */
     public PermissionAttachment addAttachment(Plugin plugin);
+
+    /**
+     * Temporarily adds a new {@link PermissionAttachment} with a single permission by name and value,
+     * and with a set priority
+     *
+     * @param plugin Plugin responsible for this attachment, may not be null or disabled
+     * @param name Name of the permission to attach
+     * @param value Value of the permission
+     * @param priority Priority of the attachment
+     * @param ticks Amount of ticks to automatically remove this attachment after
+     * @return The PermissionAttachment that was just created
+     */
+    public PermissionAttachment addAttachment(Plugin plugin, String name, boolean value, float priority, int ticks);
+
+    /**
+     * Temporarily adds a new empty {@link PermissionAttachment} to this object with a set priority
+     *
+     * @param plugin Plugin responsible for this attachment, may not be null or disabled
+     * @param priority Priority of the attachment
+     * @param ticks Amount of ticks to automatically remove this attachment after
+     * @return The PermissionAttachment that was just created
+     */
+    public PermissionAttachment addAttachment(Plugin plugin, float priority, int ticks);
 
     /**
      * Temporarily adds a new {@link PermissionAttachment} with a single permission by name and value

--- a/src/main/java/org/bukkit/permissions/PermissibleBase.java
+++ b/src/main/java/org/bukkit/permissions/PermissibleBase.java
@@ -94,6 +94,39 @@ public class PermissibleBase implements Permissible {
         return perm.getDefault().getValue(isOp());
     }
 
+    public PermissionAttachment addAttachment(Plugin plugin, String name, boolean value, float priority) {
+        if (name == null) {
+            throw new IllegalArgumentException("Permission name cannot be null");
+        } else if (plugin == null) {
+            throw new IllegalArgumentException("Plugin cannot be null");
+        } else if (!plugin.isEnabled()) {
+            throw new IllegalArgumentException("Plugin " + plugin.getDescription().getFullName() + " is disabled");
+        }
+
+        PermissionAttachment result = addAttachment(plugin);
+        if(result != null) {
+            result.setPermission(name, value);
+            result.setPriority(priority);
+        }
+        recalculatePermissions();
+        return result;
+    }
+
+    public PermissionAttachment addAttachment(Plugin plugin, float priority) {
+        if (plugin == null) {
+            throw new IllegalArgumentException("Plugin cannot be null");
+        } else if (!plugin.isEnabled()) {
+            throw new IllegalArgumentException("Plugin " + plugin.getDescription().getFullName() + " is disabled");
+        }
+
+        PermissionAttachment result = addAttachment(plugin);
+        if(result != null) {
+            result.setPriority(priority);
+        }
+        recalculatePermissions();
+        return result;
+    }
+
     public PermissionAttachment addAttachment(Plugin plugin, String name, boolean value) {
         if (name == null) {
             throw new IllegalArgumentException("Permission name cannot be null");
@@ -183,6 +216,12 @@ public class PermissibleBase implements Permissible {
             boolean value = children.get(name) ^ invert;
             String lname = name.toLowerCase();
 
+            //Don't add this permission is there's another with a higher priority
+            PermissionAttachmentInfo existing = permissions.get(lname);
+            if(existing != null && existing.getAttachment() != null && attachment != null) {
+                if(attachment.getPriority() < existing.getAttachment().getPriority()) continue;
+            }
+
             permissions.put(lname, new PermissionAttachmentInfo(parent, lname, attachment, value));
             Bukkit.getServer().getPluginManager().subscribeToPermission(name, parent);
 
@@ -190,6 +229,35 @@ public class PermissibleBase implements Permissible {
                 calculateChildPermissions(perm.getChildren(), !value, attachment);
             }
         }
+    }
+
+    public PermissionAttachment addAttachment(Plugin plugin, String name, boolean value, float priority, int ticks) {
+        if (name == null) {
+            throw new IllegalArgumentException("Permission name cannot be null");
+        } else if (plugin == null) {
+            throw new IllegalArgumentException("Plugin cannot be null");
+        } else if (!plugin.isEnabled()) {
+            throw new IllegalArgumentException("Plugin " + plugin.getDescription().getFullName() + " is disabled");
+        }
+        PermissionAttachment result = addAttachment(plugin, ticks);
+        if(result != null) {
+            result.setPermission(name, value);
+            result.setPriority(priority);
+        }
+        return result;
+    }
+
+    public PermissionAttachment addAttachment(Plugin plugin, float priority, int ticks) {
+        if (plugin == null) {
+            throw new IllegalArgumentException("Plugin cannot be null");
+        } else if (!plugin.isEnabled()) {
+            throw new IllegalArgumentException("Plugin " + plugin.getDescription().getFullName() + " is disabled");
+        }
+        PermissionAttachment result = addAttachment(plugin,ticks);
+        if(result != null) {
+            result.setPriority(priority);
+        }
+        return result;
     }
 
     public PermissionAttachment addAttachment(Plugin plugin, String name, boolean value, int ticks) {

--- a/src/main/java/org/bukkit/permissions/PermissionAttachment.java
+++ b/src/main/java/org/bukkit/permissions/PermissionAttachment.java
@@ -8,12 +8,20 @@ import org.bukkit.plugin.Plugin;
  * Holds information about a permission attachment on a {@link Permissible} object
  */
 public class PermissionAttachment {
+    public static final float DEFAULT_PRIORITY = 5.0f;
+
     private PermissionRemovedExecutor removed;
     private final Map<String, Boolean> permissions = new LinkedHashMap<String, Boolean>();
     private final Permissible permissible;
     private final Plugin plugin;
 
+    private float priority;
+
     public PermissionAttachment(Plugin plugin, Permissible Permissible) {
+        this(plugin, Permissible, DEFAULT_PRIORITY);
+    }
+
+    public PermissionAttachment(Plugin plugin, Permissible Permissible, float priority) {
         if (plugin == null) {
             throw new IllegalArgumentException("Plugin cannot be null");
         } else if (!plugin.isEnabled()) {
@@ -22,6 +30,7 @@ public class PermissionAttachment {
 
         this.permissible = Permissible;
         this.plugin = plugin;
+        this.priority = priority;
     }
 
     /**
@@ -72,6 +81,24 @@ public class PermissionAttachment {
     }
 
     /**
+     * Sets the priority of this attachment
+     *
+     * @param value Priority to set this attachment to
+     */
+    public void setPriority(float value) {
+        priority = value;
+    }
+
+    /**
+     * Gets the priority for this attachment
+     *
+     * @return Priority of this attachment
+     */
+    public float getPriority() {
+        return priority;
+    }
+
+    /**
      * Sets a permission to the given value, by its fully qualified name
      *
      * @param name Name of the permission
@@ -90,7 +117,6 @@ public class PermissionAttachment {
      */
     public void setPermission(Permission perm, boolean value) {
         setPermission(perm.getName(), value);
-        permissible.recalculatePermissions();
     }
 
     /**
@@ -114,7 +140,6 @@ public class PermissionAttachment {
      */
     public void unsetPermission(Permission perm) {
         unsetPermission(perm.getName());
-        permissible.recalculatePermissions();
     }
 
     /**

--- a/src/test/java/org/bukkit/plugin/messaging/TestPlayer.java
+++ b/src/test/java/org/bukkit/plugin/messaging/TestPlayer.java
@@ -506,11 +506,27 @@ public class TestPlayer implements Player {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
+    public PermissionAttachment addAttachment(Plugin plugin, String name, boolean value, float priority) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    public PermissionAttachment addAttachment(Plugin plugin, float priority) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
     public PermissionAttachment addAttachment(Plugin plugin, String name, boolean value) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
     public PermissionAttachment addAttachment(Plugin plugin) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    public PermissionAttachment addAttachment(Plugin plugin, String name, boolean value, float priority, int ticks) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    public PermissionAttachment addAttachment(Plugin plugin, float priority, int ticks) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 


### PR DESCRIPTION
Added extra methods to permissible to allow you to specify a priority for a PermissionAttachment. This allows one plugin to overrride the permissions given to a player of another plugin.

For example consider bPermissions for regular permissions, and a Jail plugin that revokes permissions. In a normal situation each player would just have their attachments from bPermissions. If a player were to get jailed then the jail could create an attachment at a higher priority to that of bPermissions (default is 5.0). Even if bPermissions removed, then added their attachment again the jail would still have priority. This was not the case before.

Since I added methods for Permissible, I've had to create a separate pull request for CraftBukkit to implement them in various classes. The pull request is here: <url>https://github.com/Bukkit/CraftBukkit/pull/657</url>

Finally I have removed two redundant calls to <code>permissible.recalculatePermissions();</code> in PermissionAttachment. I have noticed a few other redundant calls, although it might require a bit more refactoring.
