### PR TITLE
Reduce Pokémon(tm) exception handling in NumberConversions.java.

### DIFF
--- a/src/main/java/org/bukkit/util/NumberConversions.java
+++ b/src/main/java/org/bukkit/util/NumberConversions.java
@@ -13,8 +13,8 @@ public final class NumberConversions {
             int result = 0;
 
             try {
-                result = Integer.valueOf((String) object);
-            } catch (Throwable ex) {}
+                result = Integer.parseInt(object.toString());
+            } catch (NumberFormatException ex) {}
 
             return result;
         }
@@ -27,8 +27,8 @@ public final class NumberConversions {
             float result = 0;
 
             try {
-                result = Float.valueOf((String) object);
-            } catch (Throwable ex) {}
+                result = Float.parseFloat(object.toString());
+            } catch (NumberFormatException ex) {}
 
             return result;
         }
@@ -41,8 +41,8 @@ public final class NumberConversions {
             double result = 0;
 
             try {
-                result = Double.valueOf((String) object);
-            } catch (Throwable ex) {}
+                result = Double.parseDouble(object.toString());
+            } catch (NumberFormatException ex) {}
 
             return result;
         }
@@ -55,8 +55,8 @@ public final class NumberConversions {
             long result = 0;
 
             try {
-                result = Long.valueOf((String) object);
-            } catch (Throwable ex) {}
+                result = Long.parseLong(object.toString());
+            } catch (NumberFormatException ex) {}
 
             return result;
         }
@@ -69,8 +69,8 @@ public final class NumberConversions {
             short result = 0;
 
             try {
-                result = Short.valueOf((String) object);
-            } catch (Throwable ex) {}
+                result = Short.parseShort(object.toString());
+            } catch (NumberFormatException ex) {}
 
             return result;
         }
@@ -83,8 +83,8 @@ public final class NumberConversions {
             byte result = 0;
 
             try {
-                result = Byte.valueOf((String) object);
-            } catch (Throwable ex) {}
+                result = Byte.parseByte(object.toString());
+            } catch (NumberFormatException ex) {}
 
             return result;
         }


### PR DESCRIPTION
This also allows, for instance, to parse complex numbers with imaginary part=0, if the according toString method omits zero components.

This also saves some unboxing (Foo.valueOf returns a wrapper, while Foo.parseFoo returns a primitive)

ticket: https://bukkit.atlassian.net/browse/BUKKIT-825
