### PR TITLE
Removed period character at the end of loading and unload plugin message

### DIFF
--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -1042,7 +1042,7 @@ public class JavaPluginLoader implements PluginLoader {
         }
 
         if (!plugin.isEnabled()) {
-            String message = String.format("[%s] Loading %s.", plugin.getDescription().getName(), plugin.getDescription().getFullName());
+            String message = String.format("[%s] Loading %s", plugin.getDescription().getName(), plugin.getDescription().getFullName());
             server.getLogger().info(message);
 
             JavaPlugin jPlugin = (JavaPlugin) plugin;
@@ -1071,7 +1071,7 @@ public class JavaPluginLoader implements PluginLoader {
         }
 
         if (plugin.isEnabled()) {
-            String message = String.format("[%s] Unloading %s.", plugin.getDescription().getName(), plugin.getDescription().getFullName());
+            String message = String.format("[%s] Unloading %s", plugin.getDescription().getName(), plugin.getDescription().getFullName());
             server.getLogger().info(message);
 
             server.getPluginManager().callEvent(new PluginDisableEvent(plugin));


### PR DESCRIPTION
This pull request fixes BUKKIT-699: https://bukkit.atlassian.net/browse/BUKKIT-699
