### PR TITLE
Adds PlayerInvalidInteractEvent

### DIFF
--- a/src/main/java/org/bukkit/event/player/PlayerInvalidInteractEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerInvalidInteractEvent.java
@@ -1,0 +1,43 @@
+package org.bukkit.event.player;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+
+public class PlayerInvalidInteractEvent extends PlayerEvent {
+    private static final HandlerList handlers = new HandlerList();
+    private final int target;
+    private final boolean action;
+
+    public PlayerInvalidInteractEvent(final Player player, final int target, final int action) {
+        super(player);
+        this.target = target;
+        this.action = (action == 1);
+    }
+
+    /**
+     * Gets the entity ID that the player interacted with
+     *
+     * @return Entity ID of the target
+     */
+    public int getTarget() {
+        return target;
+    }
+
+    /**
+     * Gets whether the player left- or right-clicked
+     *
+     * @return True is left-click, False is right-click
+     */
+    public boolean getAction() {
+        return action;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}


### PR DESCRIPTION
Ticket: https://bukkit.atlassian.net/browse/BUKKIT-1145
CraftBukkit Event Sender: https://github.com/Bukkit/CraftBukkit/pull/744

This event will allow plugins to catch when a client interacts with en entity ID that is not found on the server. This is useful for plugins that create and maintain "fake entities" on the client-side.
