### PR TITLE
Added BlockState.getLocation.

### DIFF
--- a/src/main/java/org/bukkit/block/BlockState.java
+++ b/src/main/java/org/bukkit/block/BlockState.java
@@ -79,6 +79,13 @@ public interface BlockState {
     int getZ();
 
     /**
+     * Gets the location of this block
+     *
+     * @return location
+     */
+    Location getLocation();
+
+    /**
      * Gets the chunk which contains this block
      *
      * @return Containing Chunk


### PR DESCRIPTION
This function seems to be present in CraftBlockState already
Looks like an oversight.

ticket: https://bukkit.atlassian.net/browse/BUKKIT-807
