### PR TITLE
Adds ability to set the number of online players sent in ServerListPingEvent

### DIFF
--- a/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
+++ b/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
@@ -11,7 +11,7 @@ public class ServerListPingEvent extends ServerEvent {
     private static final HandlerList handlers = new HandlerList();
     private final InetAddress address;
     private String motd;
-    private final int numPlayers;
+    private int numPlayers;
     private int maxPlayers;
 
     public ServerListPingEvent(final InetAddress address, final String motd, final int numPlayers, final int maxPlayers) {
@@ -58,9 +58,18 @@ public class ServerListPingEvent extends ServerEvent {
     }
 
     /**
+     * Set the number of players sent.
+     *
+     * @param numPlayers the number of players to be sent
+     */
+    public void setNumPlayers(int numPlayers) {
+        this.numPlayers = numPlayers;
+    }
+
+    /**
      * Get the maximum number of players sent.
      *
-     * @return the the maximum number of player
+     * @return the the maximum number of players
      */
     public int getMaxPlayers() {
         return maxPlayers;
@@ -69,7 +78,7 @@ public class ServerListPingEvent extends ServerEvent {
     /**
      * Set the maximum number of players sent.
      *
-     * @param maxPlayers the maximum number of player
+     * @param maxPlayers the maximum number of players
      */
     public void setMaxPlayers(int maxPlayers) {
         this.maxPlayers = maxPlayers;


### PR DESCRIPTION
[JIRA ticket (not mine)](https://bukkit.atlassian.net/browse/BUKKIT-1646)

[Companion CraftBukkit pull request](https://github.com/Bukkit/CraftBukkit/pull/766)

Also a couple of grammatical fixes in the javadocs for getMaxPlayers and setMaxPlayers because why not.
