### PR TITLE
Prevented NullPointerExceptions from happening (Fixes BUKKIT-482)

### DIFF
--- a/src/main/java/org/bukkit/ChatColor.java
+++ b/src/main/java/org/bukkit/ChatColor.java
@@ -105,7 +105,8 @@ public enum ChatColor {
      * convert colour codes from your custom format.
      */
     public static final char COLOR_CHAR = '\u00A7';
-    private static final Pattern STRIP_COLOR_PATTERN = Pattern.compile("(?i)" + String.valueOf(COLOR_CHAR) + "[0-9A-FK-OR]");
+    private static final String ALLOWED_CHARACTERS = "[0-9A-FK-OR]";
+    private static final Pattern STRIP_COLOR_PATTERN = Pattern.compile("(?i)" + String.valueOf(COLOR_CHAR) + ALLOWED_CHARACTERS);
 
     private final int intCode;
     private final char code;
@@ -193,21 +194,14 @@ public enum ChatColor {
     /**
      * Translates a string using an alternate color code character into a string that uses the internal
      * ChatColor.COLOR_CODE color code character. The alternate color code character will only be replaced
-     * if it is immediately followed by 0-9, A-F, or a-f.
+     * if it is immediately followed by 0-9, A-F, K-O, R or the same lower-case characters.
      * 
      * @param altColorChar The alternate color code character to replace. Ex: &
      * @param textToTranslate Text containing the alternate color code character. 
      * @return Text containing the ChatColor.COLOR_CODE color code character.
      */
     public static String translateAlternateColorCodes(char altColorChar, String textToTranslate) {
-        char[] b = textToTranslate.toCharArray();
-        for (int i = 0; i < b.length - 1; i++) {
-            if (b[i] == altColorChar && "0123456789AaBbCcDdEeFfKkLlMmNnOoRr".indexOf(b[i+1]) > -1) {
-                b[i] = ChatColor.COLOR_CHAR;
-                b[i+1] = Character.toLowerCase(b[i+1]);
-            }
-        }
-        return new String(b);
+        return textToTranslate.replaceAll("(?i)" + altColorChar + "(" + ALLOWED_CHARACTERS + ")", COLOR_CHAR + "$1");
     }
 
     /**

--- a/src/main/java/org/bukkit/util/BlockIterator.java
+++ b/src/main/java/org/bukkit/util/BlockIterator.java
@@ -1,15 +1,17 @@
 package org.bukkit.util;
 
-import static org.bukkit.util.NumberConversions.*;
-
-import org.bukkit.World;
 import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.LivingEntity;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+
+import static org.bukkit.util.NumberConversions.floor;
+import static org.bukkit.util.NumberConversions.round;
+
 
 /**
  * This class performs ray tracing and iterates along blocks on a line
@@ -134,16 +136,16 @@ public class BlockIterator implements Iterator<Block> {
 
         Block lastBlock;
 
-        lastBlock = startBlock.getRelative(reverseFace(mainFace));
+        lastBlock = startBlock.getRelative(mainFace.getOppositeFace());
 
         if (secondError < 0) {
             secondError += gridSize;
-            lastBlock = lastBlock.getRelative(reverseFace(secondFace));
+            lastBlock = lastBlock.getRelative(secondFace.getOppositeFace());
         }
 
         if (thirdError < 0) {
             thirdError += gridSize;
-            lastBlock = lastBlock.getRelative(reverseFace(thirdFace));
+            lastBlock = lastBlock.getRelative(thirdFace.getOppositeFace());
         }
 
         // This means that when the variables are positive, it means that the coord=1 boundary has been crossed
@@ -176,31 +178,6 @@ public class BlockIterator implements Iterator<Block> {
 
     private boolean blockEquals(Block a, Block b) {
         return a.getX() == b.getX() && a.getY() == b.getY() && a.getZ() == b.getZ();
-    }
-
-    private BlockFace reverseFace(BlockFace face) {
-        switch (face) {
-        case UP:
-            return BlockFace.DOWN;
-
-        case DOWN:
-            return BlockFace.UP;
-
-        case NORTH:
-            return BlockFace.SOUTH;
-
-        case SOUTH:
-            return BlockFace.NORTH;
-
-        case EAST:
-            return BlockFace.WEST;
-
-        case WEST:
-            return BlockFace.EAST;
-
-        default:
-            return null;
-        }
     }
 
     private BlockFace getXFace(Vector direction) {


### PR DESCRIPTION
Just wanted to make sure that this ticket is closed. 

Also, we should use methods built-in BlockFace instead of duplicating code.

Associated JIRA ticket:

https://bukkit.atlassian.net/browse/BUKKIT-482
