### PR TITLE
Added World.getDimensionSpawn()

### DIFF
--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -398,6 +398,13 @@ public interface World extends PluginMessageRecipient, Metadatable {
      * @return Unique ID of this world.
      */
     public UUID getUID();
+    
+    /**
+     * Gets the {@link Location} of the spawn of this dimension, used to determine the spawn location for the End
+     *
+     * @return The coordinates of the spawn of this dimension, or null if the environment is not {@link Environment#THE_END}
+     */
+    public Location getDimensionSpawn();
 
     /**
      * Gets the default spawn {@link Location} of this world


### PR DESCRIPTION
This allows a plugin to call `getDimensionSpawn()` on a world so that if the dimension's spawn is ever changed the plugin does not need to be updated.

Ticket: https://bukkit.atlassian.net/browse/BUKKIT-1602
Related CraftBukkit Pull Request: https://github.com/Bukkit/CraftBukkit/pull/760
