### PR TITLE
Correctly rotate BlockFaces 90 degrees to the right

### DIFF
--- a/src/main/java/org/bukkit/block/BlockFace.java
+++ b/src/main/java/org/bukkit/block/BlockFace.java
@@ -129,4 +129,76 @@ public enum BlockFace {
 
         return BlockFace.SELF;
     }
+
+    /**
+     * Corrects BlockFaces to 90 degrees to the right. There is an
+     * inherent problem with the BlockFace to data-value mapping of
+     * directions that exists between the data value for direction
+     * and Bukkit's BlockFace implementation. The directions here are
+     * actually 90 degrees to the left of where they should be. I.E.:
+     * 
+     * BlockFace.WEST = Actually North
+     * BlockFace.SOUTH = Actually West
+     * etc.
+     * 
+     * This method corrects that. Anytime you require a representation of
+     * data value to BlockFace, use this method to correct the resulting
+     * BlockFace.
+     */
+    public static BlockFace correctBlockFace(BlockFace face) {
+        BlockFace correctFace = null;
+
+        switch (face) {
+            case WEST:
+                correctFace = BlockFace.NORTH;
+                break;
+            case WEST_NORTH_WEST:
+                correctFace = BlockFace.NORTH_NORTH_EAST;
+                break;
+            case NORTH_WEST:
+                correctFace = BlockFace.NORTH_EAST;
+                break;
+            case NORTH_NORTH_WEST:
+                correctFace = BlockFace.EAST_NORTH_EAST;
+                break;
+            case NORTH:
+                correctFace = BlockFace.EAST;
+                break;
+            case NORTH_NORTH_EAST:
+                correctFace = BlockFace.EAST_SOUTH_EAST;
+                break;
+            case NORTH_EAST:
+                correctFace = BlockFace.SOUTH_EAST;
+                break;
+            case EAST_NORTH_EAST:
+                correctFace = BlockFace.SOUTH_SOUTH_EAST;
+                break;
+            case EAST:
+                correctFace = BlockFace.SOUTH;
+                break;
+            case EAST_SOUTH_EAST:
+                correctFace = BlockFace.SOUTH_SOUTH_WEST;
+                break;
+            case SOUTH_EAST:
+                correctFace = BlockFace.SOUTH_WEST;
+                break;
+            case SOUTH_SOUTH_EAST:
+                correctFace = BlockFace.WEST_SOUTH_WEST;
+                break;
+            case SOUTH:
+                correctFace = BlockFace.WEST;
+                break;
+            case SOUTH_SOUTH_WEST:
+                correctFace = BlockFace.WEST_NORTH_WEST;
+                break;
+            case SOUTH_WEST:
+                correctFace = BlockFace.NORTH_WEST;
+                break;
+            case WEST_SOUTH_WEST:
+                correctFace = BlockFace.NORTH_NORTH_WEST;
+                break;
+        }
+
+        return correctFace;
+    }
 }

--- a/src/main/java/org/bukkit/block/BlockFace.java
+++ b/src/main/java/org/bukkit/block/BlockFace.java
@@ -144,61 +144,45 @@ public enum BlockFace {
      * This method corrects that. Anytime you require a representation of
      * data value to BlockFace, use this method to correct the resulting
      * BlockFace.
+     * @param BlockFace the block face that is being rotated
+     * @return the rotated block face, otherwise SELF if the block face is not applicable
      */
     public static BlockFace correctBlockFace(BlockFace face) {
-        BlockFace correctFace = null;
-
         switch (face) {
             case WEST:
-                correctFace = BlockFace.NORTH;
-                break;
+                return BlockFace.NORTH;
             case WEST_NORTH_WEST:
-                correctFace = BlockFace.NORTH_NORTH_EAST;
-                break;
+                return BlockFace.NORTH_NORTH_EAST;
             case NORTH_WEST:
-                correctFace = BlockFace.NORTH_EAST;
-                break;
+                return BlockFace.NORTH_EAST;
             case NORTH_NORTH_WEST:
-                correctFace = BlockFace.EAST_NORTH_EAST;
-                break;
+                return BlockFace.EAST_NORTH_EAST;
             case NORTH:
-                correctFace = BlockFace.EAST;
-                break;
+                return BlockFace.EAST;
             case NORTH_NORTH_EAST:
-                correctFace = BlockFace.EAST_SOUTH_EAST;
-                break;
+                return BlockFace.EAST_SOUTH_EAST;
             case NORTH_EAST:
-                correctFace = BlockFace.SOUTH_EAST;
-                break;
+                return BlockFace.SOUTH_EAST;
             case EAST_NORTH_EAST:
-                correctFace = BlockFace.SOUTH_SOUTH_EAST;
-                break;
+                return BlockFace.SOUTH_SOUTH_EAST;
             case EAST:
-                correctFace = BlockFace.SOUTH;
-                break;
+                return BlockFace.SOUTH;
             case EAST_SOUTH_EAST:
-                correctFace = BlockFace.SOUTH_SOUTH_WEST;
-                break;
+                return BlockFace.SOUTH_SOUTH_WEST;
             case SOUTH_EAST:
-                correctFace = BlockFace.SOUTH_WEST;
-                break;
+                return BlockFace.SOUTH_WEST;
             case SOUTH_SOUTH_EAST:
-                correctFace = BlockFace.WEST_SOUTH_WEST;
-                break;
+                return BlockFace.WEST_SOUTH_WEST;
             case SOUTH:
-                correctFace = BlockFace.WEST;
-                break;
+                return BlockFace.WEST;
             case SOUTH_SOUTH_WEST:
-                correctFace = BlockFace.WEST_NORTH_WEST;
-                break;
+                return BlockFace.WEST_NORTH_WEST;
             case SOUTH_WEST:
-                correctFace = BlockFace.NORTH_WEST;
-                break;
+                return BlockFace.NORTH_WEST;
             case WEST_SOUTH_WEST:
-                correctFace = BlockFace.NORTH_NORTH_WEST;
-                break;
+                return BlockFace.NORTH_NORTH_WEST;
         }
 
-        return correctFace;
+        return BlockFace.SELF;
     }
 }


### PR DESCRIPTION
There has been a longstanding issue with regard to data values that represent direction, and BlockFace values that mirror those data values. The issue lies in that the BlockFaces are actually 90 degrees to the left of where they should be. In a correct setting, the following values are assumed:

North = Z + 1
South = Z - 1
West = X - 1
East = X + 1

In the current BlockFace environment, these values are as follows:

North = X - 1
South = X + 1
West = Z + 1
East = Z - 1

This method rotates the current BlockFace to match the data values representing direction in various blocks in accordance with vanilla Minecraft.

It does not alter the enum itself, which allows future BlockFace representations to not interfere with this 90 degree offset issue. Simply call this method to correct your current representation.
