### PR TITLE
Updated ChatColor.translateAlternativeColorCodes to use Regex instead of a custom method

### DIFF
--- a/src/main/java/org/bukkit/ChatColor.java
+++ b/src/main/java/org/bukkit/ChatColor.java
@@ -105,7 +105,8 @@ public enum ChatColor {
      * convert colour codes from your custom format.
      */
     public static final char COLOR_CHAR = '\u00A7';
-    private static final Pattern STRIP_COLOR_PATTERN = Pattern.compile("(?i)" + String.valueOf(COLOR_CHAR) + "[0-9A-FK-OR]");
+    private static final String ALLOWED_CHARACTERS = "[0-9A-FK-OR]";
+    private static final Pattern STRIP_COLOR_PATTERN = Pattern.compile("(?i)" + String.valueOf(COLOR_CHAR) + ALLOWED_CHARACTERS);
 
     private final int intCode;
     private final char code;
@@ -193,21 +194,14 @@ public enum ChatColor {
     /**
      * Translates a string using an alternate color code character into a string that uses the internal
      * ChatColor.COLOR_CODE color code character. The alternate color code character will only be replaced
-     * if it is immediately followed by 0-9, A-F, or a-f.
+     * if it is immediately followed by 0-9, A-F, K-O, R or the same lower-case characters.
      * 
      * @param altColorChar The alternate color code character to replace. Ex: &
      * @param textToTranslate Text containing the alternate color code character. 
      * @return Text containing the ChatColor.COLOR_CODE color code character.
      */
     public static String translateAlternateColorCodes(char altColorChar, String textToTranslate) {
-        char[] b = textToTranslate.toCharArray();
-        for (int i = 0; i < b.length - 1; i++) {
-            if (b[i] == altColorChar && "0123456789AaBbCcDdEeFfKkLlMmNnOoRr".indexOf(b[i+1]) > -1) {
-                b[i] = ChatColor.COLOR_CHAR;
-                b[i+1] = Character.toLowerCase(b[i+1]);
-            }
-        }
-        return new String(b);
+        return textToTranslate.replaceAll("(?i)" + altColorChar + "(" + ALLOWED_CHARACTERS + ")", COLOR_CHAR + "$1");
     }
 
     /**


### PR DESCRIPTION
Associated JIRA ticket:

https://bukkit.atlassian.net/browse/BUKKIT-1705
