### PR TITLE
Provided a way to spawn a green robed villager.

### DIFF
--- a/src/main/java/org/bukkit/entity/Villager.java
+++ b/src/main/java/org/bukkit/entity/Villager.java
@@ -28,6 +28,7 @@ public interface Villager extends Ageable, NPC {
         PRIEST(2),
         BLACKSMITH(3),
         BUTCHER(4);
+        VILLAGER(5);
 
         private static final Profession[] professions = new Profession[Profession.values().length];
         private final int id;


### PR DESCRIPTION
The entity type villager had no way of spawning a green-robed villager. A user on the bukkit forums wished to spawn a green-robed villager, but there was no way. This provides a way, however, the profession type is just VILLAGER, because green-robed villagers have no named profession on the wiki.

-simple fix
