### PR TITLE
Fixed missing space in GameModeCommand

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/GameModeCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/GameModeCommand.java
@@ -58,7 +58,7 @@ public class GameModeCommand extends VanillaCommand {
                     sender.sendMessage("Game mode change for " + player.getName() + " failed!");
                 } else {
                     if (player == sender) {
-                        Command.broadcastCommandMessage(sender, "Set own game mode to" + mode.toString() + " mode", false);
+                        Command.broadcastCommandMessage(sender, "Set own game mode to " + mode.toString() + " mode", false);
                     } else {
                         Command.broadcastCommandMessage(sender, "Set " + player.getName() + "'s game mode to" + mode.toString() + " mode", false);
                     }


### PR DESCRIPTION
Fixed a missing space typo in the "Set own game mode..." log.
