### PR TITLE
Narrowed down the return type of most EntityEvent subclasses for convenience.

### DIFF
--- a/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
+++ b/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
@@ -2,6 +2,7 @@ package org.bukkit.event.entity;
 
 import org.bukkit.entity.CreatureType;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.Location;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
@@ -18,7 +19,7 @@ public class CreatureSpawnEvent extends EntityEvent implements Cancellable {
     private final CreatureType creatureType;
     private final SpawnReason spawnReason;
 
-    public CreatureSpawnEvent(final Entity spawnee, final CreatureType mobtype, final Location loc, final SpawnReason spawnReason) {
+    public CreatureSpawnEvent(final LivingEntity spawnee, final CreatureType mobtype, final Location loc, final SpawnReason spawnReason) {
         super(spawnee);
         this.creatureType = mobtype;
         this.location = loc;
@@ -31,6 +32,11 @@ public class CreatureSpawnEvent extends EntityEvent implements Cancellable {
 
     public void setCancelled(boolean cancel) {
         canceled = cancel;
+    }
+
+    @Override
+    public LivingEntity getEntity() {
+        return (LivingEntity) entity;
     }
 
     /**

--- a/src/main/java/org/bukkit/event/entity/CreeperPowerEvent.java
+++ b/src/main/java/org/bukkit/event/entity/CreeperPowerEvent.java
@@ -1,5 +1,6 @@
 package org.bukkit.event.entity;
 
+import org.bukkit.entity.Creeper;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
@@ -15,7 +16,7 @@ public class CreeperPowerEvent extends EntityEvent implements Cancellable {
     private final PowerCause cause;
     private Entity bolt;
 
-    public CreeperPowerEvent(final Entity creeper, final Entity bolt, final PowerCause cause) {
+    public CreeperPowerEvent(final Creeper creeper, final Entity bolt, final PowerCause cause) {
         this(creeper, cause);
         this.bolt = bolt;
     }
@@ -31,6 +32,11 @@ public class CreeperPowerEvent extends EntityEvent implements Cancellable {
 
     public void setCancelled(boolean cancel) {
         canceled = cancel;
+    }
+
+    @Override
+    public Creeper getEntity() {
+        return (Creeper) entity;
     }
 
     /**

--- a/src/main/java/org/bukkit/event/entity/EntityEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityEvent.java
@@ -18,7 +18,7 @@ public abstract class EntityEvent extends Event {
      *
      * @return Entity who is involved in this event
      */
-    public final Entity getEntity() {
+    public Entity getEntity() {
         return entity;
     }
 }

--- a/src/main/java/org/bukkit/event/entity/ItemDespawnEvent.java
+++ b/src/main/java/org/bukkit/event/entity/ItemDespawnEvent.java
@@ -2,6 +2,7 @@ package org.bukkit.event.entity;
 
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
@@ -10,8 +11,8 @@ public class ItemDespawnEvent extends EntityEvent implements Cancellable {
     private boolean canceled;
     private final Location location;
 
-    public ItemDespawnEvent(final Entity spawnee, final Location loc) {
-        super(spawnee);
+    public ItemDespawnEvent(final Item despawnee, final Location loc) {
+        super(despawnee);
         location = loc;
     }
 
@@ -21,6 +22,11 @@ public class ItemDespawnEvent extends EntityEvent implements Cancellable {
 
     public void setCancelled(boolean cancel) {
         canceled = cancel;
+    }
+
+    @Override
+    public Item getEntity() {
+        return (Item) entity;
     }
 
     /**

--- a/src/main/java/org/bukkit/event/entity/ItemSpawnEvent.java
+++ b/src/main/java/org/bukkit/event/entity/ItemSpawnEvent.java
@@ -1,6 +1,7 @@
 package org.bukkit.event.entity;
 
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
 import org.bukkit.Location;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
@@ -13,7 +14,7 @@ public class ItemSpawnEvent extends EntityEvent implements Cancellable {
     private final Location location;
     private boolean canceled;
 
-    public ItemSpawnEvent(final Entity spawnee, final Location loc) {
+    public ItemSpawnEvent(final Item spawnee, final Location loc) {
         super(spawnee);
         this.location = loc;
     }
@@ -24,6 +25,11 @@ public class ItemSpawnEvent extends EntityEvent implements Cancellable {
 
     public void setCancelled(boolean cancel) {
         canceled = cancel;
+    }
+
+    @Override
+    public Item getEntity() {
+        return (Item) entity;
     }
 
     /**

--- a/src/main/java/org/bukkit/event/entity/PigZapEvent.java
+++ b/src/main/java/org/bukkit/event/entity/PigZapEvent.java
@@ -1,6 +1,7 @@
 package org.bukkit.event.entity;
 
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Pig;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
@@ -13,7 +14,7 @@ public class PigZapEvent extends EntityEvent implements Cancellable {
     private final Entity pigzombie;
     private final Entity bolt;
 
-    public PigZapEvent(final Entity pig, final Entity bolt, final Entity pigzombie) {
+    public PigZapEvent(final Pig pig, final Entity bolt, final Entity pigzombie) {
         super(pig);
         this.bolt = bolt;
         this.pigzombie = pigzombie;
@@ -25,6 +26,11 @@ public class PigZapEvent extends EntityEvent implements Cancellable {
 
     public void setCancelled(boolean cancel) {
         canceled = cancel;
+    }
+    
+    @Override
+    public Pig getEntity() {
+        return (Pig) entity;
     }
 
     /**

--- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
+++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
@@ -2,6 +2,7 @@ package org.bukkit.event.entity;
 
 import java.util.List;
 
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -29,6 +30,11 @@ public class PlayerDeathEvent extends EntityDeathEvent {
         this.newTotalExp = newTotalExp;
         this.newLevel = newLevel;
         this.deathMessage = deathMessage;
+    }
+
+    @Override
+    public Player getEntity() {
+        return (Player) entity;
     }
 
     /**

--- a/src/main/java/org/bukkit/event/entity/PotionSplashEvent.java
+++ b/src/main/java/org/bukkit/event/entity/PotionSplashEvent.java
@@ -24,6 +24,11 @@ public class PotionSplashEvent extends ProjectileHitEvent implements Cancellable
         this.affectedEntities = affectedEntities;
     }
 
+    @Override
+    public ThrownPotion getEntity() {
+        return (ThrownPotion) entity;
+    }
+
     /**
      * Gets the potion which caused this event
      *

--- a/src/main/java/org/bukkit/event/entity/ProjectileHitEvent.java
+++ b/src/main/java/org/bukkit/event/entity/ProjectileHitEvent.java
@@ -1,5 +1,6 @@
 package org.bukkit.event.entity;
 
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Projectile;
 import org.bukkit.event.HandlerList;
 
@@ -11,6 +12,11 @@ public class ProjectileHitEvent extends EntityEvent {
 
     public ProjectileHitEvent(final Projectile projectile) {
         super(projectile);
+    }
+
+    @Override
+    public Projectile getEntity() {
+        return (Projectile) entity;
     }
 
     @Override

--- a/src/main/java/org/bukkit/event/entity/SheepDyeWoolEvent.java
+++ b/src/main/java/org/bukkit/event/entity/SheepDyeWoolEvent.java
@@ -2,6 +2,7 @@ package org.bukkit.event.entity;
 
 import org.bukkit.DyeColor;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Sheep;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
@@ -13,8 +14,8 @@ public class SheepDyeWoolEvent extends EntityEvent implements Cancellable {
     private boolean cancel;
     private DyeColor color;
 
-    public SheepDyeWoolEvent(final Entity what, final DyeColor color) {
-        super(what);
+    public SheepDyeWoolEvent(final Sheep sheep, final DyeColor color) {
+        super(sheep);
         this.cancel = false;
         this.color = color;
     }
@@ -25,6 +26,11 @@ public class SheepDyeWoolEvent extends EntityEvent implements Cancellable {
 
     public void setCancelled(boolean cancel) {
         this.cancel = cancel;
+    }
+
+    @Override
+    public Sheep getEntity() {
+        return (Sheep) entity;
     }
 
     /**

--- a/src/main/java/org/bukkit/event/entity/SheepRegrowWoolEvent.java
+++ b/src/main/java/org/bukkit/event/entity/SheepRegrowWoolEvent.java
@@ -1,6 +1,7 @@
 package org.bukkit.event.entity;
 
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Sheep;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
@@ -11,8 +12,8 @@ public class SheepRegrowWoolEvent extends EntityEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel;
 
-    public SheepRegrowWoolEvent(final Entity what) {
-        super(what);
+    public SheepRegrowWoolEvent(final Sheep sheep) {
+        super(sheep);
         this.cancel = false;
     }
 
@@ -22,6 +23,11 @@ public class SheepRegrowWoolEvent extends EntityEvent implements Cancellable {
 
     public void setCancelled(boolean cancel) {
         this.cancel = cancel;
+    }
+
+    @Override
+    public Sheep getEntity() {
+        return (Sheep) entity;
     }
 
     @Override

--- a/src/main/java/org/bukkit/event/entity/SlimeSplitEvent.java
+++ b/src/main/java/org/bukkit/event/entity/SlimeSplitEvent.java
@@ -1,6 +1,7 @@
 package org.bukkit.event.entity;
 
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Slime;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
@@ -12,8 +13,8 @@ public class SlimeSplitEvent extends EntityEvent implements Cancellable {
     private boolean cancel;
     private int count;
 
-    public SlimeSplitEvent(final Entity what, final int count) {
-        super(what);
+    public SlimeSplitEvent(final Slime slime, final int count) {
+        super(slime);
         this.cancel = false;
         this.count = count;
     }
@@ -24,6 +25,11 @@ public class SlimeSplitEvent extends EntityEvent implements Cancellable {
 
     public void setCancelled(boolean cancel) {
         this.cancel = cancel;
+    }
+
+    @Override
+    public Slime getEntity() {
+        return (Slime) entity;
     }
 
     /**


### PR DESCRIPTION
This is possible because Java allows covariant return types in overridden methods.
It shouldn't break source or binary compatibility with plugins either.

See also https://github.com/Bukkit/CraftBukkit/pull/679

ticket: https://bukkit.atlassian.net/browse/BUKKIT-809
