### PR TITLE
Implement ServerBroadcastEvent. Addresses BUKKIT-1800.

### DIFF
--- a/src/main/java/org/bukkit/event/player/PlayerToggleFlyingEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerToggleFlyingEvent.java
@@ -22,7 +22,7 @@ public class PlayerToggleFlyingEvent extends PlayerEvent implements Cancellable 
      *
      * @return flying state
      */
-    public boolean isSneaking() {
+    public boolean isFlying() {
         return isFlying;
     }
 

--- a/src/main/java/org/bukkit/event/player/PlayerToggleFlyingEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerToggleFlyingEvent.java
@@ -1,0 +1,45 @@
+package org.bukkit.event.player;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Called when a player toggles their flying state
+ */
+public class PlayerToggleFlyingEvent extends PlayerEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private final boolean isFlying;
+    private boolean cancel = false;
+
+    public PlayerToggleFlyingEvent(final Player player, final boolean isFlying) {
+        super(player);
+        this.isFlying = isFlying;
+    }
+
+    /**
+     * Returns whether the player is now flying or not.
+     *
+     * @return flying state
+     */
+    public boolean isSneaking() {
+        return isFlying;
+    }
+
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/org/bukkit/event/server/ServerBroadcastEvent.java
+++ b/src/main/java/org/bukkit/event/server/ServerBroadcastEvent.java
@@ -1,0 +1,63 @@
+package org.bukkit.event.server;
+
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Server Broadcast events
+ */
+public class ServerBroadcastEvent extends ServerEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private String message;
+    private final String permission;
+    private boolean cancelled;
+
+    public ServerBroadcastEvent(final String message, final String permission) {
+        this.message = message;
+        this.permission = permission;
+    }
+
+    /**
+     * Gets the message that is being broadcasted to the server
+     *
+     * @return Message that is being broadcast
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * Sets the message that the server will broadcast
+     *
+     * @param message New message that the server will broadcast
+     */
+    public void setMessage(String message) {
+        this.message = message;
+    }
+    
+    /**
+     * Gets the permission that will be required to see the message.
+     *
+     * @return Permission required to view message
+     */
+    public String getPermission() {
+        return message;
+    }  
+    
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }    
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}


### PR DESCRIPTION
Some plugins may want to listen for broadcasts to the server so that they can be logged or transmitted elsewhere. Right now, they can only do this by listening to commands. This implements an event that is fired whenever the server broadcasts a message, including the message and the permission required to view the message.

Leaky ticket: https://bukkit.atlassian.net/browse/BUKKIT-1800 
