### PR TITLE
Refactored (Lazy|Fixed)MetadataValue's conversions into a base class (BUKKIT-1460)

### DIFF
--- a/src/main/java/org/bukkit/metadata/FixedMetadataValue.java
+++ b/src/main/java/org/bukkit/metadata/FixedMetadataValue.java
@@ -2,13 +2,14 @@ package org.bukkit.metadata;
 
 import org.bukkit.plugin.Plugin;
 
-import java.util.concurrent.Callable;
 
 /**
  * A FixedMetadataValue is a special case metadata item that contains the same value forever after initialization.
  * Invalidating a FixedMetadataValue has no affect.
  */
-public class FixedMetadataValue extends LazyMetadataValue {
+public class FixedMetadataValue extends MetadataValueAdapter {
+	private final Object internalValue;
+	
     /**
      * Initializes a FixedMetadataValue with an Object
      *
@@ -16,10 +17,23 @@ public class FixedMetadataValue extends LazyMetadataValue {
      * @param value the value assigned to this metadata value.
      */
     public FixedMetadataValue(Plugin owningPlugin, final Object value) {
-        super(owningPlugin, CacheStrategy.CACHE_ETERNALLY, new Callable<Object>() {
-            public Object call() throws Exception {
-                return value;
-            }
-        });
+    	super(owningPlugin);
+    	this.internalValue = value;
     }
+
+    /**
+     * Gives the fixed value that this MetadataValue represents.
+     */
+	public Object value() {
+		return this.internalValue;
+	}
+
+	/**
+	 * Invalidate this value.
+	 * 
+	 * Does nothing, due to the fixed value.
+	 */
+	public void invalidate() {
+		// Do nothing
+	}
 }

--- a/src/main/java/org/bukkit/metadata/FixedMetadataValue.java
+++ b/src/main/java/org/bukkit/metadata/FixedMetadataValue.java
@@ -8,8 +8,8 @@ import org.bukkit.plugin.Plugin;
  * Invalidating a FixedMetadataValue has no affect.
  */
 public class FixedMetadataValue extends MetadataValueAdapter {
-	private final Object internalValue;
-	
+    private final Object internalValue;
+    
     /**
      * Initializes a FixedMetadataValue with an Object
      *
@@ -17,23 +17,23 @@ public class FixedMetadataValue extends MetadataValueAdapter {
      * @param value the value assigned to this metadata value.
      */
     public FixedMetadataValue(Plugin owningPlugin, final Object value) {
-    	super(owningPlugin);
-    	this.internalValue = value;
+        super(owningPlugin);
+        this.internalValue = value;
     }
 
     /**
      * Gives the fixed value that this MetadataValue represents.
      */
-	public Object value() {
-		return this.internalValue;
-	}
+    public Object value() {
+        return this.internalValue;
+    }
 
-	/**
-	 * Invalidate this value.
-	 * 
-	 * Does nothing, due to the fixed value.
-	 */
-	public void invalidate() {
-		// Do nothing
-	}
+    /**
+     * Invalidate this value.
+     * 
+     * Does nothing, due to the fixed value.
+     */
+    public void invalidate() {
+        // Do nothing
+    }
 }

--- a/src/main/java/org/bukkit/metadata/LazyMetadataValue.java
+++ b/src/main/java/org/bukkit/metadata/LazyMetadataValue.java
@@ -5,7 +5,6 @@ import java.util.concurrent.Callable;
 
 import org.apache.commons.lang.Validate;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.util.NumberConversions;
 
 /**
  * The LazyMetadataValue class implements a type of metadata that is not computed until another plugin asks for it.
@@ -14,11 +13,10 @@ import org.bukkit.util.NumberConversions;
  * or invalidated at the individual or plugin level. Once invalidated, the LazyMetadataValue will recompute its value
  * when asked.
  */
-public class LazyMetadataValue implements MetadataValue {
+public class LazyMetadataValue extends MetadataValueAdapter implements MetadataValue {
     private Callable<Object> lazyValue;
     private CacheStrategy cacheStrategy;
     private SoftReference<Object> internalValue = new SoftReference<Object>(null);
-    private Plugin owningPlugin;
     private static final Object ACTUALLY_NULL = new Object();
 
     /**
@@ -39,17 +37,12 @@ public class LazyMetadataValue implements MetadataValue {
      * @param lazyValue the lazy value assigned to this metadata value.
      */
     public LazyMetadataValue(Plugin owningPlugin, CacheStrategy cacheStrategy, Callable<Object> lazyValue) {
-        Validate.notNull(owningPlugin, "owningPlugin cannot be null");
+    	super(owningPlugin);
         Validate.notNull(cacheStrategy, "cacheStrategy cannot be null");
         Validate.notNull(lazyValue, "lazyValue cannot be null");
 
         this.lazyValue = lazyValue;
-        this.owningPlugin = owningPlugin;
         this.cacheStrategy = cacheStrategy;
-    }
-
-    public Plugin getOwningPlugin() {
-        return owningPlugin;
     }
 
     public Object value() {
@@ -61,55 +54,6 @@ public class LazyMetadataValue implements MetadataValue {
         return value;
     }
 
-    public int asInt() {
-        return NumberConversions.toInt(value());
-    }
-
-    public float asFloat() {
-        return NumberConversions.toFloat(value());
-    }
-
-    public double asDouble() {
-        return NumberConversions.toDouble(value());
-    }
-
-    public long asLong() {
-        return NumberConversions.toLong(value());
-    }
-
-    public short asShort() {
-        return NumberConversions.toShort(value());
-    }
-
-    public byte asByte() {
-        return NumberConversions.toByte(value());
-    }
-
-    public boolean asBoolean() {
-        Object value = value();
-        if (value instanceof Boolean) {
-            return (Boolean) value;
-        }
-
-        if (value instanceof Number) {
-            return ((Number) value).intValue() != 0;
-        }
-
-        if (value instanceof String) {
-            return Boolean.parseBoolean((String) value);
-        }
-
-        return value != null;
-    }
-
-    public String asString() {
-        Object value = value();
-
-        if (value == null) {
-            return "";
-        }
-        return value.toString();
-    }
 
     /**
      * Lazily evaluates the value of this metadata item.

--- a/src/main/java/org/bukkit/metadata/LazyMetadataValue.java
+++ b/src/main/java/org/bukkit/metadata/LazyMetadataValue.java
@@ -37,7 +37,7 @@ public class LazyMetadataValue extends MetadataValueAdapter implements MetadataV
      * @param lazyValue the lazy value assigned to this metadata value.
      */
     public LazyMetadataValue(Plugin owningPlugin, CacheStrategy cacheStrategy, Callable<Object> lazyValue) {
-    	super(owningPlugin);
+        super(owningPlugin);
         Validate.notNull(cacheStrategy, "cacheStrategy cannot be null");
         Validate.notNull(lazyValue, "lazyValue cannot be null");
 

--- a/src/main/java/org/bukkit/metadata/MetadataValueAdapter.java
+++ b/src/main/java/org/bukkit/metadata/MetadataValueAdapter.java
@@ -13,18 +13,18 @@ import org.bukkit.util.NumberConversions;
  *
  */
 public abstract class MetadataValueAdapter implements MetadataValue {
-	protected final Plugin owningPlugin;
-	
-	protected MetadataValueAdapter(Plugin owningPlugin) {
+    protected final Plugin owningPlugin;
+
+    protected MetadataValueAdapter(Plugin owningPlugin) {
         Validate.notNull(owningPlugin, "owningPlugin cannot be null");
-		this.owningPlugin = owningPlugin;
-	}
-    
-    public Plugin getOwningPlugin() {
-    	return owningPlugin;
+        this.owningPlugin = owningPlugin;
     }
-	
-	public int asInt() {
+
+    public Plugin getOwningPlugin() {
+        return owningPlugin;
+    }
+
+    public int asInt() {
         return NumberConversions.toInt(value());
     }
 

--- a/src/main/java/org/bukkit/metadata/MetadataValueAdapter.java
+++ b/src/main/java/org/bukkit/metadata/MetadataValueAdapter.java
@@ -1,0 +1,77 @@
+package org.bukkit.metadata;
+
+import org.apache.commons.lang.Validate;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.util.NumberConversions;
+
+/**
+ * Optional base class for facilitating MetadataValue implementations.
+ * 
+ * This provides all the conversion functions for MetadataValue 
+ * so that writing an implementation of MetadataValue is as simple 
+ * as implementing value() and invalidate()
+ *
+ */
+public abstract class MetadataValueAdapter implements MetadataValue {
+	protected final Plugin owningPlugin;
+	
+	protected MetadataValueAdapter(Plugin owningPlugin) {
+        Validate.notNull(owningPlugin, "owningPlugin cannot be null");
+		this.owningPlugin = owningPlugin;
+	}
+    
+    public Plugin getOwningPlugin() {
+    	return owningPlugin;
+    }
+	
+	public int asInt() {
+        return NumberConversions.toInt(value());
+    }
+
+    public float asFloat() {
+        return NumberConversions.toFloat(value());
+    }
+
+    public double asDouble() {
+        return NumberConversions.toDouble(value());
+    }
+
+    public long asLong() {
+        return NumberConversions.toLong(value());
+    }
+
+    public short asShort() {
+        return NumberConversions.toShort(value());
+    }
+
+    public byte asByte() {
+        return NumberConversions.toByte(value());
+    }
+
+    public boolean asBoolean() {
+        Object value = value();
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+
+        if (value instanceof Number) {
+            return ((Number) value).intValue() != 0;
+        }
+
+        if (value instanceof String) {
+            return Boolean.parseBoolean((String) value);
+        }
+
+        return value != null;
+    }
+
+    public String asString() {
+        Object value = value();
+
+        if (value == null) {
+            return "";
+        }
+        return value.toString();
+    }
+
+}

--- a/src/test/java/org/bukkit/metadata/MedatadaValueAdapterTest.java
+++ b/src/test/java/org/bukkit/metadata/MedatadaValueAdapterTest.java
@@ -1,0 +1,44 @@
+package org.bukkit.metadata;
+
+import static org.junit.Assert.assertEquals;
+
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.TestPlugin;
+import org.junit.Test;
+
+public class MedatadaValueAdapterTest {
+	private TestPlugin plugin = new TestPlugin("x");
+
+    @Test
+    public void testIncrementingAdapter() {
+        IncrementingMetaValue mv = new IncrementingMetaValue(plugin);
+        // check getOwningPlugin
+        assertEquals(mv.getOwningPlugin(), this.plugin);
+        
+        // check the various value-making methods
+        assertEquals(mv.asInt(), 1);
+        assertEquals(mv.asLong(), 2L);
+        assertEquals(mv.asFloat(), 3.0, 0.001);
+        assertEquals(mv.asByte(), 4);
+        assertEquals(mv.asDouble(), 5.0, 0.001);
+        assertEquals(mv.asShort(), 6);
+        assertEquals(mv.asString(), "7");
+    }
+    
+    /** Silly Metadata implementation that increments every time value() is called */
+    class IncrementingMetaValue extends MetadataValueAdapter {
+    	private int internalValue = 0;
+  
+		protected IncrementingMetaValue(Plugin owningPlugin) {
+			super(owningPlugin);
+		}
+
+		public Object value() {
+			return ++internalValue;
+		}
+
+		public void invalidate() {
+			internalValue = 0;
+		}
+    }
+}

--- a/src/test/java/org/bukkit/metadata/MetadataValueAdapterTest.java
+++ b/src/test/java/org/bukkit/metadata/MetadataValueAdapterTest.java
@@ -6,15 +6,15 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.TestPlugin;
 import org.junit.Test;
 
-public class MedatadaValueAdapterTest {
-	private TestPlugin plugin = new TestPlugin("x");
+public class MetadataValueAdapterTest {
+    private TestPlugin plugin = new TestPlugin("x");
 
     @Test
     public void testIncrementingAdapter() {
         IncrementingMetaValue mv = new IncrementingMetaValue(plugin);
         // check getOwningPlugin
         assertEquals(mv.getOwningPlugin(), this.plugin);
-        
+
         // check the various value-making methods
         assertEquals(mv.asInt(), 1);
         assertEquals(mv.asLong(), 2L);
@@ -24,21 +24,21 @@ public class MedatadaValueAdapterTest {
         assertEquals(mv.asShort(), 6);
         assertEquals(mv.asString(), "7");
     }
-    
+
     /** Silly Metadata implementation that increments every time value() is called */
     class IncrementingMetaValue extends MetadataValueAdapter {
-    	private int internalValue = 0;
-  
-		protected IncrementingMetaValue(Plugin owningPlugin) {
-			super(owningPlugin);
-		}
+        private int internalValue = 0;
 
-		public Object value() {
-			return ++internalValue;
-		}
+        protected IncrementingMetaValue(Plugin owningPlugin) {
+            super(owningPlugin);
+        }
 
-		public void invalidate() {
-			internalValue = 0;
-		}
+        public Object value() {
+            return ++internalValue;
+        }
+
+        public void invalidate() {
+            internalValue = 0;
+        }
     }
 }


### PR DESCRIPTION
The implementation of a MetadataValue is complicated by needing to provide a number of conversion functions, refactored this code out of LazyMetadataValue into new base abstract class.

In addition, changed FixedMetadataValue to not be a callable closure implementation of LazyMetadataValue, see explanation in relevant commit.

Includes unit tests with a test implementation as well.

Also see associated ticket: https://bukkit.atlassian.net/browse/BUKKIT-1460
