### PR TITLE
Added a PlayerConsumeItemEvent and a method to update the health and foodbar

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -282,6 +282,14 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      */
     @Deprecated
     public void updateInventory();
+    
+    /**
+     * Sends an update of the healthbar and foodbar to the player
+     *
+     * @deprecated This method should not be relied upon as it is a temporary work-around for a larger, more complicated issue.
+     */
+    @Deprecated
+    public void updateFoodAndHealth();
 
     /**
      * Awards this player the given achievement

--- a/src/main/java/org/bukkit/event/player/PlayerConsumeItemEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerConsumeItemEvent.java
@@ -1,0 +1,62 @@
+package org.bukkit.event.player;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Called when a player eats food or is drinking a potion or milk
+ */
+public class PlayerConsumeItemEvent extends PlayerEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancel = false;
+    private int nutrition;
+    private ItemStack item;
+
+    public PlayerConsumeItemEvent(final Player who, int nutrition, ItemStack item) {
+        super(who);
+        this.nutrition = nutrition;
+        this.item = item;
+    }
+
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+
+    /**
+     * Returns the amount of restored food points
+     * (nutrition fact)
+     * 0 if a potion is consumed.
+     */
+    public int getNutrition() {
+        return nutrition;
+    }
+
+    /**
+     * Sets the amount of restored food points
+     */
+    public void setNutrition(int nutrition) {
+        this.nutrition = nutrition;
+    }
+
+    /**
+     * Returns the item the player is consuming 
+     */
+    public ItemStack getItem(){
+        return item;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}


### PR DESCRIPTION
Corresponding CraftBukkit PR: https://github.com/Bukkit/CraftBukkit/pull/874

Please be kind, this is my first (real) pull request.
This event is called when the eating/drinking of an item is over and the effects would apply.

If the player consumes food, you are able to change the nutrition value.
Cancelling is possible, too!

The event is called before FoodLevelChangeEvent

If anything is missing, please tell me! :)

Hope to see this pulled

Side note:
The updateFoodAndHealth methods sends a new packet to the player, because the client would change the foodbar, even if the event is cancelled.
(Same effect appears if you cancel FoodLevelChange!)
I marked it as deprecated since this isn't the nicest way to handle it.

All changes were tested and worked correctly :)
