### PR TITLE
Additional info for error message

### DIFF
--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -282,7 +282,7 @@ public class JavaPluginLoader implements PluginLoader {
             if (eh == null) continue;
             final Class<?> checkClass = method.getParameterTypes()[0];
             if (!Event.class.isAssignableFrom(checkClass) || method.getParameterTypes().length != 1) {
-                plugin.getServer().getLogger().severe("Wrong method arguments used for event type registered");
+                plugin.getServer().getLogger().severe("Wrong method arguments used for event type registered: Plugin: " + plugin.getName() + " Class: " + listener.getClass().getName() + " Method: " + method.getName());
                 continue;
             }
             final Class<? extends Event> eventClass = checkClass.asSubclass(Event.class);


### PR DESCRIPTION
This prints the name of the plugin, the listener class and the method when a registration error occurs.

When converting an entire plugin to the new system, it speeds up tracking down which method didn't convert correctly.
