### PR TITLE
Undeprecate previously unimplemented PotionEffects.

### DIFF
--- a/src/main/java/org/bukkit/potion/PotionEffectType.java
+++ b/src/main/java/org/bukkit/potion/PotionEffectType.java
@@ -77,8 +77,7 @@ public abstract class PotionEffectType {
     /**
      * Grants invisibility.
      */
-    @Deprecated
-    public static final PotionEffectType INVISIBILITY = new PotionEffectTypeWrapper(14); // unimplemented
+    public static final PotionEffectType INVISIBILITY = new PotionEffectTypeWrapper(14);
 
     /**
      * Blinds an entity.
@@ -88,8 +87,7 @@ public abstract class PotionEffectType {
     /**
      * Allows an entity to see in the dark.
      */
-    @Deprecated
-    public static final PotionEffectType NIGHT_VISION = new PotionEffectTypeWrapper(16); // unimplemented
+    public static final PotionEffectType NIGHT_VISION = new PotionEffectTypeWrapper(16);
 
     /**
      * Increases hunger.


### PR DESCRIPTION
Two PotionEffects added to the PotionEffectType enum have been implemented into the game, and as such should be undeprecated.

Leaky: https://bukkit.atlassian.net/browse/BUKKIT-2677
