### PR TITLE
Added NotePlayEvent - Adresses BUKKIT-1779

### DIFF
--- a/src/main/java/org/bukkit/event/block/NotePlayEvent.java
+++ b/src/main/java/org/bukkit/event/block/NotePlayEvent.java
@@ -6,6 +6,9 @@ import org.bukkit.block.Block;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
+/**
+ * Called when a note-block is being played through player interaction or a redstone current.
+ */
 public class NotePlayEvent extends BlockEvent implements Cancellable {
 
     private static HandlerList handlers = new HandlerList();
@@ -30,10 +33,20 @@ public class NotePlayEvent extends BlockEvent implements Cancellable {
         return handlers;
     }
 
+    /**
+     * Gets the {@link Instrument} to be used.
+     * 
+     * @return the Instrument;
+     */
     public Instrument getInstrument() {
         return instrument;
     }
 
+    /**
+     * Gets the {@link Note} to be played.
+     * 
+     * @return the Note.
+     */
     public Note getNote() {
         return note;
     }
@@ -46,6 +59,11 @@ public class NotePlayEvent extends BlockEvent implements Cancellable {
         this.cancelled = cancel;
     }
 
+    /**
+     * Overrides the {@link Instrument} to be used.
+     * 
+     * @param instrument the Instrument. Has no effect if null.
+     */
     public void setInstrument(Instrument instrument) {
         if (instrument != null) {
             this.instrument = instrument;
@@ -53,6 +71,11 @@ public class NotePlayEvent extends BlockEvent implements Cancellable {
 
     }
 
+    /**
+     * Overrides the {@link Note} to be played.
+     *  
+     * @param note the Note. Has no effect if null.
+     */
     public void setNote(Note note) {
         if (note != null) {
             this.note = note;

--- a/src/main/java/org/bukkit/event/block/NotePlayEvent.java
+++ b/src/main/java/org/bukkit/event/block/NotePlayEvent.java
@@ -1,0 +1,62 @@
+package org.bukkit.event.block;
+
+import org.bukkit.Instrument;
+import org.bukkit.Note;
+import org.bukkit.block.Block;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+public class NotePlayEvent extends BlockEvent implements Cancellable {
+
+    private static HandlerList handlers = new HandlerList();
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    private Instrument instrument;
+    private Note note;
+
+    private boolean cancelled = false;
+
+    public NotePlayEvent(Block block, Instrument instrument, Note note) {
+        super(block);
+        this.instrument = instrument;
+        this.note = note;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public Instrument getInstrument() {
+        return instrument;
+    }
+
+    public Note getNote() {
+        return note;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    public void setInstrument(Instrument instrument) {
+        if (instrument != null) {
+            this.instrument = instrument;
+        }
+
+    }
+
+    public void setNote(Note note) {
+        if (note != null) {
+            this.note = note;
+        }
+    }
+
+}


### PR DESCRIPTION
This event is being called when a player interacts with a note block or the note block is being powered by a redstone current.

Discussion and demonstration:
http://forums.bukkit.org/threads/i-implemented-a-noteplayevent.79921/
