### PR TITLE
Fixed the spelling of Ocelot. (Instead of Ozelot)

### DIFF
--- a/src/main/java/org/bukkit/entity/EntityType.java
+++ b/src/main/java/org/bukkit/entity/EntityType.java
@@ -44,7 +44,7 @@ public enum EntityType {
     WOLF("Wolf", Wolf.class, 95),
     MUSHROOM_COW("MushroomCow", MushroomCow.class, 96),
     SNOWMAN("SnowMan", Snowman.class, 97),
-    OCELOT("Ozelot", Ocelot.class, 98),
+    OCELOT("Ocelot", Ocelot.class, 98),
     IRON_GOLEM("VillagerGolem", IronGolem.class, 99),
     VILLAGER("Villager", Villager.class, 120),
     ENDER_CRYSTAL("EnderCrystal", EnderCrystal.class, 200),


### PR DESCRIPTION
There was a small spelling mistake that made a lot of people confused on some Servers.
