### PR TITLE
Gets and sets the age of a dropped item

### DIFF
--- a/src/main/java/org/bukkit/entity/Item.java
+++ b/src/main/java/org/bukkit/entity/Item.java
@@ -34,4 +34,18 @@ public interface Item extends Entity {
      * @param delay New delay
      */
     public void setPickupDelay(int delay);
+    
+    /**
+     * Gets the age of this item in the world
+     * 
+     * @return age of item
+     */
+    public int getAge();
+    
+    /**
+     * Sets the age of this item in the world
+     *
+     * @param age the new age of the item
+     */
+    public void setAge(int age);
 }


### PR DESCRIPTION
Normally, a specialized tick value of an entity is used to determine when a specific behavior of that entity should be processed. (I.E. TNT exploding after the primed entity has been first spawned.) A dropped item relies on an age variable defined in the class itself, that specifies how long it has been in the world.

This causes a problem, whereas the getTicksLived() and setTicksLived() methods inherited from the Entity class have no effect. You cannot use these methods to get/set a custom lifespan of this dropped item.

To resolve the issue, a getAge() and setAge() method has been implemented which will get/set the variable that will determine how long an item has been in the world.

CraftBukkit PR: https://github.com/Bukkit/CraftBukkit/pull/904
