### PR TITLE
Added PlayerCoarseMoveEvent.

### DIFF
--- a/src/main/java/org/bukkit/event/player/PlayerCoarseMoveEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerCoarseMoveEvent.java
@@ -1,0 +1,18 @@
+package org.bukkit.event.player;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+/**
+ * Holds information for player movement events occurring ONLY when the player changes block position.
+ */
+public class PlayerCoarseMoveEvent extends PlayerMoveEvent {
+
+    public PlayerCoarseMoveEvent(final Player player, final Location from, final Location to) {
+        super(player, from, to);
+    }
+
+    public PlayerCoarseMoveEvent(final Type type, final Player player, final Location from, final Location to) {
+        super(type, player, from, to);
+    }
+}

--- a/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
@@ -9,7 +9,7 @@ import org.bukkit.event.HandlerList;
  * Holds information for player teleport events
  */
 @SuppressWarnings("serial")
-public class PlayerTeleportEvent extends PlayerMoveEvent {
+public class PlayerTeleportEvent extends PlayerCoarseMoveEvent {
     private static final HandlerList handlers = new HandlerList();
     private TeleportCause cause = TeleportCause.UNKNOWN;
 


### PR DESCRIPTION
Added a sub event that will typically only be called when a player actually changes block location.  PlayerTeleportEvent now extends the new sub event since it would be considered Coarse movement.
