### PR TITLE
Added The Ability To Get An Offline Player's Inventory

### DIFF
--- a/src/main/java/org/bukkit/OfflinePlayer.java
+++ b/src/main/java/org/bukkit/OfflinePlayer.java
@@ -3,6 +3,7 @@ package org.bukkit;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.entity.AnimalTamer;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.permissions.ServerOperator;
 
 public interface OfflinePlayer extends ServerOperator, AnimalTamer, ConfigurationSerializable {
@@ -92,5 +93,12 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
      * @return Bed Spawn Location if bed exists, otherwise null.
      */
     public Location getBedSpawnLocation();
+    
+    /**
+     * Get the player's inventory.
+     *
+     * @return The inventory of the player, this also contains the armor slots.
+     */
+    public PlayerInventory getInventory();
 
 }


### PR DESCRIPTION
As the title says, this pull request adds the ability for a plugin to retrieve the saved inventory of an OfflinePlayer. This would allow moderation plugins to be able to view a player's saved inventory if they are not on the server.

Implementation details:
If the player is online, it returns the player's inventory by getting the online player and then calling `getInventory()` on that object. For other players it gets a player's inventory by loading the NBT file,  creating a `net.minecraft.server.PlayerInventory` with the player set to null, calling `b(NBTTagList)` and then creating a `CraftInventoryPlayer` with the inventory already created. Also, if the player has no data, it returns null.

Corresponding CraftBukkit Pull Request: https://github.com/Bukkit/CraftBukkit/pull/811
JIRA Ticket: https://bukkit.atlassian.net/browse/BUKKIT-1877
