### PR TITLE
Makes the world seed modifiable. Addresses BUKKIT-1793.

### DIFF
--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -575,6 +575,13 @@ public interface World extends PluginMessageRecipient, Metadatable {
     public long getSeed();
 
     /**
+     * Sets the seed for this world.
+     * 
+     * @param seed the new world seed
+     */
+    public void setSeed(long seed);
+
+    /**
      * Gets the current PVP setting for this world.
      *
      * @return True if PVP is enabled


### PR DESCRIPTION
This adds a `setSeed(long)` method to the `World` interface to allow plugins to modify a world's seed directly through the API.

Link to ticket: https://bukkit.atlassian.net/browse/BUKKIT-1793
Link to CraftBukkit pull request: https://github.com/Bukkit/CraftBukkit/pull/793
