### PR TITLE
Multiple JavaDoc "fixes" as per leaky requests

### DIFF
--- a/src/main/java/org/bukkit/configuration/ConfigurationSection.java
+++ b/src/main/java/org/bukkit/configuration/ConfigurationSection.java
@@ -221,7 +221,7 @@ public interface ConfigurationSection {
      * <p>
      * If the int does not exist but a default value has been specified, this
      * will return the default value. If the int does not exist and no default
-     * value was specified, this will return null.
+     * value was specified, this will return 0.
      *
      * @param path Path of the int to get.
      * @return Requested int.

--- a/src/main/java/org/bukkit/generator/ChunkGenerator.java
+++ b/src/main/java/org/bukkit/generator/ChunkGenerator.java
@@ -87,7 +87,7 @@ public abstract class ChunkGenerator {
      * Setting a block at X, Y, Z within the chunk can be done with the following mapping function:
      * <pre>
      *    void setBlock(short[][] result, int x, int y, int z, short blkid) {
-     *        if (result[y >> 4) == null) {
+     *        if (result[y >> 4] == null) {
      *            result[y >> 4] = new short[4096];
      *        }
      *        result[y >> 4][((y & 0xF) << 8) | (z << 4) | x] = blkid;
@@ -96,7 +96,7 @@ public abstract class ChunkGenerator {
      * while reading a block ID can be done with the following mapping function:
      * <pre>
      *    short getBlock(short[][] result, int x, int y, int z) {
-     *        if (result[y >> 4) == null) {
+     *        if (result[y >> 4] == null) {
      *            return (short)0;
      *        }
      *        return result[y >> 4][((y & 0xF) << 8) | (z << 4) | x];

--- a/src/main/java/org/bukkit/inventory/Inventory.java
+++ b/src/main/java/org/bukkit/inventory/Inventory.java
@@ -205,7 +205,7 @@ public interface Inventory extends Iterable<ItemStack> {
     /**
      * Find the first empty Slot.
      *
-     * @return The first empty Slot found.
+     * @return The first empty Slot found, or -1 if no empty slots.
      */
     public int firstEmpty();
 


### PR DESCRIPTION
No CraftBukkit pull.

Leaky requests:
https://bukkit.atlassian.net/browse/BUKKIT-1653
https://bukkit.atlassian.net/browse/BUKKIT-1383
https://bukkit.atlassian.net/browse/BUKKIT-1644

The "fixes" here are as per user request, and not really considered otherwise. 

Yes I am aware there are 3 commits instead of 1. If requested I can fix that, but it's more or less to point out that they exist.
