### PR TITLE
PluginsCommand - Use .length() instead of pointless counter

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/PluginsCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/PluginsCommand.java
@@ -27,7 +27,6 @@ public class PluginsCommand extends BukkitCommand {
     private String getPluginList() {
         StringBuilder pluginList = new StringBuilder();
         Plugin[] plugins = Bukkit.getPluginManager().getPlugins();
-        int pluginCount = 0;
 
         for (Plugin plugin : plugins) {
             if (pluginList.length() > 0) {
@@ -37,9 +36,8 @@ public class PluginsCommand extends BukkitCommand {
 
             pluginList.append(plugin.isEnabled() ? ChatColor.GREEN : ChatColor.RED);
             pluginList.append(plugin.getDescription().getName());
-            pluginCount++;
         }
 
-        return "(" + pluginCount + "): " + pluginList.toString();
+        return "(" + pluginList.length() + "): " + pluginList.toString();
     }
 }


### PR DESCRIPTION
Removes pointless counter while iterating instead of just using .length().
