### PR TITLE
Proposed new Player.switchTexturePack() API - BUKKIT-2579

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -554,4 +554,21 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      * @return The current allowed speed, from -1 to 1
      */
     public float getWalkSpeed();
+
+    /**
+     * Request that the player's client download and switch texture packs.
+     * <p />
+     * The player's client will download the new texture pack asynchronously in the background, and
+     * will automatically switch to it once the download is complete. If the client has downloaded
+     * and cached the same texture pack in the past, it will perform a quick timestamp check over
+     * the network to determine if the texture pack has changed and needs to be downloaded again.
+     * When this request is sent for the very first time from a given server, the client will first
+     * display a confirmation GUI to the player before proceeding with the download.
+     *
+     * @param url The URL from which the client will download the texture pack. The string must contain
+     * only US-ASCII characters and should be encoded as per RFC 1738.
+     * @throws IllegalArgumentException Thrown if the URL is null.
+     * @throws IllegalArgumentException Thrown if the URL is too long.
+     */
+    public void switchTexturePack(String url);
 }


### PR DESCRIPTION
This adds a new Player.switchTexturePack() API which causes the Minecraft client to download and switch to a new texture pack as specified by a URL. A new API call is necessary because using sendPluginMessage() directly to send the texture pack URL to the client's builtin "MC|TPack" channel is not supported. See https://bukkit.atlassian.net/browse/BUKKIT-2579 for details.

A working plugin which makes use of this new API is my modification to WorldGuard which adds a "texture-pack" region flag. As the client moves around on the server map, WorldGuard can have the client switch to different texture packs that are appropriate for that area of the map and/or dimension. See http://github.com/thvortex/worldguard/compare/master...texture-pack for details.
