### PR TITLE
Added ability to get EventExecutors to allow individual EventExecutors to be unregistered; BUKKIT-1192

### DIFF
--- a/src/main/java/org/bukkit/plugin/PluginManager.java
+++ b/src/main/java/org/bukkit/plugin/PluginManager.java
@@ -111,8 +111,9 @@ public interface PluginManager {
      * @param priority Priority to register this event at
      * @param executor EventExecutor to register
      * @param plugin Plugin to register
+     * @return The RegisteredListener created for this registration
      */
-    public void registerEvent(Class<? extends Event> event, Listener listener, EventPriority priority, EventExecutor executor, Plugin plugin);
+    public RegisteredListener registerEvent(Class<? extends Event> event, Listener listener, EventPriority priority, EventExecutor executor, Plugin plugin);
 
     /**
      * Registers the specified executor to the given event class
@@ -123,8 +124,9 @@ public interface PluginManager {
      * @param executor EventExecutor to register
      * @param plugin Plugin to register
      * @param ignoreCancelled Whether to pass cancelled events or not
+     * @return The RegisteredListener created for this registration
      */
-    public void registerEvent(Class<? extends Event> event, Listener listener, EventPriority priority, EventExecutor executor, Plugin plugin, boolean ignoreCancelled);
+    public RegisteredListener registerEvent(Class<? extends Event> event, Listener listener, EventPriority priority, EventExecutor executor, Plugin plugin, boolean ignoreCancelled);
 
     /**
      * Enables the specified plugin

--- a/src/main/java/org/bukkit/plugin/RegisteredListener.java
+++ b/src/main/java/org/bukkit/plugin/RegisteredListener.java
@@ -70,4 +70,13 @@ public class RegisteredListener {
     public boolean isIgnoringCancelled() {
         return ignoreCancelled;
     }
+
+    /**
+     * Gets the executor for this registration
+     * 
+     * @return Registered Executor
+     */
+    public EventExecutor getExecutor() {
+        return executor;
+    }
 }

--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -474,8 +474,8 @@ public final class SimplePluginManager implements PluginManager {
 
     }
 
-    public void registerEvent(Class<? extends Event> event, Listener listener, EventPriority priority, EventExecutor executor, Plugin plugin) {
-        registerEvent(event, listener, priority, executor, plugin, false);
+    public RegisteredListener registerEvent(Class<? extends Event> event, Listener listener, EventPriority priority, EventExecutor executor, Plugin plugin) {
+        return registerEvent(event, listener, priority, executor, plugin, false);
     }
 
     /**
@@ -488,7 +488,7 @@ public final class SimplePluginManager implements PluginManager {
      * @param plugin Plugin to register
      * @param ignoreCancelled Do not call executor if event was already cancelled
      */
-    public void registerEvent(Class<? extends Event> event, Listener listener, EventPriority priority, EventExecutor executor, Plugin plugin, boolean ignoreCancelled) {
+    public RegisteredListener registerEvent(Class<? extends Event> event, Listener listener, EventPriority priority, EventExecutor executor, Plugin plugin, boolean ignoreCancelled) {
         Validate.notNull(listener, "Listener cannot be null");
         Validate.notNull(priority, "Priority cannot be null");
         Validate.notNull(executor, "Executor cannot be null");
@@ -498,11 +498,15 @@ public final class SimplePluginManager implements PluginManager {
             throw new IllegalPluginAccessException("Plugin attempted to register " + event + " while not enabled");
         }
 
+        RegisteredListener registered;
         if (useTimings) {
-            getEventListeners(event).register(new TimedRegisteredListener(listener, executor, priority, plugin, ignoreCancelled));
+            registered = new TimedRegisteredListener(listener, executor, priority, plugin, ignoreCancelled);
         } else {
-            getEventListeners(event).register(new RegisteredListener(listener, executor, priority, plugin, ignoreCancelled));
+            registered = new RegisteredListener(listener, executor, priority, plugin, ignoreCancelled);
         }
+        getEventListeners(event).register(registered);
+        
+        return registered;
     }
 
     private HandlerList getEventListeners(Class<? extends Event> type) {


### PR DESCRIPTION
This is a simple non-breaking change that would greatly enhance a plugin developer's ability to manage individual event executors.
