### PR TITLE
[B] JavaPlugin.getDefaultWorldGenerator should not print a message

### DIFF
--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
@@ -334,7 +334,6 @@ public abstract class JavaPlugin extends PluginBase {
     public void onEnable() {}
 
     public ChunkGenerator getDefaultWorldGenerator(String worldName, String id) {
-        getServer().getLogger().severe("Plugin " + description.getFullName() + " does not contain any generators that may be used in the default world!");
         return null;
     }
 


### PR DESCRIPTION
Only plugins are going to be calling this method. Thus, only plugins should be notified of the result (null). No need to tell the user that too.
See MultiVerse for an example of where this is used in practise.
https://bukkit.atlassian.net/browse/BUKKIT-2565
Bukkit/CraftBukkit#1082
