### PR TITLE
Adds ability to remove player from counted players in server list player count

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -514,4 +514,19 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      * @param value True to fly.
      */
     public void setFlying(boolean value);
+
+    /**
+     * Checks whether this player is counted in the server list player count.
+     *
+     * @return whether player is counted.
+     */
+    public boolean isCounted();
+
+    /**
+     * Sets whether this player is counted in the server list player count.
+     *
+     * @param counted whether to count this player.
+     * @see org.bukkit.event.server.ServerListPingEvent
+     */
+    public void setCounted(boolean counted);
 }

--- a/src/test/java/org/bukkit/plugin/messaging/TestPlayer.java
+++ b/src/test/java/org/bukkit/plugin/messaging/TestPlayer.java
@@ -756,4 +756,12 @@ public class TestPlayer implements Player {
     public boolean isBlocking() {
         throw new UnsupportedOperationException("Not supported yet.");
     }
+
+    public boolean isCounted() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    public void setCounted(boolean counted) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 }


### PR DESCRIPTION
As [this](https://github.com/Bukkit/Bukkit/pull/601) request could be used to make there appear to be more players than are actually on the server, this is an alternative based on setting countedness for individual players.

[JIRA](https://bukkit.atlassian.net/browse/BUKKIT-1646) (Not exactly as I've done it, as I said.)

[Implementation PR](https://github.com/Bukkit/CraftBukkit/pull/778)
