### PR TITLE
Added modifyable MaxHealth Storage of all Living entities. ADDS Bukkit-266

### DIFF
--- a/src/main/java/org/bukkit/entity/LivingEntity.java
+++ b/src/main/java/org/bukkit/entity/LivingEntity.java
@@ -28,6 +28,19 @@ public interface LivingEntity extends Entity {
      * @throws IllegalArgumentException Thrown if the health is < 0 or > max
      */
     public void setHealth(int health);
+    
+    /**
+     * Sets the entity's max health without touching its current health
+     * @param health The new max health
+     */
+    public void setMaxHealth(int health);
+    
+    /**
+     * Sets the entity's max health and if force is true, it sets its current health to the new max health.
+     * @param health the new max health
+     * @param force boolean, see above
+     */
+    public void setMaxHealth(int health, boolean force);
 
     /**
      * Gets the maximum health this entity may have

--- a/src/main/java/org/bukkit/entity/MaxHealth.java
+++ b/src/main/java/org/bukkit/entity/MaxHealth.java
@@ -1,0 +1,51 @@
+package org.bukkit.entity;
+
+/**
+ * Bukkit implementation of the Max Health
+ */
+public enum MaxHealth {
+    CREEPER(20), 
+    SKELETON(20), 
+    SPIDER(16), 
+    GIANT(100), 
+    ZOMBIE(20), 
+    GHAST(10), 
+    PIG_ZOMBIE(20),
+    ENDERMAN(40), 
+    CAVE_SPIDER(12), 
+    SILVERFISH(8), 
+    BLAZE(20), 
+    ENDER_DRAGON(100), 
+    PIG(10), 
+    SHEEP(8), 
+    COW(10), 
+    CHICKEN(4), 
+    SQUID(10), 
+    TAMED_WOLF(20), 
+    WILD_WOLF(8), 
+    MUSHROOM_COW(10), 
+    SNOWMAN(4), 
+    HUMAN(20),
+    IRON_GOLEM(100),
+    OCELOT(10),
+    VILLAGER(20); 
+    
+    private int health;
+	private MaxHealth(int health) {
+		this.health = health;
+	}
+	/**
+	 * Sets the maximum health of an entity globally
+	 * @param health The new health
+	 */
+	public void setMaxHealth(int health) {
+		this.health = health;
+	}
+	/**
+	 * Gets the current maximum health of an entity
+	 * @return int The health value
+	 */
+	public int getMaximumHealth() {
+		return this.health;
+	}
+}

--- a/src/main/java/org/bukkit/event/entity/EntityChangeMaxHealthEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityChangeMaxHealthEvent.java
@@ -1,0 +1,83 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+/**
+ * 	This event is representing, an dynamical MaxHealth change of an instance of an Entity
+ */
+public class EntityChangeMaxHealthEvent extends EntityEvent implements Cancellable {
+	private static final HandlerList handlers = new HandlerList();
+	private boolean cancelled = false;
+	private int newMax;
+	private boolean force;
+	
+	/**
+	 * Constructor
+	 * @param entity The entity
+	 * @param max The new max health
+	 * @param force If to set the current health of the instance to the maxHealth
+	 */
+	public EntityChangeMaxHealthEvent(final LivingEntity entity, int max, boolean force) {
+		super(entity);
+		this.newMax = max;
+		this.force = force;
+	}
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+	public boolean isCancelled() {
+		return cancelled;
+	}
+
+	public void setCancelled(boolean cancel) {
+		cancelled = cancel;
+	}
+	
+	/**
+	 * @return boolean, if the current health of the entity shall be equal to the new max
+	 */
+	public boolean OverwriteIsForced() {
+		return this.force;
+	}
+	
+	/**
+	 * Sets if the current health of the entity shall be equal to the new max
+	 * @param boolean, see above
+	 */
+	public void setOverwriteIsForced(boolean force) {
+		this.force = force;
+	}
+	
+	/**
+	 * Sets the (new) max health of the Entity
+	 * @param max int, The new max health
+	 */
+	public void setMaxHealth(int max) {
+		this.newMax = max;
+	}
+	
+	/**
+	 * Get the new max health
+	 * @return int, The new max health
+	 */
+	public int getNewMaxHealth() {
+		return this.newMax;
+	}
+	
+	/**
+	 * Get the current max health of the entity
+	 * @return int, the current max health
+	 */
+	public int getCurrentMaxHealth() {
+		return ((LivingEntity) this.entity).getMaxHealth();
+	}
+}

--- a/src/test/java/org/bukkit/plugin/messaging/TestPlayer.java
+++ b/src/test/java/org/bukkit/plugin/messaging/TestPlayer.java
@@ -744,4 +744,12 @@ public class TestPlayer implements Player {
     public void abandonConversation(Conversation conversation, ConversationAbandonedEvent details) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
+	
+	public void setMaxHealth(int i) { 
+		throw new UnsupportedOperationException("Not supported yet.");
+	}
+	
+	public void setMaxHealth(int i, boolean b) { 
+		throw new UnsupportedOperationException("Not supported yet.");
+	}
 }


### PR DESCRIPTION
Added a storage, which provides the Max Health of the living entitys.
This will allow it to modify the max health of each entity easily.

Sample Code:
MaxHealth.BLAZE.setMaxHealth(1);
MaxHealth.PIG.setMaxHealth(1000);
instanceOfEntityLiving.setMaxHealth(100);

CB-Implementation:
https://github.com/Bukkit/CraftBukkit/pull/716
