### PR TITLE
Fixes ItemStack.deserialize() when working with unsafe enchantment values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.bukkit</groupId>
+    <groupId>com.afforess</groupId>
     <artifactId>bukkit</artifactId>
     <version>1.1-R5-SNAPSHOT</version>
     <name>Bukkit</name>

--- a/src/main/java/org/bukkit/inventory/ItemStack.java
+++ b/src/main/java/org/bukkit/inventory/ItemStack.java
@@ -398,7 +398,7 @@ public class ItemStack implements Cloneable, ConfigurationSerializable {
                     Enchantment enchantment = Enchantment.getByName(entry.getKey().toString());
 
                     if ((enchantment != null) && (entry.getValue() instanceof Integer)) {
-                        result.addEnchantment(enchantment, (Integer) entry.getValue());
+                        result.addUnsafeEnchantment(enchantment, (Integer) entry.getValue());
                     }
                 }
             }


### PR DESCRIPTION
ItemStack.deserialize() now uses addUnsafeEnchantment() instead of addEnchantment() - unsafe values can be serialized but they cause an exception on deserialization; this corrects that issue.
