### PR TITLE
two new APIs: affect spawning and entity-entity collision

### DIFF
--- a/src/main/java/org/bukkit/entity/Entity.java
+++ b/src/main/java/org/bukkit/entity/Entity.java
@@ -257,4 +257,16 @@ public interface Entity extends Metadatable {
      * @return The current vehicle.
      */
     public Entity getVehicle();
+
+    /**
+     * Set whether this entity can physically collide with other entities
+     * @param yes true to collide with other entities, false to not collide
+     */
+    public void setEntityCollision(boolean yes);
+
+    /**
+     * Get whether this entity can physically collide with other entities
+     * @return true if this entity can collide with others, false if it can't
+     */
+    public boolean getEntityCollision();
 }

--- a/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -146,4 +146,17 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, Permissible, Inv
      * @return Whether they are blocking.
      */
     public boolean isBlocking();
+
+    /**
+     * Setting this to false prevents players from activating mob spawners and
+     * allows mobs to randomly spawn and despawn near them (which normally can't happen).
+     * @param yes true to prevent this player from affecting mob spawning
+     */
+    public void setAffectsSpawning(boolean yes);
+
+    /**
+     * @return whether this player can activate mob spawners and prevent
+     *         random spawning and despawning near them.
+     */
+    public boolean getAffectsSpawning();
 }

--- a/src/test/java/org/bukkit/plugin/messaging/TestPlayer.java
+++ b/src/test/java/org/bukkit/plugin/messaging/TestPlayer.java
@@ -341,6 +341,14 @@ public class TestPlayer implements Player {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
+    public void setEntityCollision(boolean yes) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    public boolean getEntityCollision() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
     public int getRemainingAir() {
         throw new UnsupportedOperationException("Not supported yet.");
     }

--- a/src/test/java/org/bukkit/plugin/messaging/TestPlayer.java
+++ b/src/test/java/org/bukkit/plugin/messaging/TestPlayer.java
@@ -764,4 +764,12 @@ public class TestPlayer implements Player {
     public boolean isBlocking() {
         throw new UnsupportedOperationException("Not supported yet.");
     }
+
+    public void setAffectsSpawning(boolean yes) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    public boolean getAffectsSpawning() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 }


### PR DESCRIPTION
I added these two APIs to support better vanish plugins.

The entity-entity collision API provides overrides for the Entity.canBePushed() and Entity.canBeCollidedWith() predicates (MCP names). A player that returns false from these methods will not be able to push other players or mobs, or block projectiles, though it will look a bit glitchy from their perspective due to client-side logic.

The spawn-affecting API adds a flag to players to indicate whether they should be ignored by mob spawning algorithms. Normally, mobs don't spawn within 24m or despawn within 32m of a player. Players also activate spawners within 16m and affect the mob caps. Using this API, individual players can be exempted from all that.

CraftBukkit implementation PR:
https://github.com/Bukkit/CraftBukkit/pull/754
