### PR TITLE
Adding Enchanted item functionality to ingredients for recipes - BUKKIT-2286

### DIFF
--- a/src/main/java/org/bukkit/inventory/ShapedRecipe.java
+++ b/src/main/java/org/bukkit/inventory/ShapedRecipe.java
@@ -99,6 +99,20 @@ public class ShapedRecipe implements Recipe {
     }
 
     /**
+     * Sets the item that a character in the recipe shape refers to.
+     *
+     * @param key The character that represents the ingredient in the shape.
+     * @param ingredient The ingredient.
+     * @return The changed recipe, so you can chain calls.
+     */
+    public ShapedRecipe setIngredient(char key, ItemStack item) {
+    	item.setAmount(1);
+        Validate.isTrue(ingredients.containsKey(key), "Symbol does not appear in the shape:", key);
+        ingredients.put(key, new ItemStack(item));
+        return this;
+    }
+    
+    /**
      * Get a copy of the ingredients map.
      *
      * @return The mapping of character to ingredients.

--- a/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
+++ b/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
@@ -104,6 +104,19 @@ public class ShapelessRecipe implements Recipe {
     }
 
     /**
+     * Adds the specified ingredient.
+     *
+     * @param ingredient The ingredient to add.
+     * @return The changed recipe, so you can chain calls.
+     */
+    public ShapelessRecipe addIngredient(ItemStack item) {
+    	item.setAmount(1);
+        Validate.isTrue(ingredients.size() + 1 <= 9, "Shapeless recipes cannot have more than 9 ingredients");
+        ingredients.add(new ItemStack(item));
+    	return this;
+    }
+
+    /**
      * Removes an ingredient from the list. If the ingredient occurs multiple times,
      * only one instance of it is removed. Only removes exact matches, with a data value
      * of 0.


### PR DESCRIPTION
https://bukkit.atlassian.net/browse/BUKKIT-2286
Craft-Bukkit Pull Request: https://github.com/Bukkit/CraftBukkit/pull/859

Adds functionality that allows creating recipes that have components with specific enchantments.  This means you can now have recipes such as combining two Diamond Sword Sharpness I and creating a Diamond Sword Sharpness II, and much more.
