### PR TITLE
Adds interface to modify amount and consumption of fuel in powered minecarts, and change minecart types

### DIFF
--- a/src/main/java/org/bukkit/entity/Minecart.java
+++ b/src/main/java/org/bukkit/entity/Minecart.java
@@ -81,4 +81,61 @@ public interface Minecart extends Vehicle {
      * @param derailed visible speed
      */
     public void setDerailedVelocityMod(Vector derailed);
+
+    /**
+     * Changes the type of this minecart, returning an object of the new type to continue managing.
+     * Do <b>not</b> continue to use the current object after this - use the returned one instead!
+     *
+     * @param type Type of minecart to change to
+     * @return The instance of the new type (Minecart, {@link StorageMinecart} or {@link PoweredMinecart})
+     *  that represents this minecart.
+     */
+    public Minecart setMinecartType(Type type);
+
+    /**
+     * Gets the type of this minecart.
+     *
+     * @return Type of the minecart.
+     */
+    public Type getMinecartType();
+
+    /**
+     * Represents the different types on minecart.
+     */
+    public enum Type {
+        MINECART(0),
+        STORAGE_MINECART(1),
+        POWERED_MINECART(2);
+        private final int id;
+        private static final Type[] types = values();
+
+        static {
+            for (Type type : values()) {
+                types[type.id] = type;
+            }
+        }
+
+        private Type(int id) {
+            this.id = id;
+        }
+
+        /**
+         * Get Minecraft's ID number representing this minecart type.
+         *
+         * @return
+         */
+        public int getId() {
+            return id;
+        }
+
+        /**
+         * Gets the minecart type with this ID.
+         *
+         * @param id ID to get type of.
+         * @return Minecart type with this ID.
+         */
+        public static Type getType(int id) {
+            return types[id];
+        }
+    }
 }

--- a/src/main/java/org/bukkit/entity/PoweredMinecart.java
+++ b/src/main/java/org/bukkit/entity/PoweredMinecart.java
@@ -1,6 +1,65 @@
 package org.bukkit.entity;
 
+import org.bukkit.util.Vector;
+
 /**
  * Represents a powered minecart.
  */
-public interface PoweredMinecart extends Minecart {}
+public interface PoweredMinecart extends Minecart {
+
+    /**
+     * Gets the amount of fuel in the minecart. The fuel is measured in ticks,
+     * and one piece of coal put into the minecart adds 3600 ticks.
+     *
+     * @return Number of ticks for which the minecart will continue moving under power.
+     */
+    public int getFuel();
+
+    /**
+     * Sets the amount of fuel in the minecart. The fuel is measured in ticks,
+     * and one piece of coal put into the minecart adds 3600 ticks.
+     * If you want to add fuel to a static powered minecart, {@link #setPushMod(Vector) setPushMod() } 
+     * will have to be used aswell.
+     *
+     * @param fuel Number of ticks for which the minecart will continue moving under power.
+     */
+    public void setFuel(int fuel);
+
+    /**
+     * Get whether this minecart consumes fuel while running.
+     * Should return true unless a plugin has changed it.
+     *
+     * @return true if the minecart consumes fuel.
+     */
+    public boolean consumesFuel();
+
+    /**
+     * Get whether this minecart consumes fuel while running.
+     * Should return true unless a plugin has changed it.
+     *
+     * @return true if the minecart consumes fuel.
+     */
+    public void setConsumesFuel(boolean consumes);
+
+    /**
+     * Gets the push modifier for the minecart. The push modifier is the effect the
+     * "engine" has on the minecart velocity in 2D space, and the vector Y value will always be 0.
+     * The minecart will move autonomously as long as the push modifier x or z is greater than 0 and
+     * fuel is greater than 0. When coal is added to the minecart, the push modifier is set to
+     * the difference in x and y between the location of the player and the minecart.
+     *
+     * @return Vector representation of the push modifier, Y value will always be 0.
+     */
+    public Vector getPushMod();
+
+    /**
+     * Sets the push modifier for the minecart.  The push modifier is the effect the
+     * "engine" has on the minecart velocity in 2D space, and the vector Y value will be ignored.
+     * The minecart will move autonomously as long as the push modifier x or z is greater than 0 and
+     * fuel is greater than 0. When coal is added to the minecart, the push modifier is set to
+     * the difference in x and y between the location of the player and the minecart.
+     *
+     * @param push Vector to set the push modifier to, Y value will be ignored.
+     */
+    public void setPushMod(Vector push);
+}


### PR DESCRIPTION
Relevant ticket (not created by me) [here](https://bukkit.atlassian.net/browse/BUKKIT-1492).

Adds methods to get and set fuel contents (in ticks), change the push modifier (to start/stop the minecart moving) and disable/enable fuel consumption entirely for the minecart. 

Also adds ability to easily change the type of a minecart between standard, storage and powered; and new event MinecartTypeChangeEvent to watch such changes.
The corresponding CraftBukkit pull request is [here](https://github.com/Bukkit/CraftBukkit/pull/753).
