### PR TITLE
Implement ping method

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -98,6 +98,13 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
     public void sendRawMessage(String message);
 
     /**
+     * Gets the ping of this player.
+     *
+     * @return The ping of this player.
+     */
+    public int getPing();
+
+    /**
      * Kicks player with custom kick message.
      *
      * @param message kick message


### PR DESCRIPTION
This implements a ping method by accessing the field "ping" in the EntityPlayer object.

https://bukkit.atlassian.net/browse/BUKKIT-2437

Is it updated?

Yep it updates automatically.

What is ping?

The ping is the time, it takes to send a package to the server and receive it.

Is it accurate?

It is almost. This equals the ping value which you can see in your server list if you hover the connection symbol.

Here is a test:

From ingame:
19:32:33 [INFO] p000ison - 7
19:32:35 [INFO] p000ison - 48
19:32:37 [INFO] p000ison - 43
19:32:39 [INFO] p000ison - 47
19:32:41 [INFO] p000ison - 62
19:32:43 [INFO] p000ison - 59
19:32:46 [INFO] p000ison - 59
19:32:47 [INFO] p000ison - 53
19:32:49 [INFO] p000ison - 61
19:32:51 [INFO] p000ison - 53
19:32:53 [INFO] p000ison - 46
19:32:55 [INFO] p000ison - 50
19:32:57 [INFO] p000ison - 41
19:32:59 [INFO] p000ison - 44
19:33:01 [INFO] p000ison - 66
19:33:03 [INFO] p000ison - 54

Direct ping:

Antwort von ****_: Bytes=32 Zeit=23ms TTL=56
Antwort von ***__: Bytes=32 Zeit=11ms TTL=56
Antwort von *_**_: Bytes=32 Zeit=21ms TTL=56
Antwort von ***__: Bytes=32 Zeit=16ms TTL=56
Antwort von *_**_: Bytes=32 Zeit=14ms TTL=56
Antwort von ***__: Bytes=32 Zeit=13ms TTL=56
Antwort von *_**_: Bytes=32 Zeit=18ms TTL=56
Antwort von ***__: Bytes=32 Zeit=14ms TTL=56
Antwort von *_**_: Bytes=32 Zeit=15ms TTL=56
Antwort von ***__: Bytes=32 Zeit=14ms TTL=56
Antwort von *_**_: Bytes=32 Zeit=14ms TTL=56
Antwort von ***_*: Bytes=32 Zeit=17ms TTL=56

Why do you need it? 

I think it can help to check if the connection to the player is not good. This can help for example plugins which prevent cheating (like NoCheat)

It seems like the first ping is always a bit less, but the other values are ok.
