### PR TITLE
use equalsIgnoreCase() instead of startsWith() to match /stop

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/StopCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/StopCommand.java
@@ -24,6 +24,6 @@ public class StopCommand extends VanillaCommand {
 
     @Override
     public boolean matches(String input) {
-        return input.startsWith("stop");
+        return input.equalsIgnoreCase("stop");
     }
 }

--- a/src/main/java/org/bukkit/command/defaults/StopCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/StopCommand.java
@@ -24,6 +24,6 @@ public class StopCommand extends VanillaCommand {
 
     @Override
     public boolean matches(String input) {
-        return input.equalsIgnoreCase("stop");
+        return (input.startsWith("stop ") || input.equalsIgnoreCase("stop"));
     }
 }


### PR DESCRIPTION
`/stop`'s matching method currently allows unsuspecting server ops to kill the server using any command that begins with `/stop`, such as `/stopfire` or `/stopstorm`. 

This pull will make it so only `/stop` will work.
