### PR TITLE
Added PlayerEatEvent class

### DIFF
--- a/src/main/java/org/bukkit/event/player/PlayerEatEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerEatEvent.java
@@ -1,0 +1,49 @@
+package org.bukkit.event.player;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+
+public class PlayerEatEvent extends PlayerEvent implements Cancellable {
+
+	private static final HandlerList handlers = new HandlerList();
+	private boolean isCancelled = false;
+	private int amount;
+	private ItemStack item;
+
+	public PlayerEatEvent(final Player who, int amount, ItemStack item) {
+		super(who);
+		this.amount = amount;
+		this.item = item;
+	}
+
+	public boolean isCancelled() {
+		return isCancelled;
+	}
+
+	public void setCancelled(boolean cancel) {
+		isCancelled = cancel;
+	}
+
+	public int getAmount() {
+		return amount;
+	}
+
+	public void setAmount(int amount) {
+		this.amount = amount;
+	}
+	
+	public ItemStack getItem(){
+		return this.item;
+	}
+	
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+}


### PR DESCRIPTION
This event allows devs to know what itemstack called this event and what nutrition value the ItemFood has. This event allows devs to change the amount of nutrition the ItemFood gives the HumanEntity and the Animation and noises still continue. It is a lot more stable than using PlayerInteractEvent.

Ticket: https://bukkit.atlassian.net/browse/BUKKIT-280
CraftBukkit PR: https://github.com/Bukkit/CraftBukkit/pull/821
