### PR TITLE
Fix PlayerInteractEvent.isCancelled

### DIFF
--- a/src/main/java/org/bukkit/event/player/PlayerInteractEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerInteractEvent.java
@@ -48,7 +48,7 @@ public class PlayerInteractEvent extends PlayerEvent implements Cancellable {
      * @return boolean cancellation state
      */
     public boolean isCancelled() {
-        return useInteractedBlock() == Result.DENY;
+        return useInteractedBlock() == Result.DENY && useItemInHand() == Result.DENY;
     }
 
     /**


### PR DESCRIPTION
If you simply do `event.setCancelled(event.isCancelled())` in a PlayerInteractEvent handler, players lose the ability to do many things, including eating,  unless they have targetted a block.

The problem that has been addressed is that getCancelled was reporting true any time the players did not have a block highlighted. It now also checks if there is an item in hand set to be used.
