### PR TITLE
PluginLogger listeners, to enable access to plugin output.

### DIFF
--- a/src/main/java/org/bukkit/plugin/PluginLoggerListener.java
+++ b/src/main/java/org/bukkit/plugin/PluginLoggerListener.java
@@ -1,0 +1,7 @@
+package org.bukkit.plugin;
+
+import java.util.logging.LogRecord;
+
+public abstract class PluginLoggerListener {
+    public abstract void onLogged(Plugin plugin, LogRecord record);
+}


### PR DESCRIPTION
This commit allows plugins to register listeners that capture output of PluginLoggers.

Local: this registers a listener to one specific plugin.
Global: this registers a listener to all plugins.
