### PR TITLE
[B] Add an enum for Nether Wart growth stages. Adds BUKKIT-1599

### DIFF
--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -29,6 +29,7 @@ import org.bukkit.material.LongGrass;
 import org.bukkit.material.MaterialData;
 import org.bukkit.material.MonsterEggs;
 import org.bukkit.material.Mushroom;
+import org.bukkit.material.NetherWarts;
 import org.bukkit.material.PistonBaseMaterial;
 import org.bukkit.material.PistonExtensionMaterial;
 import org.bukkit.material.PoweredRail;
@@ -176,7 +177,7 @@ public enum Material {
     NETHER_BRICK(112),
     NETHER_FENCE(113),
     NETHER_BRICK_STAIRS(114, Stairs.class),
-    NETHER_WARTS(115, MaterialData.class),
+    NETHER_WARTS(115, NetherWarts.class),
     ENCHANTMENT_TABLE(116),
     BREWING_STAND(117, MaterialData.class),
     CAULDRON(118, Cauldron.class),

--- a/src/main/java/org/bukkit/NetherWartsState.java
+++ b/src/main/java/org/bukkit/NetherWartsState.java
@@ -1,0 +1,20 @@
+package org.bukkit;
+
+public enum NetherWartsState {
+    /**
+     * State when first seeded
+     */
+    SEEDED,
+    /**
+     * First growth stage
+     */
+    STAGE_ONE,
+    /**
+     * Second growth stage
+     */
+    STAGE_TWO,
+    /**
+     * Ready to harvest
+     */
+    RIPE;
+}

--- a/src/main/java/org/bukkit/material/NetherWarts.java
+++ b/src/main/java/org/bukkit/material/NetherWarts.java
@@ -1,0 +1,84 @@
+package org.bukkit.material;
+
+import org.bukkit.Material;
+import org.bukkit.NetherWartsState;
+
+/**
+ * Represents nether wart
+ */
+public class NetherWarts extends MaterialData {
+    public NetherWarts() {
+        super(Material.NETHER_WARTS);
+    }
+
+    public NetherWarts(NetherWartsState state) {
+        this();
+        setState(state);
+    }
+
+    public NetherWarts(final int type) {
+        super(type);
+    }
+
+    public NetherWarts(final Material type) {
+        super (type);
+    }
+
+    public NetherWarts(final int type, final byte data) {
+        super(type, data);
+    }
+
+    public NetherWarts(final Material type, final byte data) {
+        super(type, data);
+    }
+
+    /**
+     * Gets the current growth state of this nether wart
+     *
+     * @return NetherWartsState of this nether wart
+     */
+    public NetherWartsState getState() {
+        switch (getData()) {
+            case 0:
+                return NetherWartsState.SEEDED;
+            case 1:
+                return NetherWartsState.STAGE_ONE;
+            case 2:
+                return NetherWartsState.STAGE_TWO;
+            default:
+                return NetherWartsState.RIPE;
+        }
+    }
+
+    /**
+     * Sets the growth state of this nether wart
+     *
+     * @param state New growth state of this nether wart
+     */
+    public void setState(NetherWartsState state) {
+        switch (state) {
+            case SEEDED:
+                setData((byte) 0x0);
+                return;
+            case STAGE_ONE:
+                setData((byte) 0x1);
+                return;
+            case STAGE_TWO:
+                setData((byte) 0x2);
+                return;
+            case RIPE:
+                setData((byte) 0x3);
+                return;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return getState() + " " + super.toString();
+    }
+
+    @Override
+    public NetherWarts clone() {
+        return (NetherWarts) super.clone();
+    }
+}


### PR DESCRIPTION
Currently, there is an enum or other class to handle the growth state for all other plants - Crops, Cocoa, etc. There isn't one, however, for Nether Wart, which means that you have to use raw byte data to handle these instead of a formatted name.

Associated JIRA Ticket - https://bukkit.atlassian.net/browse/BUKKIT-1599
