### PR TITLE
Add setName to PlayerPreLoginEvent

### DIFF
--- a/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java
@@ -11,7 +11,7 @@ public class PlayerPreLoginEvent extends Event {
     private static final HandlerList handlers = new HandlerList();
     private Result result;
     private String message;
-    private final String name;
+    private String name;
     private final InetAddress ipAddress;
 
     public PlayerPreLoginEvent(final String name, final InetAddress ipAddress) {
@@ -83,6 +83,17 @@ public class PlayerPreLoginEvent extends Event {
      */
     public String getName() {
         return name;
+    }
+    
+    /**
+     * Set the player's name.
+     * @param newName
+     */
+    public void setName(String newName) {
+    	if (newName == null || newName.length()<1) {
+    		throw new IllegalArgumentException("Name must be non-null");
+    	}
+    	name = newName;
     }
 
     /**


### PR DESCRIPTION
This allows a plugin to change the player name during pre-login.  I use this on my family server to allow multiple identities from a single account, without hacking the client.
