### PR TITLE
Add a third position in the load queue right before the Done message is spewed out. (Bukkit part)

### DIFF
--- a/src/main/java/org/bukkit/plugin/PluginLoadOrder.java
+++ b/src/main/java/org/bukkit/plugin/PluginLoadOrder.java
@@ -12,4 +12,8 @@ public enum PluginLoadOrder {
      * Indicates that the plugin will be loaded after the first/default world was created
      */
     POSTWORLD
+    /**
+     * Indicates that the plugin will be loaded right before the Server is done with it's booting
+     */
+    DONE
 }


### PR DESCRIPTION
This would prevent some of the mess created by World Managing plugins loading on POSTWORLD.

Changes:
- Adds PluginLoadOrder.DONE
- Adds two calls to enablePlugins(PluginLoadOrder.DONE)

CraftBukkit: https://github.com/Bukkit/CraftBukkit/pull/798
