### PR TITLE
Updated support for unpacked folder, Addresses BUKKIT-1404

### DIFF
--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -181,22 +181,37 @@ public class JavaPluginLoader implements PluginLoader {
 
     public PluginDescriptionFile getPluginDescription(File file) throws InvalidDescriptionException {
         Validate.notNull(file, "File cannot be null");
+        
+        final String pluginFileName = "plugin.yml";
 
         JarFile jar = null;
         InputStream stream = null;
-
         try {
-            jar = new JarFile(file);
-            JarEntry entry = jar.getJarEntry("plugin.yml");
-
-            if (entry == null) {
-                throw new InvalidDescriptionException(new FileNotFoundException("Jar does not contain plugin.yml"));
-            }
-
-            stream = jar.getInputStream(entry);
-
-            return new PluginDescriptionFile(stream);
-
+        	
+	        if(file.exists() && file.isDirectory()) {
+	        	File[] files = file.listFiles(new java.io.FilenameFilter() {
+					public boolean accept(File dir, String filename) {
+						return filename.toLowerCase().equals(pluginFileName);
+					}
+	        	});
+	        	
+	        	if(files.length > 0){
+	        		stream = new java.io.FileInputStream(files[0]);
+	        	} else {
+	        		throw new InvalidDescriptionException(new FileNotFoundException("Folder does not contain " + pluginFileName));
+	        	}
+	        } else {
+		        jar = new JarFile(file);
+	            JarEntry entry = jar.getJarEntry(pluginFileName);
+	
+	            if (entry == null) {
+	                throw new InvalidDescriptionException(new FileNotFoundException("Jar does not contain " + pluginFileName));
+	            }
+	
+	            stream = jar.getInputStream(entry);
+	        }
+	        
+	        return new PluginDescriptionFile(stream);
         } catch (IOException ex) {
             throw new InvalidDescriptionException(ex);
         } catch (YAMLException ex) {


### PR DESCRIPTION
As far as I can understand the main problem when trying to use a folder instead of a JAR, when trying to run a plugin seems to be that the getPluginDescription(File file) is dead set for it to be a Jar, thus when trying to get "plugin.yml" things goes bad.

What I did was I added a check to see if the File possibly could be a folder and then handeled it and looked for a file in that folder named "plugin.yml". If not it behaves like when it didn't find it for a JAR.

I tested on my downloaded Plugins and so far so good seems to be working.

As this is my first contribution any feedback is appreciated. 
