### PR TITLE
Added ability to get EventExecutor from RegisteredListener to allow individual EventExecutors to be identifiable and unregistered; BUKKIT-1192

### DIFF
--- a/src/main/java/org/bukkit/plugin/RegisteredListener.java
+++ b/src/main/java/org/bukkit/plugin/RegisteredListener.java
@@ -46,6 +46,15 @@ public class RegisteredListener {
     public EventPriority getPriority() {
         return priority;
     }
+    
+    /**
+    * Gets the executor for this registration
+    *
+    * @return Registered Executor
+    */
+    public EventExecutor getExecutor() {
+        return executor;
+    }
 
     /**
      * Calls the event executor


### PR DESCRIPTION
This will allow a plugin developer to identify a specific EventExecutor in a RegisteredListener (from HandlerList.getRegisteredListeners) in order to unregister it independently from any other EventExecutors in the same Listener.

I believe this is binary compatible and should therefore be a non-breaking change.
