### PR TITLE
Make DoubleChest abstract and compatible with Chest. (Fixes BUKKIT-1713)

### DIFF
--- a/src/main/java/org/bukkit/block/DoubleChest.java
+++ b/src/main/java/org/bukkit/block/DoubleChest.java
@@ -1,47 +1,11 @@
 package org.bukkit.block;
 
-import org.bukkit.Location;
-import org.bukkit.World;
-import org.bukkit.inventory.DoubleChestInventory;
-import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 
-public class DoubleChest implements InventoryHolder {
-    private DoubleChestInventory inventory;
+public interface DoubleChest extends Chest {
 
-    public DoubleChest(DoubleChestInventory chest) {
-        inventory = chest;
-    }
+    public InventoryHolder getLeftSide();
 
-    public Inventory getInventory() {
-        return inventory;
-    }
-
-    public InventoryHolder getLeftSide() {
-        return inventory.getLeftSide().getHolder();
-    }
-
-    public InventoryHolder getRightSide() {
-        return inventory.getRightSide().getHolder();
-    }
-
-    public Location getLocation() {
-        return new Location(getWorld(), getX(), getY(), getZ());
-    }
-
-    public World getWorld() {
-        return ((Chest)getLeftSide()).getWorld();
-    }
-
-    public double getX() {
-        return 0.5 * (((Chest)getLeftSide()).getX() + ((Chest)getRightSide()).getX());
-    }
-
-    public double getY() {
-        return 0.5 * (((Chest)getLeftSide()).getY() + ((Chest)getRightSide()).getY());
-    }
-
-    public double getZ() {
-        return 0.5 * (((Chest)getLeftSide()).getZ() + ((Chest)getRightSide()).getZ());
-    }
+    public InventoryHolder getRightSide();
+    
 }


### PR DESCRIPTION
Changes DoubleChest to also be an abstract interface with the rest of the InventoryHolder interfaces, which allows it to be casted and used interchangeably with standard Chests.

This fixes [BUKKIT-1713](https://bukkit.atlassian.net/browse/BUKKIT-1713).
