### PR TITLE
Added encoding options to allow explicit setting by plugins. Addresses BUKKIT-1853

### DIFF
--- a/src/main/java/org/bukkit/configuration/file/FileConfiguration.java
+++ b/src/main/java/org/bukkit/configuration/file/FileConfiguration.java
@@ -8,10 +8,11 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import org.bukkit.configuration.Configuration;
 import org.bukkit.configuration.MemoryConfiguration;
 
@@ -53,7 +54,7 @@ public abstract class FileConfiguration extends MemoryConfiguration {
 
         String data = saveToString();
 
-        FileWriter writer = new FileWriter(file);
+        OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(file), options().getEncoding());
 
         try {
             writer.write(data);
@@ -119,7 +120,7 @@ public abstract class FileConfiguration extends MemoryConfiguration {
     public void load(InputStream stream) throws IOException, InvalidConfigurationException {
         Validate.notNull(stream, "Stream cannot be null");
 
-        InputStreamReader reader = new InputStreamReader(stream);
+        InputStreamReader reader = new InputStreamReader(stream, options().getEncoding());
         StringBuilder builder = new StringBuilder();
         BufferedReader input = new BufferedReader(reader);
 

--- a/src/main/java/org/bukkit/configuration/file/FileConfigurationOptions.java
+++ b/src/main/java/org/bukkit/configuration/file/FileConfigurationOptions.java
@@ -2,15 +2,19 @@ package org.bukkit.configuration.file;
 
 import org.bukkit.configuration.*;
 
+import java.nio.charset.*;
+
 /**
  * Various settings for controlling the input and output of a {@link FileConfiguration}
  */
 public class FileConfigurationOptions extends MemoryConfigurationOptions {
     private String header = null;
     private boolean copyHeader = true;
+    private Charset encoding;
 
     protected FileConfigurationOptions(MemoryConfiguration configuration) {
         super(configuration);
+        this.encoding = Charset.defaultCharset();
     }
 
     @Override
@@ -104,5 +108,23 @@ public class FileConfigurationOptions extends MemoryConfigurationOptions {
         copyHeader = value;
 
         return this;
+    }
+
+    /**
+     * Gets the character encoding set used by this FileConfiguration object.
+     * @return The character encoding used for this FileConfiguration.
+     */
+    public String getEncoding() {
+        return this.encoding.displayName();
+    }
+
+    /**
+     * Attempts to set the character encoding for this FileConfiguration object.
+     * @param charset The name of the character set, such as UTF-8 or ISO-8859-1
+     * @throws IllegalCharsetNameException If the given charset name is invalid
+     * @throws UnsupportedCharsetException If no support for the given charset exists in this instance of the JVM
+     */
+    public void setEncoding(String charset) throws IllegalCharsetNameException, UnsupportedCharsetException {
+        this.encoding = Charset.forName(charset);
     }
 }


### PR DESCRIPTION
This allows plugins to specify their own character encoding if they need it (for whatever) reason, and preserves the default functionality of plugins that do not change it (ie no enforced UTF-8 unless the system is already doing so).
