### PR TITLE
Renamed PlayerEvent to AbstractPlayerEvent and added a new PlayerEvent interface that is implemented by all events dealing with players.

### DIFF
--- a/src/main/java/org/bukkit/entity/LivingEntity.java
+++ b/src/main/java/org/bukkit/entity/LivingEntity.java
@@ -269,4 +269,13 @@ public interface LivingEntity extends Entity {
      * @return A collection of {@link PotionEffect}s
      */
     public Collection<PotionEffect> getActivePotionEffects();
+
+    /**
+     * Checks whether the entity has block line of sight to another.<br />
+     * This uses the same algorithm that hostile mobs use to find the closest player.
+     *
+     * @param other The entity to determine line of sight to.
+     * @return true if there is a line of sight, false if not.
+     */
+    public boolean hasLineOfSight(Entity other);
 }

--- a/src/main/java/org/bukkit/event/block/BlockBreakEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockBreakEvent.java
@@ -4,6 +4,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
 
 /**
  * Called when a block is broken by a player.
@@ -14,7 +15,7 @@ import org.bukkit.event.HandlerList;
  * <p />
  * If a Block Break event is cancelled, the block will not break.
  */
-public class BlockBreakEvent extends BlockEvent implements Cancellable {
+public class BlockBreakEvent extends BlockEvent implements Cancellable, PlayerEvent {
 
     private static final HandlerList handlers = new HandlerList();
     private final Player player;

--- a/src/main/java/org/bukkit/event/block/BlockDamageEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockDamageEvent.java
@@ -4,6 +4,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
 import org.bukkit.inventory.ItemStack;
 
 /**
@@ -11,7 +12,7 @@ import org.bukkit.inventory.ItemStack;
  * <p />
  * If a Block Damage event is cancelled, the block will not be damaged.
  */
-public class BlockDamageEvent extends BlockEvent implements Cancellable {
+public class BlockDamageEvent extends BlockEvent implements Cancellable, PlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     private final Player player;
     private boolean instaBreak;

--- a/src/main/java/org/bukkit/event/block/BlockIgniteEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockIgniteEvent.java
@@ -4,13 +4,14 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
 
 /**
  * Called when a block is ignited. If you want to catch when a Player places fire, you need to use {@link BlockPlaceEvent}.
  * <p />
  * If a Block Ignite event is cancelled, the block will not be ignited.
  */
-public class BlockIgniteEvent extends BlockEvent implements Cancellable {
+public class BlockIgniteEvent extends BlockEvent implements Cancellable, PlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     private final IgniteCause cause;
     private boolean cancel;

--- a/src/main/java/org/bukkit/event/block/BlockPlaceEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockPlaceEvent.java
@@ -5,6 +5,7 @@ import org.bukkit.block.BlockState;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
 import org.bukkit.inventory.ItemStack;
 
 /**
@@ -12,7 +13,7 @@ import org.bukkit.inventory.ItemStack;
  * <p />
  * If a Block Place event is cancelled, the block will not be placed.
  */
-public class BlockPlaceEvent extends BlockEvent implements Cancellable {
+public class BlockPlaceEvent extends BlockEvent implements Cancellable, PlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     protected boolean cancel;
     protected boolean canBuild;

--- a/src/main/java/org/bukkit/event/block/SignChangeEvent.java
+++ b/src/main/java/org/bukkit/event/block/SignChangeEvent.java
@@ -4,13 +4,14 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
 
 /**
  * Called when a sign is changed by a player.
  * <p />
  * If a Sign Change event is cancelled, the sign will not be changed.
  */
-public class SignChangeEvent extends BlockEvent implements Cancellable {
+public class SignChangeEvent extends BlockEvent implements Cancellable, PlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;
     private final Player player;

--- a/src/main/java/org/bukkit/event/enchantment/EnchantItemEvent.java
+++ b/src/main/java/org/bukkit/event/enchantment/EnchantItemEvent.java
@@ -9,13 +9,14 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.inventory.InventoryEvent;
+import org.bukkit.event.player.PlayerEvent;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 
 /**
  * Called when an ItemStack is successfully enchanted (currently at enchantment table)
  */
-public class EnchantItemEvent extends InventoryEvent implements Cancellable {
+public class EnchantItemEvent extends InventoryEvent implements Cancellable, PlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     private final Block table;
     private final ItemStack item;
@@ -112,5 +113,9 @@ public class EnchantItemEvent extends InventoryEvent implements Cancellable {
 
     public static HandlerList getHandlerList() {
         return handlers;
+    }
+
+    public Player getPlayer() {
+        return enchanter;
     }
 }

--- a/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java
+++ b/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java
@@ -5,13 +5,14 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.inventory.InventoryEvent;
+import org.bukkit.event.player.PlayerEvent;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 
 /**
  * Called when an ItemStack is inserted in an enchantment table - can be called multiple times
  */
-public class PrepareItemEnchantEvent extends InventoryEvent implements Cancellable {
+public class PrepareItemEnchantEvent extends InventoryEvent implements Cancellable, PlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     private final Block table;
     private final ItemStack item;
@@ -88,5 +89,9 @@ public class PrepareItemEnchantEvent extends InventoryEvent implements Cancellab
 
     public static HandlerList getHandlerList() {
         return handlers;
+    }
+
+    public Player getPlayer() {
+        return enchanter;
     }
 }

--- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
+++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
@@ -3,12 +3,13 @@ package org.bukkit.event.entity;
 import java.util.List;
 
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerEvent;
 import org.bukkit.inventory.ItemStack;
 
 /**
  * Thrown whenever a {@link Player} dies
  */
-public class PlayerDeathEvent extends EntityDeathEvent {
+public class PlayerDeathEvent extends EntityDeathEvent implements PlayerEvent {
     private int newExp = 0;
     private String deathMessage = "";
     private int newLevel = 0;
@@ -134,5 +135,9 @@ public class PlayerDeathEvent extends EntityDeathEvent {
      */
     public void setKeepLevel(boolean keepLevel) {
         this.keepLevel = keepLevel;
+    }
+
+    public Player getPlayer() {
+        return (Player) entity;
     }
 }

--- a/src/main/java/org/bukkit/event/painting/PaintingPlaceEvent.java
+++ b/src/main/java/org/bukkit/event/painting/PaintingPlaceEvent.java
@@ -6,11 +6,12 @@ import org.bukkit.entity.Painting;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
 
 /**
  * Triggered when a painting is created in the world
  */
-public class PaintingPlaceEvent extends PaintingEvent implements Cancellable {
+public class PaintingPlaceEvent extends PaintingEvent implements Cancellable, PlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancelled;
     private final Player player;

--- a/src/main/java/org/bukkit/event/player/AbstractPlayerEvent.java
+++ b/src/main/java/org/bukkit/event/player/AbstractPlayerEvent.java
@@ -1,0 +1,19 @@
+package org.bukkit.event.player;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+
+/**
+ * Abstract class representing a player related event
+ */
+public abstract class AbstractPlayerEvent extends Event implements PlayerEvent {
+    protected Player player;
+
+    public AbstractPlayerEvent(final Player who) {
+        player = who;
+    }
+
+    public final Player getPlayer() {
+        return player;
+    }
+}

--- a/src/main/java/org/bukkit/event/player/PlayerAnimationEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerAnimationEvent.java
@@ -7,7 +7,7 @@ import org.bukkit.event.HandlerList;
 /**
  * Represents a player animation event
  */
-public class PlayerAnimationEvent extends PlayerEvent implements Cancellable {
+public class PlayerAnimationEvent extends AbstractPlayerEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private final PlayerAnimationType animationType;
     private boolean isCancelled = false;

--- a/src/main/java/org/bukkit/event/player/PlayerBedEnterEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerBedEnterEvent.java
@@ -8,7 +8,7 @@ import org.bukkit.event.HandlerList;
 /**
  * This event is fired when the player is almost about to enter the bed.
  */
-public class PlayerBedEnterEvent extends PlayerEvent implements Cancellable {
+public class PlayerBedEnterEvent extends AbstractPlayerEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;
     private final Block bed;

--- a/src/main/java/org/bukkit/event/player/PlayerBedLeaveEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerBedLeaveEvent.java
@@ -7,7 +7,7 @@ import org.bukkit.event.HandlerList;
 /**
  * This event is fired when the player is leaving a bed.
  */
-public class PlayerBedLeaveEvent extends PlayerEvent {
+public class PlayerBedLeaveEvent extends AbstractPlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     private final Block bed;
 

--- a/src/main/java/org/bukkit/event/player/PlayerBucketEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerBucketEvent.java
@@ -7,7 +7,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.inventory.ItemStack;
 
-public abstract class PlayerBucketEvent extends PlayerEvent implements Cancellable {
+public abstract class PlayerBucketEvent extends AbstractPlayerEvent implements Cancellable {
     private ItemStack itemStack;
     private boolean cancelled = false;
     private final Block blockClicked;

--- a/src/main/java/org/bukkit/event/player/PlayerChangedWorldEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerChangedWorldEvent.java
@@ -4,7 +4,7 @@ import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 
-public class PlayerChangedWorldEvent extends PlayerEvent {
+public class PlayerChangedWorldEvent extends AbstractPlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     private final World from;
 

--- a/src/main/java/org/bukkit/event/player/PlayerChatEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerChatEvent.java
@@ -11,7 +11,7 @@ import org.bukkit.event.HandlerList;
 /**
  * Holds information for player chat and commands
  */
-public class PlayerChatEvent extends PlayerEvent implements Cancellable {
+public class PlayerChatEvent extends AbstractPlayerEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;
     private String message;

--- a/src/main/java/org/bukkit/event/player/PlayerDropItemEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerDropItemEvent.java
@@ -8,7 +8,7 @@ import org.bukkit.event.HandlerList;
 /**
  * Thrown when a player drops an item from their inventory
  */
-public class PlayerDropItemEvent extends PlayerEvent implements Cancellable {
+public class PlayerDropItemEvent extends AbstractPlayerEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private final Item drop;
     private boolean cancel = false;

--- a/src/main/java/org/bukkit/event/player/PlayerEggThrowEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerEggThrowEvent.java
@@ -9,7 +9,7 @@ import org.bukkit.event.HandlerList;
 /**
  * Called when a player throws an egg and it might hatch
  */
-public class PlayerEggThrowEvent extends PlayerEvent {
+public class PlayerEggThrowEvent extends AbstractPlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     private final Egg egg;
     private boolean hatching;

--- a/src/main/java/org/bukkit/event/player/PlayerEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerEvent.java
@@ -1,24 +1,15 @@
 package org.bukkit.event.player;
 
 import org.bukkit.entity.Player;
-import org.bukkit.event.Event;
 
 /**
  * Represents a player related event
  */
-public abstract class PlayerEvent extends Event {
-    protected Player player;
-
-    public PlayerEvent(final Player who) {
-        player = who;
-    }
-
+public interface PlayerEvent {
     /**
      * Returns the player involved in this event
      *
      * @return Player who is involved in this event
      */
-    public final Player getPlayer() {
-        return player;
-    }
+    public Player getPlayer();
 }

--- a/src/main/java/org/bukkit/event/player/PlayerExpChangeEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerExpChangeEvent.java
@@ -6,7 +6,7 @@ import org.bukkit.event.HandlerList;
 /**
  * Called when a players experience changes naturally
  */
-public class PlayerExpChangeEvent extends PlayerEvent {
+public class PlayerExpChangeEvent extends AbstractPlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     private int exp;
 

--- a/src/main/java/org/bukkit/event/player/PlayerFishEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerFishEvent.java
@@ -8,7 +8,7 @@ import org.bukkit.event.HandlerList;
 /**
  * Thrown when a player is fishing
  */
-public class PlayerFishEvent extends PlayerEvent implements Cancellable {
+public class PlayerFishEvent extends AbstractPlayerEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private final Entity entity;
     private boolean cancel = false;

--- a/src/main/java/org/bukkit/event/player/PlayerGameModeChangeEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerGameModeChangeEvent.java
@@ -5,7 +5,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
-public class PlayerGameModeChangeEvent extends PlayerEvent implements Cancellable {
+public class PlayerGameModeChangeEvent extends AbstractPlayerEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancelled;
     private final GameMode newGameMode;

--- a/src/main/java/org/bukkit/event/player/PlayerInteractEntityEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerInteractEntityEvent.java
@@ -8,7 +8,7 @@ import org.bukkit.event.HandlerList;
 /**
  * Represents an event that is called when a player right clicks an entity.
  */
-public class PlayerInteractEntityEvent extends PlayerEvent implements Cancellable {
+public class PlayerInteractEntityEvent extends AbstractPlayerEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     protected Entity clickedEntity;
     boolean cancelled = false;

--- a/src/main/java/org/bukkit/event/player/PlayerInteractEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerInteractEvent.java
@@ -12,7 +12,7 @@ import org.bukkit.event.block.Action;
 /**
  * Called when a player interacts with an object or air.
  */
-public class PlayerInteractEvent extends PlayerEvent implements Cancellable {
+public class PlayerInteractEvent extends AbstractPlayerEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     protected ItemStack item;
     protected Action action;

--- a/src/main/java/org/bukkit/event/player/PlayerInventoryEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerInventoryEvent.java
@@ -12,7 +12,7 @@ import org.bukkit.inventory.Inventory;
  * the other inventory events in {@link org.bukkit.event.inventory}.
  */
 @Deprecated
-public class PlayerInventoryEvent extends PlayerEvent {
+public class PlayerInventoryEvent extends AbstractPlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     protected Inventory inventory;
 

--- a/src/main/java/org/bukkit/event/player/PlayerItemHeldEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerItemHeldEvent.java
@@ -6,7 +6,7 @@ import org.bukkit.event.HandlerList;
 /**
  * Fired when a player changes their currently held item
  */
-public class PlayerItemHeldEvent extends PlayerEvent {
+public class PlayerItemHeldEvent extends AbstractPlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     private final int previous;
     private final int current;

--- a/src/main/java/org/bukkit/event/player/PlayerJoinEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerJoinEvent.java
@@ -6,7 +6,7 @@ import org.bukkit.event.HandlerList;
 /**
  * Called when a player joins a server
  */
-public class PlayerJoinEvent extends PlayerEvent {
+public class PlayerJoinEvent extends AbstractPlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     private String joinMessage;
 

--- a/src/main/java/org/bukkit/event/player/PlayerKickEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerKickEvent.java
@@ -7,7 +7,7 @@ import org.bukkit.event.HandlerList;
 /**
  * Called when a player gets kicked from the server
  */
-public class PlayerKickEvent extends PlayerEvent implements Cancellable {
+public class PlayerKickEvent extends AbstractPlayerEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private String leaveMessage;
     private String kickReason;

--- a/src/main/java/org/bukkit/event/player/PlayerLevelChangeEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerLevelChangeEvent.java
@@ -6,7 +6,7 @@ import org.bukkit.event.HandlerList;
 /**
  * Called when a players level changes
  */
-public class PlayerLevelChangeEvent extends PlayerEvent {
+public class PlayerLevelChangeEvent extends AbstractPlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     private final int oldLevel;
     private final int newLevel;

--- a/src/main/java/org/bukkit/event/player/PlayerLoginEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerLoginEvent.java
@@ -6,7 +6,7 @@ import org.bukkit.event.HandlerList;
 /**
  * Stores details for players attempting to log in
  */
-public class PlayerLoginEvent extends PlayerEvent {
+public class PlayerLoginEvent extends AbstractPlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     private Result result = Result.ALLOWED;
     private String message = "";

--- a/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
@@ -8,7 +8,7 @@ import org.bukkit.event.HandlerList;
 /**
  * Holds information for player movement events
  */
-public class PlayerMoveEvent extends PlayerEvent implements Cancellable {
+public class PlayerMoveEvent extends AbstractPlayerEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;
     private Location from;

--- a/src/main/java/org/bukkit/event/player/PlayerPickupItemEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerPickupItemEvent.java
@@ -8,7 +8,7 @@ import org.bukkit.event.HandlerList;
 /**
  * Thrown when a player picks an item up from the ground
  */
-public class PlayerPickupItemEvent extends PlayerEvent implements Cancellable {
+public class PlayerPickupItemEvent extends AbstractPlayerEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private final Item item;
     private boolean cancel = false;

--- a/src/main/java/org/bukkit/event/player/PlayerQuitEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerQuitEvent.java
@@ -6,7 +6,7 @@ import org.bukkit.event.HandlerList;
 /**
  * Called when a player leaves a server
  */
-public class PlayerQuitEvent extends PlayerEvent {
+public class PlayerQuitEvent extends AbstractPlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     private String quitMessage;
 

--- a/src/main/java/org/bukkit/event/player/PlayerRespawnEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerRespawnEvent.java
@@ -4,7 +4,7 @@ import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 
-public class PlayerRespawnEvent extends PlayerEvent {
+public class PlayerRespawnEvent extends AbstractPlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     private Location respawnLocation;
     private final boolean isBedSpawn;

--- a/src/main/java/org/bukkit/event/player/PlayerShearEntityEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerShearEntityEvent.java
@@ -8,7 +8,7 @@ import org.bukkit.event.HandlerList;
 /**
  * Called when a player shears an entity
  */
-public class PlayerShearEntityEvent extends PlayerEvent implements Cancellable {
+public class PlayerShearEntityEvent extends AbstractPlayerEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel;
     private final Entity what;

--- a/src/main/java/org/bukkit/event/player/PlayerToggleSneakEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerToggleSneakEvent.java
@@ -7,7 +7,7 @@ import org.bukkit.event.HandlerList;
 /**
  * Called when a player toggles their sneaking state
  */
-public class PlayerToggleSneakEvent extends PlayerEvent implements Cancellable {
+public class PlayerToggleSneakEvent extends AbstractPlayerEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private final boolean isSneaking;
     private boolean cancel = false;

--- a/src/main/java/org/bukkit/event/player/PlayerToggleSprintEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerToggleSprintEvent.java
@@ -7,7 +7,7 @@ import org.bukkit.event.HandlerList;
 /**
  * Called when a player toggles their sprinting state
  */
-public class PlayerToggleSprintEvent extends PlayerEvent implements Cancellable {
+public class PlayerToggleSprintEvent extends AbstractPlayerEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private final boolean isSprinting;
     private boolean cancel = false;

--- a/src/main/java/org/bukkit/event/player/PlayerVelocityEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerVelocityEvent.java
@@ -5,7 +5,7 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.bukkit.util.Vector;
 
-public class PlayerVelocityEvent extends PlayerEvent implements Cancellable {
+public class PlayerVelocityEvent extends AbstractPlayerEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;
     private Vector velocity;

--- a/src/main/java/org/bukkit/event/world/StructureGrowEvent.java
+++ b/src/main/java/org/bukkit/event/world/StructureGrowEvent.java
@@ -7,11 +7,12 @@ import org.bukkit.block.BlockState;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
 
 /**
  * Event that is called when an organic structure attempts to grow (Sapling -> Tree), (Mushroom -> Huge Mushroom), naturally or using bonemeal.
  */
-public class StructureGrowEvent extends WorldEvent implements Cancellable {
+public class StructureGrowEvent extends WorldEvent implements Cancellable, PlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancelled = false;
     private final Location location;


### PR DESCRIPTION
This allows writing code that generically deals with all player events.

To evaluate:
1. deprecate/remove getEnchanter from the enchant events
2. add an IEvent interface with getEventName
3. Reverse the changes and add an IPlayerEvent interface instead

ticket: https://bukkit.atlassian.net/browse/BUKKIT-1114
