### PR TITLE
Add player collision API

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -514,4 +514,16 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      * @param value True to fly.
      */
     public void setFlying(boolean value);
+
+    /**
+     * Change whether this player can push other entities
+     * @param yes true to push other entities, which is the default
+     */
+    public void setCollidesWithEntities(boolean yes);
+
+    /**
+     * Whether this player can push other entities
+     * @return true if the player can push other entities
+     */
+    public boolean getCollidesWithEntities();
 }

--- a/src/test/java/org/bukkit/plugin/messaging/TestPlayer.java
+++ b/src/test/java/org/bukkit/plugin/messaging/TestPlayer.java
@@ -645,6 +645,14 @@ public class TestPlayer implements Player {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
+    public void setCollidesWithEntities(boolean yes) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    public boolean getCollidesWithEntities() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
     public boolean addPotionEffect(PotionEffect effect) {
         throw new UnsupportedOperationException("Not supported yet.");
     }


### PR DESCRIPTION
Add an API to control whether players can collide with other entities, such as mobs and projectiles

Implementation:
https://github.com/Bukkit/CraftBukkit/pull/776
