### PR TITLE
API for changing localized name of a player

### DIFF
--- a/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -146,4 +146,16 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, Permissible, Inv
      * @return Whether they are blocking.
      */
     public boolean isBlocking();
+    
+    /**
+     * Gets the player's localized name (name that appears above the player)
+     * @return the name
+     */
+    public String getLocalizedName();
+    
+    /**
+     * Sets the localized name (name that appears above the player)
+     * @param name the new name
+     */
+    public void setLocalizedName(String name);
 }

--- a/src/test/java/org/bukkit/plugin/messaging/TestPlayer.java
+++ b/src/test/java/org/bukkit/plugin/messaging/TestPlayer.java
@@ -756,4 +756,12 @@ public class TestPlayer implements Player {
     public boolean isBlocking() {
         throw new UnsupportedOperationException("Not supported yet.");
     }
+
+	public String getLocalizedName() {
+		throw new UnsupportedOperationException("Not supported yet.");
+	}
+
+	public void setLocalizedName(String name) {
+		throw new UnsupportedOperationException("Not supported yet.");
+	}
 }

--- a/src/test/java/org/bukkit/plugin/messaging/TestPlayer.java
+++ b/src/test/java/org/bukkit/plugin/messaging/TestPlayer.java
@@ -757,11 +757,11 @@ public class TestPlayer implements Player {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
-	public String getLocalizedName() {
-		throw new UnsupportedOperationException("Not supported yet.");
-	}
+    public String getLocalizedName() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 
-	public void setLocalizedName(String name) {
-		throw new UnsupportedOperationException("Not supported yet.");
-	}
+    public void setLocalizedName(String name) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 }


### PR DESCRIPTION
This add an API for changing the localized name of a player. Instead of CraftPlayer, the wrapper of EntityPlayer, getting and setting the name value that the localized name originates from, EntityPlayer retrieves from CraftPlayer it's own method that only affects the EntityHuman#getLocalizedName method. This can change the appearance of the name without actually changing the name.

CraftBukkit pull request: https://github.com/Bukkit/CraftBukkit/pull/772
