### PR TITLE
Don't recreate a pointer to the configuration file every time saveDefaul...

### DIFF
--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
@@ -133,7 +133,7 @@ public abstract class JavaPlugin extends PluginBase {
     }
 
     public void saveDefaultConfig() {
-        if (!new File(getDataFolder(), "config.yml").exists()) {
+        if (!configFile.exists()) {
             saveResource("config.yml", false);
         }
     }


### PR DESCRIPTION
...tConfig() is called.

configFile is initalized in the initialize() method, why was the File pointer to the actuall file recreated every time saveDefaultConfig() is called when configFile is already there?
