### PR TITLE
Updated maven compiler plugin version to 2.5.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.0.2</version>
+                <version>2.5.1</version>
                 <configuration>
                     <source>1.5</source>
                     <target>1.5</target>


### PR DESCRIPTION
There's no reason to keep using such an ancient version.

Problem with that version: it defaults to Java 1.3, forcing everyone to specify Java versions in their pom.xml if they want to use features beyond that.

Same change for CraftBukkit: https://github.com/Bukkit/CraftBukkit/pull/887
