### PR TITLE
Added .getExactPermission() method in PermissionAttachmentInfo to get original cased permissions

### DIFF
--- a/src/main/java/org/bukkit/permissions/PermissibleBase.java
+++ b/src/main/java/org/bukkit/permissions/PermissibleBase.java
@@ -164,7 +164,7 @@ public class PermissibleBase implements Permissible {
         }
 
         for (PermissionAttachment attachment : attachments) {
-            calculateChildPermissions(attachment.getPermissions(), false, attachment);
+            calculateChildPermissions(attachment.getExactPermissions(), false, attachment);
         }
     }
 
@@ -187,8 +187,6 @@ public class PermissibleBase implements Permissible {
         for (String name : keys) {
             Permission perm = Bukkit.getServer().getPluginManager().getPermission(name);
             boolean value = children.get(name) ^ invert;
-            // Removed "String lname = name.toLowerCase();",
-            // does not need extra variable
 
             // This adds the name as lower case like in the original code yet
             // able to store the permission with its original case in

--- a/src/main/java/org/bukkit/permissions/PermissibleBase.java
+++ b/src/main/java/org/bukkit/permissions/PermissibleBase.java
@@ -151,8 +151,14 @@ public class PermissibleBase implements Permissible {
         Bukkit.getServer().getPluginManager().subscribeToDefaultPerms(isOp(), parent);
 
         for (Permission perm : defaults) {
-            String name = perm.getName().toLowerCase();
-            permissions.put(name, new PermissionAttachmentInfo(parent, name, null, true));
+        	// Since the lower case is only used at one place,
+        	// the variable should be with its original case
+            String name = perm.getName();
+
+            // This adds the name as lower case like in the original code yet
+            // able to store the permission with its original case in
+            // the PermissionAttachmentInfo
+            permissions.put(name.toLowerCase(), new PermissionAttachmentInfo(parent, name, null, true));
             Bukkit.getServer().getPluginManager().subscribeToPermission(name, parent);
             calculateChildPermissions(perm.getChildren(), false, null);
         }
@@ -181,9 +187,13 @@ public class PermissibleBase implements Permissible {
         for (String name : keys) {
             Permission perm = Bukkit.getServer().getPluginManager().getPermission(name);
             boolean value = children.get(name) ^ invert;
-            String lname = name.toLowerCase();
+            // Removed "String lname = name.toLowerCase();",
+            // does not need extra variable
 
-            permissions.put(lname, new PermissionAttachmentInfo(parent, lname, attachment, value));
+            // This adds the name as lower case like in the original code yet
+            // able to store the permission with its original case in
+            // the PermissionAttachmentInfo
+            permissions.put(name.toLowerCase(), new PermissionAttachmentInfo(parent, name, attachment, value));
             Bukkit.getServer().getPluginManager().subscribeToPermission(name, parent);
 
             if (perm != null) {

--- a/src/main/java/org/bukkit/permissions/PermissionAttachment.java
+++ b/src/main/java/org/bukkit/permissions/PermissionAttachment.java
@@ -78,7 +78,10 @@ public class PermissionAttachment {
      * @param value New value of the permission
      */
     public void setPermission(String name, boolean value) {
-        permissions.put(name.toLowerCase(), value);
+    	// Original name without lower case so that
+    	// when the PermissionAttachmentInfos are
+    	// created, they have the original case
+        permissions.put(name, value);
         permissible.recalculatePermissions();
     }
 
@@ -90,7 +93,7 @@ public class PermissionAttachment {
      */
     public void setPermission(Permission perm, boolean value) {
         setPermission(perm.getName(), value);
-        permissible.recalculatePermissions();
+        // Removed "permissible.recalculatePermissions();", already done in setPermission(name, value)
     }
 
     /**
@@ -101,7 +104,10 @@ public class PermissionAttachment {
      * @param name Name of the permission to remove
      */
     public void unsetPermission(String name) {
-        permissions.remove(name.toLowerCase());
+    	// Original name without lower case so that
+    	// when the PermissionAttachmentInfos are
+    	// created, they have the original case
+        permissions.remove(name);
         permissible.recalculatePermissions();
     }
 
@@ -114,7 +120,7 @@ public class PermissionAttachment {
      */
     public void unsetPermission(Permission perm) {
         unsetPermission(perm.getName());
-        permissible.recalculatePermissions();
+        // Removed "permissible.recalculatePermissions();", already done in unsetPermission(name, value)
     }
 
     /**

--- a/src/main/java/org/bukkit/permissions/PermissionAttachment.java
+++ b/src/main/java/org/bukkit/permissions/PermissionAttachment.java
@@ -9,6 +9,7 @@ import org.bukkit.plugin.Plugin;
  */
 public class PermissionAttachment {
     private PermissionRemovedExecutor removed;
+    private final Map<String, Boolean> exactPermissions = new LinkedHashMap<String, Boolean>();
     private final Map<String, Boolean> permissions = new LinkedHashMap<String, Boolean>();
     private final Permissible permissible;
     private final Plugin plugin;
@@ -59,6 +60,17 @@ public class PermissionAttachment {
     public Permissible getPermissible() {
         return permissible;
     }
+    
+    /**
+     * Gets a copy of all set exact permissions and values contained within this attachment
+     * <p />
+     * This map may be modified but will not affect the attachment, as it is a copy
+     * 
+     * @return Copy of all permissions and values expressed by the attachment
+     */
+    public Map<String, Boolean> getExactPermissions() {
+    	return new LinkedHashMap<String, Boolean>(exactPermissions);
+    }
 
     /**
      * Gets a copy of all set permissions and values contained within this attachment.
@@ -78,10 +90,8 @@ public class PermissionAttachment {
      * @param value New value of the permission
      */
     public void setPermission(String name, boolean value) {
-    	// Original name without lower case so that
-    	// when the PermissionAttachmentInfos are
-    	// created, they have the original case
-        permissions.put(name, value);
+        permissions.put(name.toLowerCase(), value);
+        exactPermissions.put(name, value);
         permissible.recalculatePermissions();
     }
 
@@ -93,7 +103,6 @@ public class PermissionAttachment {
      */
     public void setPermission(Permission perm, boolean value) {
         setPermission(perm.getName(), value);
-        // Removed "permissible.recalculatePermissions();", already done in setPermission(name, value)
     }
 
     /**
@@ -104,10 +113,8 @@ public class PermissionAttachment {
      * @param name Name of the permission to remove
      */
     public void unsetPermission(String name) {
-    	// Original name without lower case so that
-    	// when the PermissionAttachmentInfos are
-    	// created, they have the original case
-        permissions.remove(name);
+        permissions.remove(name.toLowerCase());
+        exactPermissions.remove(name);
         permissible.recalculatePermissions();
     }
 
@@ -120,7 +127,6 @@ public class PermissionAttachment {
      */
     public void unsetPermission(Permission perm) {
         unsetPermission(perm.getName());
-        // Removed "permissible.recalculatePermissions();", already done in unsetPermission(name, value)
     }
 
     /**

--- a/src/main/java/org/bukkit/permissions/PermissionAttachmentInfo.java
+++ b/src/main/java/org/bukkit/permissions/PermissionAttachmentInfo.java
@@ -23,6 +23,16 @@ public class PermissionAttachmentInfo {
     }
 
     /**
+     * Gets the exact permission being set
+     * 
+     * @return
+     */
+    public String getExactPermission() {
+    	// This will return the permission in its original case
+    	return permission;
+    }
+
+    /**
      * Gets the permissible this is attached to
      *
      * @return Permissible this permission is for
@@ -37,7 +47,8 @@ public class PermissionAttachmentInfo {
      * @return Name of the permission
      */
     public String getPermission() {
-        return permission;
+    	// Lower cased so it works like the old code
+        return permission.toLowerCase();
     }
 
     /**


### PR DESCRIPTION
...iginal cased permissions

This allows developers to get original cased permissions (as in exactly how users typed them in permissions plugin's configs / exactly how developers set them in PermissionAttachments) and will not break Bukkit's permission system nor will it break plugins. Very useful if a plugin were to parse permissions for some info unknown at start.

The TestPlugin that I used to test and its source can be found [here](http://www.nodinchan.com/TestPlugin.jar) and [here](http://www.nodinchan.com/src.rar) respectively.
