### PR TITLE
Fix cloning ItemStacks with unsafe enchantments (prevent "IllegalArgum...

### DIFF
--- a/src/main/java/org/bukkit/inventory/ItemStack.java
+++ b/src/main/java/org/bukkit/inventory/ItemStack.java
@@ -211,7 +211,7 @@ public class ItemStack implements ConfigurationSerializable {
     @Override
     public ItemStack clone() {
         ItemStack result = new ItemStack(type, amount, durability);
-        result.addEnchantments(getEnchantments());
+        result.addUnsafeEnchantments(getEnchantments());
 
         return result;
     }


### PR DESCRIPTION
...entException: Specified enchantment cannot be applied to this itemstack"). Fixes BUKKIT-621.
