### PR TITLE
add isDatabaseEnabled() method for optional DB support

### DIFF
--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
@@ -221,6 +221,19 @@ public abstract class JavaPlugin extends PluginBase {
         }
     }
 
+    /** Is the ebean database enabled for this plugin? We punt the decision to
+     * the description file, but this method can be overridden by a plugin
+     * to make the decision dynamically (such as based on config settings).
+     * NOTE this is invoked PRE-onEnable(), so if you override be sure not
+     * to count on any initializations from onEnable(). getConfig() is safe
+     * to invoke at this point.
+     * 
+     * @return true if database is enabled, false if not
+     */
+    public boolean isDatabaseEnabled() {
+        return getDescription().isDatabaseEnabled();
+    }
+
     /**
      * Initializes this plugin with the given variables.
      * <p />
@@ -244,7 +257,7 @@ public abstract class JavaPlugin extends PluginBase {
             this.classLoader = classLoader;
             this.configFile = new File(dataFolder, "config.yml");
 
-            if (description.isDatabaseEnabled()) {
+            if (isDatabaseEnabled()) {
                 ServerConfig db = new ServerConfig();
 
                 db.setDefaultServer(false);


### PR DESCRIPTION
This gives plugins a chance to override this method if they want to decide at runtime whether or not to use the database. A simple change that allows plugins with optional DB support to not incur ebeans loading overhead and startup spam if the admin has not enabled DB use for the plugin.

Use Case: A plugin wants to provide optional DB support, without forcing the admin to take the overhead of the Avaje EBean startup (or the confusing 'ebeans.properties missing' messages) when the admin isn't using a SQL DB. Two examples:

1- Logging. Ordinarily log to a file, but optionally allow the admin to specify they want to log to a database as well.
2- Backend choice. Support a YAML back-end but optionally allow the admin to use a database instead.

In both cases, the intended database support is optional and currently the developer must make the choice at archive distribution time in plugin.yml: either your plugin has database support or not. This leads to extra startup and overhead and confusing messages when admins are not using the database at all.

The proposed solution does not affect backwards compatibility at all, plugins can still continue to set "database: true" in plugin.yml and all works the same. The solution allows an author to optionally enable/disable DB based on a config setting like so:

class MyPlugin extends JavaPlutgin {
    @Override
    public boolean isDatabaseEnabled() {
        return getConfig().getBoolean("databaseEnabled");
    }
}

I've tested this change and reviewed the code surrounding the invocation of this method, getConfig() is safe to be called at this point. This gives developers who want it the ability to provide optional database support while not changing anything for developers who don't.
