### PR TITLE
BUKKIT-2220 Player.getLanguage()

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -554,4 +554,10 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      * @return The current allowed speed, from -1 to 1
      */
     public float getWalkSpeed();
+    
+    /**
+     * Gets the language this player has configured.
+     * @return The locale code of the language such as "en_US"
+     */
+    public String getLanguage();
 }


### PR DESCRIPTION
This pull request adds the method getLanguage() to the Player interface to retrieve the Player's configured language.

Use cases:
- per-player translation
- language statistics

As discussed on IRC: This doesn't fix the lack of a proper localization system, but it allows the plugin developers to implement their solutions untill Bukkit provides one, without depending on reflection crap. And even if Bukkit finally adds a localization system, someone might still implement it in a different way as it might suit his project better. I planned to open-source my implementation as a small independent library.

Addresses [BUKKIT-2220](https://bukkit.atlassian.net/browse/BUKKIT-2220)

CraftBukkit PR: https://github.com/Bukkit/CraftBukkit/pull/889
