### PR TITLE
Reduced the GUARANTEED_NO_WRAP_CHAT_PAGE_WIDTH.

### DIFF
--- a/src/main/java/org/bukkit/util/ChatPaginator.java
+++ b/src/main/java/org/bukkit/util/ChatPaginator.java
@@ -10,7 +10,7 @@ import java.util.List;
  * for displaying on the Minecraft player console.
  */
 public class ChatPaginator {
-    public static final int GUARANTEED_NO_WRAP_CHAT_PAGE_WIDTH = 55; // Will never wrap, even with the largest characters
+    public static final int GUARANTEED_NO_WRAP_CHAT_PAGE_WIDTH = 53; // Will never wrap, even with the largest characters
     public static final int AVERAGE_CHAT_PAGE_WIDTH = 65; // Will typically not wrap using an average character distribution
     public static final int UNBOUNDED_PAGE_WIDTH = Integer.MAX_VALUE;
     public static final int OPEN_CHAT_PAGE_HEIGHT = 20; // The height of an expanded chat window


### PR DESCRIPTION
If all hyphens <code>-</code> are used in the chat, the max number of characters is 53 not 55.
