### PR TITLE
Added getOriginalBlock() to EntityTNTPrimed - Adds BUKKIT-45

### DIFF
--- a/src/main/java/org/bukkit/entity/TNTPrimed.java
+++ b/src/main/java/org/bukkit/entity/TNTPrimed.java
@@ -1,5 +1,7 @@
 package org.bukkit.entity;
 
+import org.bukkit.block.Block;
+
 /**
  * Represents a Primed TNT.
  */
@@ -17,4 +19,11 @@ public interface TNTPrimed extends Explosive {
      * @return the number of ticks until this TNTPrimed explodes
      */
     public int getFuseTicks();
+    
+    /**
+     * Retrieve the original block (the TNT block placed)
+     * 
+     * @return the TNT block placed
+     */
+    public Block getOriginalBlock();
 }


### PR DESCRIPTION
Literally gets the original block from an EntityTNTPrimed.

Although the block is not there (in the world) anymore, people (such as myself) may still want to use the block for metadata or other uses.

Associated CraftBukkit Pull: https://github.com/Bukkit/CraftBukkit/pull/731
Ancient Leaky: https://bukkit.atlassian.net/browse/BUKKIT-45
