### PR TITLE
All block face references re-oriented 90 degrees to the left, where they should be. Fixes BUKKIT-1567

### DIFF
--- a/src/main/java/org/bukkit/block/BlockFace.java
+++ b/src/main/java/org/bukkit/block/BlockFace.java
@@ -4,24 +4,24 @@ package org.bukkit.block;
  * Represents the face of a block
  */
 public enum BlockFace {
-    NORTH(-1, 0, 0),
-    EAST(0, 0, -1),
-    SOUTH(1, 0, 0),
-    WEST(0, 0, 1),
+    WEST(-1, 0, 0),
+    NORTH(0, 0, 1),
+    EAST(1, 0, 0),
+    SOUTH(0, 0, -1),
     UP(0, 1, 0),
     DOWN(0, -1, 0),
-    NORTH_EAST(NORTH, EAST),
-    NORTH_WEST(NORTH, WEST),
-    SOUTH_EAST(SOUTH, EAST),
-    SOUTH_WEST(SOUTH, WEST),
+    NORTH_WEST(WEST, NORTH),
+    SOUTH_WEST(WEST, SOUTH),
+    NORTH_EAST(EAST, NORTH),
+    SOUTH_EAST(EAST, SOUTH),
+    SOUTH_SOUTH_WEST(SOUTH, SOUTH_WEST),
+    WEST_SOUTH_WEST(WEST, SOUTH_WEST),
     WEST_NORTH_WEST(WEST, NORTH_WEST),
     NORTH_NORTH_WEST(NORTH, NORTH_WEST),
     NORTH_NORTH_EAST(NORTH, NORTH_EAST),
     EAST_NORTH_EAST(EAST, NORTH_EAST),
     EAST_SOUTH_EAST(EAST, SOUTH_EAST),
     SOUTH_SOUTH_EAST(SOUTH, SOUTH_EAST),
-    SOUTH_SOUTH_WEST(SOUTH, SOUTH_WEST),
-    WEST_SOUTH_WEST(WEST, SOUTH_WEST),
     SELF(0, 0, 0);
 
     private final int modX;
@@ -69,17 +69,17 @@ public enum BlockFace {
 
     public BlockFace getOppositeFace() {
         switch (this) {
+        case WEST:
+            return BlockFace.EAST;
+
+        case EAST:
+            return BlockFace.WEST;
+
         case NORTH:
             return BlockFace.SOUTH;
 
         case SOUTH:
             return BlockFace.NORTH;
-
-        case EAST:
-            return BlockFace.WEST;
-
-        case WEST:
-            return BlockFace.EAST;
 
         case UP:
             return BlockFace.DOWN;
@@ -87,17 +87,23 @@ public enum BlockFace {
         case DOWN:
             return BlockFace.UP;
 
-        case NORTH_EAST:
-            return BlockFace.SOUTH_WEST;
-
         case NORTH_WEST:
             return BlockFace.SOUTH_EAST;
+
+        case SOUTH_WEST:
+            return BlockFace.NORTH_EAST;
+
+        case NORTH_EAST:
+            return BlockFace.SOUTH_WEST;
 
         case SOUTH_EAST:
             return BlockFace.NORTH_WEST;
 
-        case SOUTH_WEST:
-            return BlockFace.NORTH_EAST;
+        case SOUTH_SOUTH_WEST:
+            return BlockFace.NORTH_NORTH_EAST;
+
+        case WEST_SOUTH_WEST:
+            return BlockFace.EAST_NORTH_EAST;
 
         case WEST_NORTH_WEST:
             return BlockFace.EAST_SOUTH_EAST;
@@ -116,12 +122,6 @@ public enum BlockFace {
 
         case SOUTH_SOUTH_EAST:
             return BlockFace.NORTH_NORTH_WEST;
-
-        case SOUTH_SOUTH_WEST:
-            return BlockFace.NORTH_NORTH_EAST;
-
-        case WEST_SOUTH_WEST:
-            return BlockFace.EAST_NORTH_EAST;
 
         case SELF:
             return BlockFace.SELF;

--- a/src/main/java/org/bukkit/material/Bed.java
+++ b/src/main/java/org/bukkit/material/Bed.java
@@ -67,19 +67,19 @@ public class Bed extends MaterialData implements Directional {
         byte data;
 
         switch (face) {
-        case WEST:
+        case SOUTH:
             data = 0x0;
             break;
 
-        case NORTH:
+        case WEST:
             data = 0x1;
             break;
 
-        case EAST:
+        case NORTH:
             data = 0x2;
             break;
 
-        case SOUTH:
+        case EAST:
         default:
             data = 0x3;
         }
@@ -101,17 +101,17 @@ public class Bed extends MaterialData implements Directional {
 
         switch (data) {
         case 0x0:
-            return BlockFace.WEST;
+            return BlockFace.SOUTH;
 
         case 0x1:
-            return BlockFace.NORTH;
+            return BlockFace.WEST;
 
         case 0x2:
-            return BlockFace.EAST;
+            return BlockFace.NORTH;
 
         case 0x3:
         default:
-            return BlockFace.SOUTH;
+            return BlockFace.EAST;
         }
     }
 

--- a/src/main/java/org/bukkit/material/Button.java
+++ b/src/main/java/org/bukkit/material/Button.java
@@ -57,16 +57,16 @@ public class Button extends SimpleAttachableMaterialData implements Redstone {
 
         switch (data) {
         case 0x1:
-            return BlockFace.NORTH;
+            return BlockFace.WEST;
 
         case 0x2:
-            return BlockFace.SOUTH;
-
-        case 0x3:
             return BlockFace.EAST;
 
+        case 0x3:
+            return BlockFace.NORTH;
+
         case 0x4:
-            return BlockFace.WEST;
+            return BlockFace.SOUTH;
         }
 
         return null;
@@ -79,19 +79,19 @@ public class Button extends SimpleAttachableMaterialData implements Redstone {
         byte data = (byte) (getData() & 0x8);
 
         switch (face) {
-        case SOUTH:
+        case EAST:
             data |= 0x1;
             break;
 
-        case NORTH:
+        case WEST:
             data |= 0x2;
             break;
 
-        case WEST:
+        case SOUTH:
             data |= 0x3;
             break;
 
-        case EAST:
+        case NORTH:
             data |= 0x4;
             break;
         }

--- a/src/main/java/org/bukkit/material/Diode.java
+++ b/src/main/java/org/bukkit/material/Diode.java
@@ -56,19 +56,19 @@ public class Diode extends MaterialData implements Directional {
         byte data;
 
         switch (face) {
-        case SOUTH:
+        case EAST:
             data = 0x1;
             break;
 
-        case WEST:
+        case SOUTH:
             data = 0x2;
             break;
 
-        case NORTH:
+        case WEST:
             data = 0x3;
             break;
 
-        case EAST:
+        case NORTH:
         default:
             data = 0x0;
         }
@@ -83,16 +83,16 @@ public class Diode extends MaterialData implements Directional {
         switch (data) {
         case 0x0:
         default:
-            return BlockFace.EAST;
+            return BlockFace.NORTH;
 
         case 0x1:
-            return BlockFace.SOUTH;
+            return BlockFace.EAST;
 
         case 0x2:
-            return BlockFace.WEST;
+            return BlockFace.SOUTH;
 
         case 0x3:
-            return BlockFace.NORTH;
+            return BlockFace.WEST;
         }
     }
 

--- a/src/main/java/org/bukkit/material/Door.java
+++ b/src/main/java/org/bukkit/material/Door.java
@@ -58,14 +58,14 @@ public class Door extends MaterialData implements Directional, Openable {
         byte d = getData();
 
         if ((d & 0x3) == 0x3) {
-            return BlockFace.NORTH_WEST;
-        } else if ((d & 0x1) == 0x1) {
-            return BlockFace.SOUTH_EAST;
-        } else if ((d & 0x2) == 0x2) {
             return BlockFace.SOUTH_WEST;
+        } else if ((d & 0x1) == 0x1) {
+            return BlockFace.NORTH_EAST;
+        } else if ((d & 0x2) == 0x2) {
+            return BlockFace.SOUTH_EAST;
         }
 
-        return BlockFace.NORTH_EAST;
+        return BlockFace.NORTH_WEST;
     }
 
     @Override
@@ -81,15 +81,15 @@ public class Door extends MaterialData implements Directional, Openable {
     public void setFacingDirection(BlockFace face) {
         byte data = (byte) (getData() & 0x12);
         switch (face) {
-        case EAST:
+        case NORTH:
             data |= 0x1;
             break;
 
-        case SOUTH:
+        case EAST:
             data |= 0x2;
             break;
 
-        case WEST:
+        case SOUTH:
             data |= 0x3;
             break;
         }
@@ -105,16 +105,16 @@ public class Door extends MaterialData implements Directional, Openable {
         byte data = (byte) (getData() & 0x3);
         switch (data) {
         case 0:
-            return BlockFace.NORTH;
+            return BlockFace.WEST;
 
         case 1:
-            return BlockFace.EAST;
+            return BlockFace.NORTH;
 
         case 2:
-            return BlockFace.SOUTH;
+            return BlockFace.EAST;
 
         case 3:
-            return BlockFace.WEST;
+            return BlockFace.SOUTH;
         }
         return null; // shouldn't happen
     }

--- a/src/main/java/org/bukkit/material/ExtendedRails.java
+++ b/src/main/java/org/bukkit/material/ExtendedRails.java
@@ -37,7 +37,7 @@ public class ExtendedRails extends Rails {
     public void setDirection(BlockFace face, boolean isOnSlope) {
         boolean extraBitSet = (getData() & 0x8) == 0x8;
 
-        if (face != BlockFace.NORTH && face != BlockFace.SOUTH && face != BlockFace.EAST && face != BlockFace.WEST) {
+        if (face != BlockFace.WEST && face != BlockFace.EAST && face != BlockFace.NORTH && face != BlockFace.SOUTH) {
             throw new IllegalArgumentException("Detector rails and powered rails cannot be set on a curve!");
         }
 

--- a/src/main/java/org/bukkit/material/FurnaceAndDispenser.java
+++ b/src/main/java/org/bukkit/material/FurnaceAndDispenser.java
@@ -27,19 +27,19 @@ public class FurnaceAndDispenser extends MaterialData implements Directional {
         byte data;
 
         switch (face) {
-        case EAST:
+        case NORTH:
             data = 0x2;
             break;
 
-        case WEST:
+        case SOUTH:
             data = 0x3;
             break;
 
-        case NORTH:
+        case WEST:
             data = 0x4;
             break;
 
-        case SOUTH:
+        case EAST:
         default:
             data = 0x5;
         }
@@ -52,17 +52,17 @@ public class FurnaceAndDispenser extends MaterialData implements Directional {
 
         switch (data) {
         case 0x2:
-            return BlockFace.EAST;
+            return BlockFace.NORTH;
 
         case 0x3:
-            return BlockFace.WEST;
+            return BlockFace.SOUTH;
 
         case 0x4:
-            return BlockFace.NORTH;
+            return BlockFace.WEST;
 
         case 0x5:
         default:
-            return BlockFace.SOUTH;
+            return BlockFace.EAST;
         }
     }
 

--- a/src/main/java/org/bukkit/material/Gate.java
+++ b/src/main/java/org/bukkit/material/Gate.java
@@ -31,16 +31,16 @@ public class Gate extends MaterialData implements Directional, Openable {
 
         switch (face) {
             default:
-            case SOUTH:
+            case EAST:
                 data |= GATE_SOUTH;
                 break;
-            case WEST:
+            case SOUTH:
                 data |= GATE_WEST;
                 break;
-            case NORTH:
+            case WEST:
                 data |= GATE_NORTH;
                 break;
-            case EAST:
+            case NORTH:
                 data |= GATE_EAST;
                 break;
         }
@@ -51,16 +51,16 @@ public class Gate extends MaterialData implements Directional, Openable {
     public BlockFace getFacing() {
         switch (getData() & DIR_BIT) {
             case GATE_SOUTH:
-                return BlockFace.SOUTH;
-            case GATE_WEST:
-                return BlockFace.WEST;
-            case GATE_NORTH:
-                return BlockFace.NORTH;
-            case GATE_EAST:
                 return BlockFace.EAST;
+            case GATE_WEST:
+                return BlockFace.SOUTH;
+            case GATE_NORTH:
+                return BlockFace.WEST;
+            case GATE_EAST:
+                return BlockFace.NORTH;
         }
 
-        return BlockFace.SOUTH;
+        return BlockFace.EAST;
     }
 
     public boolean isOpen() {

--- a/src/main/java/org/bukkit/material/Ladder.java
+++ b/src/main/java/org/bukkit/material/Ladder.java
@@ -37,16 +37,16 @@ public class Ladder extends SimpleAttachableMaterialData {
 
         switch (data) {
         case 0x2:
-            return BlockFace.WEST;
-
-        case 0x3:
-            return BlockFace.EAST;
-
-        case 0x4:
             return BlockFace.SOUTH;
 
-        case 0x5:
+        case 0x3:
             return BlockFace.NORTH;
+
+        case 0x4:
+            return BlockFace.EAST;
+
+        case 0x5:
+            return BlockFace.WEST;
         }
 
         return null;
@@ -59,19 +59,19 @@ public class Ladder extends SimpleAttachableMaterialData {
         byte data = (byte) 0x0;
 
         switch (face) {
-        case WEST:
+        case SOUTH:
             data = 0x2;
             break;
 
-        case EAST:
+        case NORTH:
             data = 0x3;
             break;
 
-        case SOUTH:
+        case EAST:
             data = 0x4;
             break;
 
-        case NORTH:
+        case WEST:
             data = 0x5;
             break;
         }

--- a/src/main/java/org/bukkit/material/Lever.java
+++ b/src/main/java/org/bukkit/material/Lever.java
@@ -56,16 +56,16 @@ public class Lever extends SimpleAttachableMaterialData implements Redstone {
 
         switch (data) {
         case 0x1:
-            return BlockFace.NORTH;
+            return BlockFace.WEST;
 
         case 0x2:
-            return BlockFace.SOUTH;
-
-        case 0x3:
             return BlockFace.EAST;
 
+        case 0x3:
+            return BlockFace.NORTH;
+
         case 0x4:
-            return BlockFace.WEST;
+            return BlockFace.SOUTH;
 
         case 0x5:
         case 0x6:
@@ -83,31 +83,31 @@ public class Lever extends SimpleAttachableMaterialData implements Redstone {
 
         if (getAttachedFace() == BlockFace.DOWN) {
             switch (face) {
-            case WEST:
-            case EAST:
+            case SOUTH:
+            case NORTH:
                 data |= 0x5;
                 break;
 
-            case SOUTH:
-            case NORTH:
+            case EAST:
+            case WEST:
                 data |= 0x6;
                 break;
             }
         } else {
             switch (face) {
-            case SOUTH:
+            case EAST:
                 data |= 0x1;
                 break;
 
-            case NORTH:
+            case WEST:
                 data |= 0x2;
                 break;
 
-            case WEST:
+            case SOUTH:
                 data |= 0x3;
                 break;
 
-            case EAST:
+            case NORTH:
                 data |= 0x4;
                 break;
             }

--- a/src/main/java/org/bukkit/material/Mushroom.java
+++ b/src/main/java/org/bukkit/material/Mushroom.java
@@ -63,13 +63,13 @@ public class Mushroom extends MaterialData {
         }
 
         switch (face) {
-            case NORTH:
-                return data < NORTH_LIMIT;
-            case SOUTH:
-                return data > SOUTH_LIMIT;
-            case EAST:
-                return data % EAST_WEST_LIMIT == EAST_REMAINDER;
             case WEST:
+                return data < NORTH_LIMIT;
+            case EAST:
+                return data > SOUTH_LIMIT;
+            case NORTH:
+                return data % EAST_WEST_LIMIT == EAST_REMAINDER;
+            case SOUTH:
                 return data % EAST_WEST_LIMIT == WEST_REMAINDER;
             case UP:
                 return true;
@@ -96,23 +96,23 @@ public class Mushroom extends MaterialData {
         }
 
         switch (face) {
-            case NORTH:
+            case WEST:
                 if (painted) {
                     data -= NORTH_SOUTH_MOD;
                 } else {
                     data += NORTH_SOUTH_MOD;
-                }
-
-                break;
-            case SOUTH:
-                if (painted) {
-                    data += NORTH_SOUTH_MOD;
-                } else {
-                    data -= NORTH_SOUTH_MOD;
                 }
 
                 break;
             case EAST:
+                if (painted) {
+                    data += NORTH_SOUTH_MOD;
+                } else {
+                    data -= NORTH_SOUTH_MOD;
+                }
+
+                break;
+            case NORTH:
                 if (painted) {
                     data += EAST_WEST_MOD;
                 } else {
@@ -120,7 +120,7 @@ public class Mushroom extends MaterialData {
                 }
 
                 break;
-            case WEST:
+            case SOUTH:
                 if (painted) {
                     data -= EAST_WEST_MOD;
                 } else {
@@ -147,20 +147,20 @@ public class Mushroom extends MaterialData {
     public Set<BlockFace> getPaintedFaces() {
         EnumSet<BlockFace> faces = EnumSet.noneOf(BlockFace.class);
 
-        if (isFacePainted(BlockFace.NORTH)) {
-            faces.add(BlockFace.NORTH);
-        }
-
-        if (isFacePainted(BlockFace.EAST)) {
-            faces.add(BlockFace.EAST);
-        }
-
         if (isFacePainted(BlockFace.WEST)) {
             faces.add(BlockFace.WEST);
         }
 
+        if (isFacePainted(BlockFace.NORTH)) {
+            faces.add(BlockFace.NORTH);
+        }
+
         if (isFacePainted(BlockFace.SOUTH)) {
             faces.add(BlockFace.SOUTH);
+        }
+
+        if (isFacePainted(BlockFace.EAST)) {
+            faces.add(BlockFace.EAST);
         }
 
         if (isFacePainted(BlockFace.UP)) {

--- a/src/main/java/org/bukkit/material/PistonBaseMaterial.java
+++ b/src/main/java/org/bukkit/material/PistonBaseMaterial.java
@@ -30,16 +30,16 @@ public class PistonBaseMaterial extends MaterialData implements Directional, Red
         case UP:
             data |= 1;
             break;
-        case EAST:
+        case NORTH:
             data |= 2;
             break;
-        case WEST:
+        case SOUTH:
             data |= 3;
             break;
-        case NORTH:
+        case WEST:
             data |= 4;
             break;
-        case SOUTH:
+        case EAST:
             data |= 5;
             break;
         }
@@ -55,13 +55,13 @@ public class PistonBaseMaterial extends MaterialData implements Directional, Red
         case 1:
             return BlockFace.UP;
         case 2:
-            return BlockFace.EAST;
-        case 3:
-            return BlockFace.WEST;
-        case 4:
             return BlockFace.NORTH;
-        case 5:
+        case 3:
             return BlockFace.SOUTH;
+        case 4:
+            return BlockFace.WEST;
+        case 5:
+            return BlockFace.EAST;
         default:
             return BlockFace.SELF;
         }

--- a/src/main/java/org/bukkit/material/PistonExtensionMaterial.java
+++ b/src/main/java/org/bukkit/material/PistonExtensionMaterial.java
@@ -30,16 +30,16 @@ public class PistonExtensionMaterial extends MaterialData implements Attachable 
         case UP:
             data |= 1;
             break;
-        case EAST:
+        case NORTH:
             data |= 2;
             break;
-        case WEST:
+        case SOUTH:
             data |= 3;
             break;
-        case NORTH:
+        case WEST:
             data |= 4;
             break;
-        case SOUTH:
+        case EAST:
             data |= 5;
             break;
         }
@@ -55,13 +55,13 @@ public class PistonExtensionMaterial extends MaterialData implements Attachable 
         case 1:
             return BlockFace.UP;
         case 2:
-            return BlockFace.EAST;
-        case 3:
-            return BlockFace.WEST;
-        case 4:
             return BlockFace.NORTH;
-        case 5:
+        case 3:
             return BlockFace.SOUTH;
+        case 4:
+            return BlockFace.WEST;
+        case 5:
+            return BlockFace.EAST;
         default:
             return BlockFace.SELF;
         }

--- a/src/main/java/org/bukkit/material/Pumpkin.java
+++ b/src/main/java/org/bukkit/material/Pumpkin.java
@@ -46,19 +46,19 @@ public class Pumpkin extends MaterialData implements Directional {
         byte data;
 
         switch (face) {
-        case EAST:
+        case NORTH:
             data = 0x0;
             break;
 
-        case SOUTH:
+        case EAST:
             data = 0x1;
             break;
 
-        case WEST:
+        case SOUTH:
             data = 0x2;
             break;
 
-        case NORTH:
+        case WEST:
         default:
             data = 0x3;
         }
@@ -71,17 +71,17 @@ public class Pumpkin extends MaterialData implements Directional {
 
         switch (data) {
         case 0x0:
-            return BlockFace.EAST;
+            return BlockFace.NORTH;
 
         case 0x1:
-            return BlockFace.SOUTH;
+            return BlockFace.EAST;
 
         case 0x2:
-            return BlockFace.WEST;
+            return BlockFace.SOUTH;
 
         case 0x3:
         default:
-            return BlockFace.SOUTH;
+            return BlockFace.EAST;
         }
     }
 

--- a/src/main/java/org/bukkit/material/Rails.java
+++ b/src/main/java/org/bukkit/material/Rails.java
@@ -59,34 +59,34 @@ public class Rails extends MaterialData {
         switch (d) {
         case 0x0:
         default:
-            return BlockFace.WEST;
+            return BlockFace.SOUTH;
 
         case 0x1:
-            return BlockFace.SOUTH;
-
-        case 0x2:
-            return BlockFace.SOUTH;
-
-        case 0x3:
-            return BlockFace.NORTH;
-
-        case 0x4:
             return BlockFace.EAST;
 
-        case 0x5:
+        case 0x2:
+            return BlockFace.EAST;
+
+        case 0x3:
             return BlockFace.WEST;
 
+        case 0x4:
+            return BlockFace.NORTH;
+
+        case 0x5:
+            return BlockFace.SOUTH;
+
         case 0x6:
-            return BlockFace.NORTH_EAST;
+            return BlockFace.NORTH_WEST;
 
         case 0x7:
-            return BlockFace.SOUTH_EAST;
+            return BlockFace.NORTH_EAST;
 
         case 0x8:
-            return BlockFace.SOUTH_WEST;
+            return BlockFace.SOUTH_EAST;
 
         case 0x9:
-            return BlockFace.NORTH_WEST;
+            return BlockFace.SOUTH_WEST;
         }
     }
 
@@ -116,35 +116,35 @@ public class Rails extends MaterialData {
      */
     public void setDirection(BlockFace face, boolean isOnSlope) {
         switch (face) {
-        case SOUTH:
+        case EAST:
             setData((byte) (isOnSlope ? 0x2 : 0x1));
             break;
 
-        case NORTH:
+        case WEST:
             setData((byte) (isOnSlope ? 0x3 : 0x1));
             break;
 
-        case EAST:
+        case NORTH:
             setData((byte) (isOnSlope ? 0x4 : 0x0));
             break;
 
-        case WEST:
+        case SOUTH:
             setData((byte) (isOnSlope ? 0x5 : 0x0));
             break;
 
-        case NORTH_EAST:
+        case NORTH_WEST:
             setData((byte) 0x6);
             break;
 
-        case SOUTH_EAST:
+        case NORTH_EAST:
             setData((byte) 0x7);
             break;
 
-        case SOUTH_WEST:
+        case SOUTH_EAST:
             setData((byte) 0x8);
             break;
 
-        case NORTH_WEST:
+        case SOUTH_WEST:
             setData((byte) 0x9);
             break;
         }

--- a/src/main/java/org/bukkit/material/Sign.java
+++ b/src/main/java/org/bukkit/material/Sign.java
@@ -48,16 +48,16 @@ public class Sign extends MaterialData implements Attachable {
 
             switch (data) {
             case 0x2:
-                return BlockFace.WEST;
-
-            case 0x3:
-                return BlockFace.EAST;
-
-            case 0x4:
                 return BlockFace.SOUTH;
 
-            case 0x5:
+            case 0x3:
                 return BlockFace.NORTH;
+
+            case 0x4:
+                return BlockFace.EAST;
+
+            case 0x5:
+                return BlockFace.WEST;
             }
 
             return null;
@@ -77,52 +77,52 @@ public class Sign extends MaterialData implements Attachable {
         if (!isWallSign()) {
             switch (data) {
             case 0x0:
-                return BlockFace.WEST;
-
-            case 0x1:
-                return BlockFace.WEST_NORTH_WEST;
-
-            case 0x2:
-                return BlockFace.NORTH_WEST;
-
-            case 0x3:
-                return BlockFace.NORTH_NORTH_WEST;
-
-            case 0x4:
-                return BlockFace.NORTH;
-
-            case 0x5:
-                return BlockFace.NORTH_NORTH_EAST;
-
-            case 0x6:
-                return BlockFace.NORTH_EAST;
-
-            case 0x7:
-                return BlockFace.EAST_NORTH_EAST;
-
-            case 0x8:
-                return BlockFace.EAST;
-
-            case 0x9:
-                return BlockFace.EAST_SOUTH_EAST;
-
-            case 0xA:
-                return BlockFace.SOUTH_EAST;
-
-            case 0xB:
-                return BlockFace.SOUTH_SOUTH_EAST;
-
-            case 0xC:
                 return BlockFace.SOUTH;
 
-            case 0xD:
+            case 0x1:
                 return BlockFace.SOUTH_SOUTH_WEST;
 
-            case 0xE:
+            case 0x2:
                 return BlockFace.SOUTH_WEST;
 
-            case 0xF:
+            case 0x3:
                 return BlockFace.WEST_SOUTH_WEST;
+
+            case 0x4:
+                return BlockFace.WEST;
+
+            case 0x5:
+                return BlockFace.WEST_NORTH_WEST;
+
+            case 0x6:
+                return BlockFace.NORTH_WEST;
+
+            case 0x7:
+                return BlockFace.NORTH_NORTH_WEST;
+
+            case 0x8:
+                return BlockFace.NORTH;
+
+            case 0x9:
+                return BlockFace.NORTH_NORTH_EAST;
+
+            case 0xA:
+                return BlockFace.NORTH_EAST;
+
+            case 0xB:
+                return BlockFace.EAST_NORTH_EAST;
+
+            case 0xC:
+                return BlockFace.EAST;
+
+            case 0xD:
+                return BlockFace.EAST_SOUTH_EAST;
+
+            case 0xE:
+                return BlockFace.SOUTH_EAST;
+
+            case 0xF:
+                return BlockFace.SOUTH_SOUTH_EAST;
             }
 
             return null;
@@ -136,85 +136,85 @@ public class Sign extends MaterialData implements Attachable {
 
         if (isWallSign()) {
             switch (face) {
-            case EAST:
+            case NORTH:
                 data = 0x2;
                 break;
 
-            case WEST:
+            case SOUTH:
                 data = 0x3;
                 break;
 
-            case NORTH:
+            case WEST:
                 data = 0x4;
                 break;
 
-            case SOUTH:
+            case EAST:
             default:
                 data = 0x5;
             }
         } else {
             switch (face) {
-            case WEST:
+            case SOUTH:
                 data = 0x0;
                 break;
 
-            case WEST_NORTH_WEST:
+            case SOUTH_SOUTH_WEST:
                 data = 0x1;
                 break;
 
-            case NORTH_WEST:
+            case SOUTH_WEST:
                 data = 0x2;
                 break;
 
-            case NORTH_NORTH_WEST:
+            case WEST_SOUTH_WEST:
                 data = 0x3;
                 break;
 
-            case NORTH:
+            case WEST:
                 data = 0x4;
                 break;
 
-            case NORTH_NORTH_EAST:
+            case WEST_NORTH_WEST:
                 data = 0x5;
                 break;
 
-            case NORTH_EAST:
+            case NORTH_WEST:
                 data = 0x6;
                 break;
 
-            case EAST_NORTH_EAST:
+            case NORTH_NORTH_WEST:
                 data = 0x7;
                 break;
 
-            case EAST:
+            case NORTH:
                 data = 0x8;
                 break;
 
-            case EAST_SOUTH_EAST:
+            case NORTH_NORTH_EAST:
                 data = 0x9;
                 break;
 
-            case SOUTH_EAST:
+            case NORTH_EAST:
                 data = 0xA;
                 break;
 
-            case SOUTH_SOUTH_EAST:
+            case EAST_NORTH_EAST:
                 data = 0xB;
                 break;
 
-            case SOUTH:
+            case EAST:
                 data = 0xC;
                 break;
 
-            case SOUTH_SOUTH_WEST:
+            case EAST_SOUTH_EAST:
                 data = 0xD;
                 break;
 
-            case WEST_SOUTH_WEST:
+            case SOUTH_SOUTH_EAST:
                 data = 0xF;
                 break;
 
-            case SOUTH_WEST:
+            case SOUTH_EAST:
             default:
                 data = 0xE;
             }

--- a/src/main/java/org/bukkit/material/Stairs.java
+++ b/src/main/java/org/bukkit/material/Stairs.java
@@ -33,16 +33,16 @@ public class Stairs extends MaterialData implements Directional {
         switch (data) {
         case 0x0:
         default:
-            return BlockFace.SOUTH;
+            return BlockFace.EAST;
 
         case 0x1:
-            return BlockFace.NORTH;
-
-        case 0x2:
             return BlockFace.WEST;
 
+        case 0x2:
+            return BlockFace.SOUTH;
+
         case 0x3:
-            return BlockFace.EAST;
+            return BlockFace.NORTH;
         }
     }
 
@@ -60,20 +60,20 @@ public class Stairs extends MaterialData implements Directional {
         byte data;
 
         switch (face) {
-        case NORTH:
+        case WEST:
         default:
             data = 0x0;
             break;
 
-        case SOUTH:
+        case EAST:
             data = 0x1;
             break;
 
-        case EAST:
+        case NORTH:
             data = 0x2;
             break;
 
-        case WEST:
+        case SOUTH:
             data = 0x3;
             break;
         }

--- a/src/main/java/org/bukkit/material/Torch.java
+++ b/src/main/java/org/bukkit/material/Torch.java
@@ -37,16 +37,16 @@ public class Torch extends SimpleAttachableMaterialData {
 
         switch (data) {
         case 0x1:
-            return BlockFace.NORTH;
+            return BlockFace.WEST;
 
         case 0x2:
-            return BlockFace.SOUTH;
-
-        case 0x3:
             return BlockFace.EAST;
 
+        case 0x3:
+            return BlockFace.NORTH;
+
         case 0x4:
-            return BlockFace.WEST;
+            return BlockFace.SOUTH;
 
         case 0x5:
             return BlockFace.DOWN;
@@ -59,19 +59,19 @@ public class Torch extends SimpleAttachableMaterialData {
         byte data;
 
         switch (face) {
-        case SOUTH:
+        case EAST:
             data = 0x1;
             break;
 
-        case NORTH:
+        case WEST:
             data = 0x2;
             break;
 
-        case WEST:
+        case SOUTH:
             data = 0x3;
             break;
 
-        case EAST:
+        case NORTH:
             data = 0x4;
             break;
 

--- a/src/main/java/org/bukkit/material/TrapDoor.java
+++ b/src/main/java/org/bukkit/material/TrapDoor.java
@@ -48,16 +48,16 @@ public class TrapDoor extends SimpleAttachableMaterialData implements Openable {
 
         switch (data) {
             case 0x0:
-                return BlockFace.WEST;
-
-            case 0x1:
-                return BlockFace.EAST;
-
-            case 0x2:
                 return BlockFace.SOUTH;
 
-            case 0x3:
+            case 0x1:
                 return BlockFace.NORTH;
+
+            case 0x2:
+                return BlockFace.EAST;
+
+            case 0x3:
+                return BlockFace.WEST;
         }
 
         return null;
@@ -68,13 +68,13 @@ public class TrapDoor extends SimpleAttachableMaterialData implements Openable {
         byte data = (byte) (getData() & 0x4);
 
         switch (face) {
-            case WEST:
+            case SOUTH:
                 data |= 0x1;
                 break;
-            case NORTH:
+            case WEST:
                 data |= 0x2;
                 break;
-            case SOUTH:
+            case EAST:
                 data |= 0x3;
                 break;
         }

--- a/src/main/java/org/bukkit/material/Vine.java
+++ b/src/main/java/org/bukkit/material/Vine.java
@@ -14,7 +14,7 @@ public class Vine extends MaterialData {
     private static final int VINE_EAST = 0x8;
     private static final int VINE_WEST = 0x2;
     private static final int VINE_SOUTH = 0x1;
-    EnumSet<BlockFace> possibleFaces = EnumSet.of(BlockFace.NORTH, BlockFace.EAST, BlockFace.WEST, BlockFace.SOUTH);
+    EnumSet<BlockFace> possibleFaces = EnumSet.of(BlockFace.WEST, BlockFace.NORTH, BlockFace.SOUTH, BlockFace.EAST);
 
     public Vine() {
         super(Material.VINE);
@@ -38,19 +38,19 @@ public class Vine extends MaterialData {
 
         byte data = 0;
 
-        if (faces.contains(BlockFace.NORTH)) {
+        if (faces.contains(BlockFace.WEST)) {
             data |= VINE_NORTH;
         }
 
-        if (faces.contains(BlockFace.EAST)) {
+        if (faces.contains(BlockFace.NORTH)) {
             data |= VINE_EAST;
         }
 
-        if (faces.contains(BlockFace.WEST)) {
+        if (faces.contains(BlockFace.SOUTH)) {
             data |= VINE_WEST;
         }
 
-        if (faces.contains(BlockFace.SOUTH)) {
+        if (faces.contains(BlockFace.EAST)) {
             data |= VINE_SOUTH;
         }
 
@@ -59,29 +59,29 @@ public class Vine extends MaterialData {
 
     /**
      * Check if the vine is attached to the specified face of an adjacent block. You can
-     * check two faces at once by passing eg {@link BlockFace#NORTH_EAST}.
+     * check two faces at once by passing eg {@link BlockFace#NORTH_WEST}.
      *
      * @param face The face to check.
      * @return Whether it is attached to that face.
      */
     public boolean isOnFace(BlockFace face) {
         switch (face) {
-            case NORTH:
-                return (getData() & VINE_NORTH) > 0;
-            case EAST:
-                return (getData() & VINE_EAST) > 0;
             case WEST:
-                return (getData() & VINE_WEST) > 0;
+                return (getData() & VINE_NORTH) > 0;
+            case NORTH:
+                return (getData() & VINE_EAST) > 0;
             case SOUTH:
+                return (getData() & VINE_WEST) > 0;
+            case EAST:
                 return (getData() & VINE_SOUTH) > 0;
-            case NORTH_EAST:
-                return isOnFace(BlockFace.NORTH) && isOnFace(BlockFace.EAST);
             case NORTH_WEST:
-                return isOnFace(BlockFace.NORTH) && isOnFace(BlockFace.WEST);
-            case SOUTH_EAST:
-                return isOnFace(BlockFace.SOUTH) && isOnFace(BlockFace.EAST);
+                return isOnFace(BlockFace.WEST) && isOnFace(BlockFace.NORTH);
             case SOUTH_WEST:
-                return isOnFace(BlockFace.SOUTH) && isOnFace(BlockFace.WEST);
+                return isOnFace(BlockFace.WEST) && isOnFace(BlockFace.SOUTH);
+            case NORTH_EAST:
+                return isOnFace(BlockFace.EAST) && isOnFace(BlockFace.NORTH);
+            case SOUTH_EAST:
+                return isOnFace(BlockFace.EAST) && isOnFace(BlockFace.SOUTH);
             case UP: // It's impossible to be accurate with this since it's contextual
                 return true;
             default:
@@ -96,33 +96,33 @@ public class Vine extends MaterialData {
      */
     public void putOnFace(BlockFace face) {
         switch(face) {
-            case NORTH:
+            case WEST:
                 setData((byte) (getData() | VINE_NORTH));
                 break;
-            case EAST:
+            case NORTH:
                 setData((byte) (getData() | VINE_EAST));
                 break;
-            case WEST:
+            case SOUTH:
                 setData((byte) (getData() | VINE_WEST));
                 break;
-            case SOUTH:
+            case EAST:
                 setData((byte) (getData() | VINE_SOUTH));
                 break;
-            case NORTH_EAST:
-                putOnFace(BlockFace.NORTH);
-                putOnFace(BlockFace.EAST);
-                break;
             case NORTH_WEST:
-                putOnFace(BlockFace.NORTH);
                 putOnFace(BlockFace.WEST);
-                break;
-            case SOUTH_EAST:
-                putOnFace(BlockFace.SOUTH);
-                putOnFace(BlockFace.EAST);
+                putOnFace(BlockFace.NORTH);
                 break;
             case SOUTH_WEST:
-                putOnFace(BlockFace.SOUTH);
                 putOnFace(BlockFace.WEST);
+                putOnFace(BlockFace.SOUTH);
+                break;
+            case NORTH_EAST:
+                putOnFace(BlockFace.EAST);
+                putOnFace(BlockFace.NORTH);
+                break;
+            case SOUTH_EAST:
+                putOnFace(BlockFace.EAST);
+                putOnFace(BlockFace.SOUTH);
                 break;
             case UP:
                 break;
@@ -138,33 +138,33 @@ public class Vine extends MaterialData {
      */
     public void removeFromFace(BlockFace face) {
         switch(face) {
-            case NORTH:
+            case WEST:
                 setData((byte) (getData() &~ VINE_NORTH));
                 break;
-            case EAST:
+            case NORTH:
                 setData((byte) (getData() &~ VINE_EAST));
                 break;
-            case WEST:
+            case SOUTH:
                 setData((byte) (getData() &~ VINE_WEST));
                 break;
-            case SOUTH:
+            case EAST:
                 setData((byte) (getData() &~ VINE_SOUTH));
                 break;
-            case NORTH_EAST:
-                removeFromFace(BlockFace.NORTH);
-                removeFromFace(BlockFace.EAST);
-                break;
             case NORTH_WEST:
-                removeFromFace(BlockFace.NORTH);
                 removeFromFace(BlockFace.WEST);
-                break;
-            case SOUTH_EAST:
-                removeFromFace(BlockFace.SOUTH);
-                removeFromFace(BlockFace.EAST);
+                removeFromFace(BlockFace.NORTH);
                 break;
             case SOUTH_WEST:
-                removeFromFace(BlockFace.SOUTH);
                 removeFromFace(BlockFace.WEST);
+                removeFromFace(BlockFace.SOUTH);
+                break;
+            case NORTH_EAST:
+                removeFromFace(BlockFace.EAST);
+                removeFromFace(BlockFace.NORTH);
+                break;
+            case SOUTH_EAST:
+                removeFromFace(BlockFace.EAST);
+                removeFromFace(BlockFace.SOUTH);
                 break;
             case UP:
                 break;

--- a/src/main/java/org/bukkit/util/BlockIterator.java
+++ b/src/main/java/org/bukkit/util/BlockIterator.java
@@ -186,17 +186,17 @@ public class BlockIterator implements Iterator<Block> {
         case DOWN:
             return BlockFace.UP;
 
+        case WEST:
+            return BlockFace.EAST;
+
+        case EAST:
+            return BlockFace.WEST;
+
         case NORTH:
             return BlockFace.SOUTH;
 
         case SOUTH:
             return BlockFace.NORTH;
-
-        case EAST:
-            return BlockFace.WEST;
-
-        case WEST:
-            return BlockFace.EAST;
 
         default:
             return null;
@@ -204,7 +204,7 @@ public class BlockIterator implements Iterator<Block> {
     }
 
     private BlockFace getXFace(Vector direction) {
-        return ((direction.getX() > 0) ? BlockFace.SOUTH : BlockFace.NORTH);
+        return ((direction.getX() > 0) ? BlockFace.EAST : BlockFace.WEST);
     }
 
     private BlockFace getYFace(Vector direction) {
@@ -212,7 +212,7 @@ public class BlockIterator implements Iterator<Block> {
     }
 
     private BlockFace getZFace(Vector direction) {
-        return ((direction.getZ() > 0) ? BlockFace.WEST : BlockFace.EAST);
+        return ((direction.getZ() > 0) ? BlockFace.SOUTH : BlockFace.NORTH);
     }
 
     private double getXLength(Vector direction) {


### PR DESCRIPTION
EdGruberman originally made a pull request, changing the coordinates for the block faces. This would have changed the definition, but left the original references alone, which might have been bad for plugins.

This pull request updates each reference to be 90 degrees to the left of where it originally is. This will correct the directions to what they should be. North is no longer Z - 1, but Z + 1, and vice versa for South. I'm not sure why they were switched.
