### PR TITLE
Corrected javadocs for ChatColor.translateAlternateColorCodes().

### DIFF
--- a/src/main/java/org/bukkit/ChatColor.java
+++ b/src/main/java/org/bukkit/ChatColor.java
@@ -193,7 +193,7 @@ public enum ChatColor {
     /**
      * Translates a string using an alternate color code character into a string that uses the internal
      * ChatColor.COLOR_CODE color code character. The alternate color code character will only be replaced
-     * if it is immediately followed by 0-9, A-F, or a-f.
+     * if it is immediately followed by 0-9, A-F, a-f, K-O, k-o, R or r.
      * 
      * @param altColorChar The alternate color code character to replace. Ex: &
      * @param textToTranslate Text containing the alternate color code character. 


### PR DESCRIPTION
Added missing color chars to the java doc.
