### PR TITLE
Don't make these final.

### DIFF
--- a/src/main/java/org/bukkit/plugin/PluginBase.java
+++ b/src/main/java/org/bukkit/plugin/PluginBase.java
@@ -7,12 +7,12 @@ package org.bukkit.plugin;
  */
 public abstract class PluginBase implements Plugin {
     @Override
-    public final int hashCode() {
+    public int hashCode() {
         return getName().hashCode();
     }
 
     @Override
-    public final boolean equals(Object obj) {
+    public boolean equals(Object obj) {
         if (this == obj) {
             return true;
         }


### PR DESCRIPTION
In some cases, plugin developers might **have to** override `equals(Object)` and `hashCode()`. Best example: Tests. In the Multiverse-Core tests, we're partially mocking the plugin-class to inject custom methods (like `getDescription()`). However, Mockito relies on overriding `equals(Object)`. So making this method final broke our entire tests.

Please pull this.

Fixes [BUKKIT-881](https://bukkit.atlassian.net/browse/BUKKIT-881).
