### PR TITLE
Made Material.LEAVES constructor actually call it's associated MaterialData.

### DIFF
--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -36,7 +36,7 @@ public enum Material {
     IRON_ORE(15),
     COAL_ORE(16),
     LOG(17, Tree.class),
-    LEAVES(18, Tree.class),
+    LEAVES(18, Leaves.class),
     SPONGE(19),
     GLASS(20),
     LAPIS_ORE(21),


### PR DESCRIPTION
Leaves was calling the Tree.class, so it was impossible to get the species from the leaves.

Associated ticket: https://bukkit.atlassian.net/browse/BUKKIT-1196
