### PR TITLE
PluginLoader that reads yml files and loads the plugin from the classpath

### DIFF
--- a/src/main/java/org/bukkit/plugin/java/YmlJavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/YmlJavaPluginLoader.java
@@ -1,0 +1,47 @@
+package org.bukkit.plugin.java;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.regex.Pattern;
+
+import org.bukkit.Server;
+import org.bukkit.plugin.InvalidDescriptionException;
+import org.bukkit.plugin.PluginDescriptionFile;
+
+/**
+ * Represents a Java plugin loader which loads plugins from class path, read from .yml files.
+ */
+public class YmlJavaPluginLoader extends JavaPluginLoader {
+
+    protected final Pattern[] fileFilters = new Pattern[] { Pattern.compile("\\.yml$"), };
+
+    public YmlJavaPluginLoader(Server instance) {
+        super(instance);
+    }
+
+    @Override
+    public PluginDescriptionFile getPluginDescription(File file) throws InvalidDescriptionException {
+        try {
+            return getYmlPluginDescription(file);
+        } catch (IOException e) {
+            throw new InvalidDescriptionException(e);
+        }
+    }
+
+    private PluginDescriptionFile getYmlPluginDescription(File file) throws InvalidDescriptionException, IOException {
+        InputStream stream = new FileInputStream(file);
+        try {
+            return new PluginDescriptionFile(stream);
+        } finally {
+            stream.close();
+        }
+    }
+
+    @Override
+    public Pattern[] getPluginFileFilters() {
+        return fileFilters;
+    }
+
+}


### PR DESCRIPTION
This loader will accept yml files in the plugin directory
and load the plugin specified there-in.

This is realy useful when doing plugin development.
