### PR TITLE
Add EndermanTeleportEvent.

### DIFF
--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -826,6 +826,12 @@ public abstract class Event implements Serializable {
          */
         ENDERMAN_PLACE(Category.LIVING_ENTITY, EndermanPlaceEvent.class),
         /**
+         * Called when an Enderman teleports
+         *
+         * @see org.bukkit.event.entity.EndermanTeleportEvent
+         */
+        ENDERMAN_TELEPORT(Category.LIVING_ENTITY, EndermanTeleportEvent.class),
+        /**
          * Called when a human entity's food level changes
          *
          * @see org.bukkit.event.entity.FoodLevelChangeEvent

--- a/src/main/java/org/bukkit/event/entity/EndermanTeleportEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EndermanTeleportEvent.java
@@ -1,0 +1,95 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+@SuppressWarnings("serial")
+public class EndermanTeleportEvent extends EntityEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+
+    private boolean cancel;
+    private Location from;
+    private Location to;
+
+    public EndermanTeleportEvent(Entity what, Location from, Location to) {
+        super(Type.ENDERMAN_TELEPORT, what);
+        this.from = from;
+        this.to = to;
+        this.cancel = false;
+    }
+
+    /**
+     * Gets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     * <p />
+     * If the teleport event is cancelled, the Enderman will be moved or
+     * teleported back to the Location as defined by getFrom(). This will not
+     * fire an event
+     *
+     * @return true if this event is cancelled
+     */
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    /**
+     * Sets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     * <p />
+     * If the teleport event is cancelled, the Enderman will be moved or
+     * teleported back to the Location as defined by getFrom(). This will not
+     * fire an event
+     *
+     * @param cancel true if you wish to cancel this event
+     */
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+
+    /**
+     * Gets the location that this Enderman moved from
+     *
+     * @return Location this Enderman moved from
+     */
+    public Location getFrom() {
+        return from;
+    }
+
+    /**
+     * Sets the location that this Enderman moved from
+     *
+     * @param from New location to mark as the Enderman's previous location
+     */
+    public void setFrom(Location from) {
+        this.from = from;
+    }
+
+    /**
+     * Gets the location that this Enderman moved to
+     *
+     * @return Location the Enderman moved to
+     */
+    public Location getTo() {
+        return to;
+    }
+
+    /**
+     * Sets the location that this Enderman moved to
+     *
+     * @param to New Location this Enderman moved to
+     */
+    public void setTo(Location to) {
+        this.to = to;
+    }
+    
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}


### PR DESCRIPTION
Fires whenever an Enderman teleports and allows checking of to/from location. I wrote this to fix BUKKIT-366 (https://bukkit.atlassian.net/browse/BUKKIT-366), as I need the feature for a plugin I'm working on. This is my first foray into Bukkit modifications, so any constructive criticism would be very helpful.

The event can be a bit spammy when the an Enderman starts going crazy in the rain, but hopefully this situation should always resolve itself quickly via the Enderman's death or teleportation to a dry spot (unless you just blindly cancel every teleport, forcing the Enderman to stay out in the rain and continue to try to escape).
