### PR TITLE
Use event class instead of event to prevent the event from staying in memory

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/TimingsCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/TimingsCommand.java
@@ -84,9 +84,9 @@ public class TimingsCommand extends BukkitCommand {
                             if (count == 0) continue;
                             long avg = time / count;
                             totalTime += time;
-                            Event event = trl.getEvent();
-                            if (count > 0 && event != null) {
-                                fileTimings.println("    " + event.getClass().getSimpleName() + (trl.hasMultiple() ? " (and others)" : "") + " Time: " + time + " Count: " + count + " Avg: " + avg);
+                            Class<? extends Event> eventClass = trl.getEventClass();
+                            if (count > 0 && eventClass != null) {
+                                fileTimings.println("    " + eventClass.getSimpleName() + (trl.hasMultiple() ? " (and others)" : "") + " Time: " + time + " Count: " + count + " Avg: " + avg);
                             }
                         }
                     }

--- a/src/main/java/org/bukkit/plugin/TimedRegisteredListener.java
+++ b/src/main/java/org/bukkit/plugin/TimedRegisteredListener.java
@@ -11,7 +11,7 @@ import org.bukkit.event.Listener;
 public class TimedRegisteredListener extends RegisteredListener {
     private int count;
     private long totalTime;
-    private Event event;
+    private Class<? extends Event> eventClass;
     private boolean multiple = false;
 
     public TimedRegisteredListener(final Listener pluginListener, final EventExecutor eventExecutor, final EventPriority eventPriority, final Plugin registeredPlugin, final boolean listenCancelled) {
@@ -25,15 +25,23 @@ public class TimedRegisteredListener extends RegisteredListener {
             return;
         }
         count++;
-        if (this.event == null) {
-            this.event = event;
-        }
-        else if (!this.event.getClass().equals(event.getClass())) {
+        Class<? extends Event> newEventClass = event.getClass();
+        if (this.eventClass == null) {
+            this.eventClass = newEventClass;
+        } else if (!this.eventClass.equals(newEventClass)) {
             multiple = true;
+            this.eventClass = getCommonSuperclass(newEventClass, this.eventClass).asSubclass(Event.class);
         }
         long start = System.nanoTime();
         super.callEvent(event);
         totalTime += System.nanoTime() - start;
+    }
+
+    private static Class<?> getCommonSuperclass(Class<?> class1, Class<?> class2) {
+        while (!class1.isAssignableFrom(class2)) {
+            class1 = class1.getSuperclass();
+        }
+        return class1;
     }
 
     /**
@@ -63,12 +71,13 @@ public class TimedRegisteredListener extends RegisteredListener {
     }
 
     /**
-     * Gets the first event this listener handled
+     * Gets the class of the events this listener handled.
+     * If it handled multiple classes of event, the closest superclass will be returned.
      *
-     * @return An event handled by this RegisteredListener
+     * @return The event class handled by this RegisteredListener
      */
-    public Event getEvent() {
-        return event;
+    public Class<? extends Event> getEventClass() {
+        return eventClass;
     }
 
     /**

--- a/src/test/java/org/bukkit/plugin/TimedRegisteredListenerTest.java
+++ b/src/test/java/org/bukkit/plugin/TimedRegisteredListenerTest.java
@@ -1,0 +1,54 @@
+package org.bukkit.plugin;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.EventException;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TimedRegisteredListenerTest {
+    @Test
+    public void testEventClass() throws EventException {
+        Listener listener = new Listener() {};
+        EventExecutor executor = new EventExecutor() {
+            public void execute(Listener listener, Event event) {}
+        };
+        TestPlugin plugin = new TestPlugin("Test");
+
+        PlayerInteractEvent interactEvent = new PlayerInteractEvent(null, null, null, null, null);
+        PlayerMoveEvent moveEvent = new PlayerMoveEvent(null, null, null);
+        BlockBreakEvent breakEvent = new BlockBreakEvent(null, null);
+
+        TimedRegisteredListener trl = new TimedRegisteredListener(listener, executor, EventPriority.NORMAL, plugin, false);
+
+        // Ensure that the correct event type is reported for a single event
+        trl.callEvent(interactEvent);
+        assertEquals(trl.getEventClass(), PlayerInteractEvent.class);
+        // Ensure that no superclass is used in lieu of the actual event, after two identical event types
+        trl.callEvent(interactEvent);
+        assertEquals(trl.getEventClass(), PlayerInteractEvent.class);
+        // Ensure that the closest superclass of the two events is chosen
+        trl.callEvent(moveEvent);
+        assertEquals(trl.getEventClass(), PlayerEvent.class);
+        // As above, so below
+        trl.callEvent(breakEvent);
+        assertEquals(trl.getEventClass(), Event.class);
+        // In the name of being thorough, check that it never travels down the hierarchy again.
+        trl.callEvent(breakEvent);
+        assertEquals(trl.getEventClass(), Event.class);
+
+        trl = new TimedRegisteredListener(listener, executor, EventPriority.NORMAL, plugin, false);
+
+        trl.callEvent(breakEvent);
+        assertEquals(trl.getEventClass(), BlockBreakEvent.class);
+        // Test moving up the class hierarchy by more than one class at a time
+        trl.callEvent(moveEvent);
+        assertEquals(trl.getEventClass(), Event.class);
+    }
+}


### PR DESCRIPTION
...when using plugin profiling.

(And all associated entities / players / NetServerHandlers / packet queues / AxisAlignedBBs / etc.)
