### PR TITLE
Deprecated spawnCreature and added spawnEntity

### DIFF
--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -319,6 +319,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
      * @param loc The location to spawn the creature
      * @param type The creature to spawn
      * @return Resulting LivingEntity of this method, or null if it was unsuccessful
+     * @deprecated Has issues spawning non LivingEntities. Use {@link #spawnEntity(Location, EntityType) spawnEntity} instead.
      */
     @Deprecated
     public LivingEntity spawnCreature(Location loc, EntityType type);

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -305,12 +305,22 @@ public interface World extends PluginMessageRecipient, Metadatable {
     public boolean generateTree(Location loc, TreeType type, BlockChangeDelegate delegate);
 
     /**
+     * Creates a entity at the given {@link Location}
+     *
+     * @param loc The location to spawn the entity
+     * @param type The entity to spawn
+     * @return Resulting Entity of this method, or null if it was unsuccessful
+     */
+    public Entity spawnEntity(Location loc, EntityType type);
+
+    /**
      * Creates a creature at the given {@link Location}
      *
      * @param loc The location to spawn the creature
      * @param type The creature to spawn
      * @return Resulting LivingEntity of this method, or null if it was unsuccessful
      */
+    @Deprecated
     public LivingEntity spawnCreature(Location loc, EntityType type);
 
     /**


### PR DESCRIPTION
As spawnCreature was designed to spawn a CreatureType it has some issues by spawning a EntityType (see: https://bukkit.atlassian.net/browse/BUKKIT-1168 ). So I think the best way is to go away from spawnCreature and replace it with spawnEntity. This is the Bukkit part, for the CraftBukkit part see https://github.com/Bukkit/CraftBukkit/pull/758
