### PR TITLE
Added PlayerPortalEvent-Related Values To TeleportCause Enum

### DIFF
--- a/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
@@ -21,6 +21,11 @@ public class PlayerPortalEvent extends PlayerTeleportEvent {
         super(Type.PLAYER_PORTAL, player, from, to);
         this.travelAgent = pta;
     }
+    
+    public PlayerPortalEvent(Player player, Location from, Location to, TravelAgent pta, TeleportCause cause) {
+        super(Type.PLAYER_PORTAL, player, from, to, cause);
+        this.travelAgent = pta;
+    }
 
     public void useTravelAgent(boolean useTravelAgent) {
         this.useTravelAgent = useTravelAgent;

--- a/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
@@ -56,6 +56,14 @@ public class PlayerTeleportEvent extends PlayerMoveEvent {
          */
         PLUGIN,
         /**
+         * Indicates the teleportation was caused by a player entering a Nether portal
+         */
+        NETHER_PORTAL,
+        /**
+         * Indicates the teleportation was caused by a player entering an End portal
+         */
+        END_PORTAL,
+        /**
          * Indicates the teleportation was caused by an event not covered by this enum
          */
         UNKNOWN;


### PR DESCRIPTION
Currently the dimension to which the player will travel can only be obtained by a plugin if the dimension of the world they are coming from is less than 10 (i.e. not a Bukkit multiworld). This is a better implementation of an old pull request, https://github.com/Bukkit/Bukkit/pull/478.

Corresponding CraftBukkit pull request: https://github.com/Bukkit/CraftBukkit/pull/671
