### PR TITLE
Location implements Serializable

### DIFF
--- a/src/main/java/org/bukkit/Location.java
+++ b/src/main/java/org/bukkit/Location.java
@@ -1,5 +1,10 @@
 package org.bukkit;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
 import org.bukkit.block.Block;
 import org.bukkit.util.NumberConversions;
 import org.bukkit.util.Vector;
@@ -7,8 +12,8 @@ import org.bukkit.util.Vector;
 /**
  * Represents a 3-dimensional position in a world
  */
-public class Location implements Cloneable {
-    private World world;
+public class Location implements Cloneable, Serializable {
+    private transient World world;
     private double x;
     private double y;
     private double z;
@@ -44,6 +49,35 @@ public class Location implements Cloneable {
         this.z = z;
         this.pitch = pitch;
         this.yaw = yaw;
+    }
+
+    /**
+    * Method invoked by the JVM during serialization to properly save world data.
+    * 
+    * @param os An ObjectOutputStream passed during serialization of the Location.
+    */
+    private void writeObject(ObjectOutputStream os){
+        try{
+            os.defaultWriteObject();
+            os.writeUTF(world.getName());
+        }catch(IOException e){
+            e.printStackTrace();
+        }
+    }
+
+    /**
+    * Method invoked by the JVM during deserialization to properly read world data.
+    * 
+    * @param is An ObjectInputStream passed during deserialization of the Location.
+    */
+    private void readObject(ObjectInputStream is){
+        try{
+            is.defaultReadObject();
+            String name = is.readUTF();
+            this.world = Bukkit.getWorld(name);
+        }catch(Exception e){
+            e.printStackTrace();
+        }
     }
 
     /**


### PR DESCRIPTION
This is my first pull request, I got the idea to try this from this forum thread: http://forums.bukkit.org/threads/make-org-bukkit-location-serializable.56521/

Location's field World is now transient, to avoid a non-serializable object from being written. Instead, the private methods writeObject() and readObject() are implemented to save the world as a String. These are invoked, if found, by the JVM when ObjectOutputStream.writeObject() or ObjectInputStream.readObject() is called. They save the world as a String.

Here is the demonstration plugin, which can save and load Locations if the Bukkit it's running on has my Location class:
http://www.pyraetos.net/SerializeLocation.jar

Commands:
    /save: Creates a file called "location" in the CD and writes the player's location.
    /load: Loads the file and messages the player with the new Location's toString()
