### PR TITLE
Fixed '/whitelist list' displaying commented lines

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/WhitelistCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/WhitelistCommand.java
@@ -44,6 +44,7 @@ public class WhitelistCommand extends VanillaCommand {
 
                 for (OfflinePlayer player : Bukkit.getWhitelistedPlayers()) {
                     if (result.length() > 0) {
+                        if (player.getName().startsWith("#")) { continue; }
                         result.append(", ");
                     }
 


### PR DESCRIPTION
Added a check to prevent commented lines from white-list.txt from being
displayed as whitelisted users.
