### PR TITLE
Added overloads for the playSound methods that allow to pass raw sound names instead of an enum.

### DIFF
--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -996,6 +996,18 @@ public interface World extends PluginMessageRecipient, Metadatable {
     void playSound(Location loc, Sound sound, float volume, float pitch);
 
     /**
+     * Play a Sound at the provided Location in the World
+     * <p />
+     * This function will fail silently if Location or Sound are null.
+     *
+     * @param location The location to play the sound
+     * @param sound The sound to play
+     * @param volume The volume of the sound
+     * @param pitch The pitch of the sound
+     */
+    void playSound(Location loc, String sound, float volume, float pitch);
+
+    /**
      * Represents various map environment types that a world may be
      */
     public enum Environment {

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -212,6 +212,18 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
     public void playSound(Location location, Sound sound, float volume, float pitch);
 
     /**
+     * Play a sound for a player at the location.
+     * <p />
+     * This function will fail silently if Location or Sound are null.
+     *
+     * @param location The location to play the sound
+     * @param sound The sound to play
+     * @param volume The volume of the sound
+     * @param pitch The pitch of the sound
+     */
+    public void playSound(Location location, String sound, float volume, float pitch);
+
+    /**
      * Plays an effect to just this player.
      *
      * @param loc the location to play the effect at


### PR DESCRIPTION
Added overloads for the playSound methods that allow to pass raw sound names instead of an enum.

This allows playing custom (i.e. non-minecraft) sounds and makes playing sounds by name easier.

Accompanying this are https://github.com/Bukkit/CraftBukkit/pull/881 and https://bukkit.atlassian.net/browse/BUKKIT-2443
