### PR TITLE
Added getRemainingDelay to the BukkitScheduler.

### DIFF
--- a/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
+++ b/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
@@ -148,4 +148,15 @@ public interface BukkitScheduler {
      */
     public List<BukkitTask> getPendingTasks();
 
+    /**
+     * Returns the remaining time till the task will get executed.
+     * <p />
+     * If a repeating task is currently running, it might return -1.
+     * A task that is not queued will return -1, too.
+     *
+     * @param taskId The task to check.
+     * @return The time in ticks till the task will get executed or a negative value on errors.
+     */
+    public List<BukkitTask> getRemainingDelay(int taskId);
+
 }

--- a/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
+++ b/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
@@ -157,6 +157,6 @@ public interface BukkitScheduler {
      * @param taskId The task to check.
      * @return The time in ticks till the task will get executed or a negative value on errors.
      */
-    public List<BukkitTask> getRemainingDelay(int taskId);
+    public long getRemainingDelay(int taskId);
 
 }


### PR DESCRIPTION
This nice new request allows it to get the remaining time till a task gets executed.
More information at the associated ticket: https://bukkit.atlassian.net/browse/BUKKIT-1912
Associated CraftBukkit pull request: https://github.com/Bukkit/CraftBukkit/pull/816
