### PR TITLE
Add API to set whether or not a player affects nearby mob spawning

### DIFF
--- a/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -146,4 +146,17 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, Permissible, Inv
      * @return Whether they are blocking.
      */
     public boolean isBlocking();
+
+    /**
+     * Setting this to false prevents players from activating mob spawners and
+     * allows mobs to randomly spawn and despawn near them (which normally can't happen).
+     * @param yes true to prevent this player from affecting mob spawning
+     */
+    public void setAffectsSpawning(boolean yes);
+
+    /**
+     * @return whether this player can activate mob spawners and prevent
+     *         random spawning and despawning near them.
+     */
+    public boolean getAffectsSpawning();
 }

--- a/src/test/java/org/bukkit/plugin/messaging/TestPlayer.java
+++ b/src/test/java/org/bukkit/plugin/messaging/TestPlayer.java
@@ -645,6 +645,14 @@ public class TestPlayer implements Player {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
+    public void setAffectsSpawning(boolean yes) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    public boolean getAffectsSpawning() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
     public boolean addPotionEffect(PotionEffect effect) {
         throw new UnsupportedOperationException("Not supported yet.");
     }


### PR DESCRIPTION
Players that don't affect spawning will not activate mob spawners and will be ignored by the natural spawning and despawning algorithms.

Implementation:
https://github.com/Bukkit/CraftBukkit/pull/775
