### PR TITLE
Add getMotd() and setMotd() methods to the Server interface

### DIFF
--- a/src/main/java/org/bukkit/Bukkit.java
+++ b/src/main/java/org/bukkit/Bukkit.java
@@ -130,6 +130,10 @@ public final class Bukkit {
         return server.getPlayer(name);
     }
 
+    public static String getMotd() {
+        return server.getMotd();
+    }
+
     public static List<Player> matchPlayer(String name) {
         return server.matchPlayer(name);
     }
@@ -276,6 +280,10 @@ public final class Bukkit {
 
     public static void setWhitelist(boolean value) {
         server.setWhitelist(value);
+    }
+
+    public static void setMotd(String newmotd, boolean save) {
+        server.setMotd(newmotd, save);
     }
 
     public static Set<OfflinePlayer> getWhitelistedPlayers() {

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -160,6 +160,21 @@ public interface Server extends PluginMessageRecipient {
     public void setWhitelist(boolean value);
 
     /**
+     * Returns the current motd
+     *
+     * @return The active motd (message sent to clients browsing their server list)
+     */
+    public String getMotd();
+
+    /**
+     * Sets the motd
+     *
+     * @param newmotd the new message of the day
+     * @param save specifies whether or not the new motd should be persistent (saved to the configuration file)
+     */
+     public void setMotd(String newmotd, boolean save);
+
+    /**
      * Gets a list of whitelisted players
      *
      * @return Set containing all whitelisted players


### PR DESCRIPTION
Adds `getMotd()` and `setMotd()` methods to the Server interface and the Bukkit class. 

This coupled with [my pull request in CraftBukkit](https://github.com/Bukkit/CraftBukkit/pull/794) will allow plugins to change the motd with one function call and optionally save it to the config file.

Ticket: https://bukkit.atlassian.net/browse/BUKKIT-1799
