### PR TITLE
Fixed casting in ItemStack.deserialize AGAIN

### DIFF
--- a/src/main/java/org/bukkit/inventory/ItemStack.java
+++ b/src/main/java/org/bukkit/inventory/ItemStack.java
@@ -360,7 +360,11 @@ public class ItemStack implements ConfigurationSerializable {
         int amount = 1;
 
         if (args.containsKey("damage")) {
-            damage = (Short) args.get("damage");
+            if (args.get("damage") instanceof Integer) {
+                damage = ((Integer) args.get("damage")).shortValue();
+            } else {
+                damage = (Short) args.get("damage");
+            }
         }
 
         if (args.containsKey("amount")) {


### PR DESCRIPTION
"Reverting" bug introduced by commit https://github.com/possi/Bukkit/commit/46284565a7d9127c25328e5ec036068f3f24dd49#src/main/java/org/bukkit/inventory/ItemStack.java.
YamlConfiguration's automatic serialization stores ItemStacks like

<pre>
    ==: org.bukkit.inventory.ItemStack
    type: DIAMOND_SWORD
    damage: 6
</pre>

Because it doesn't store the class for native objects, the damage gets an Integer-object on deserialization. Integer casting to (Short) fails.
Using instanceof, to not cast to integer if not needed.

http://dev.bukkit.org/server-mods/limited-creative/tickets/15-console-spam/
