### PR TITLE
BossEntity interface

### DIFF
--- a/src/main/java/org/bukkit/entity/BossEntity.java
+++ b/src/main/java/org/bukkit/entity/BossEntity.java
@@ -1,0 +1,6 @@
+package org.bukkit.entity;
+
+/**
+ * Represents a Boss Entity
+ */
+public interface BossEntity extends LivingEntity {}

--- a/src/main/java/org/bukkit/entity/EnderDragon.java
+++ b/src/main/java/org/bukkit/entity/EnderDragon.java
@@ -3,6 +3,4 @@ package org.bukkit.entity;
 /**
  * Represents an Ender Dragon
  */
-public interface EnderDragon extends ComplexLivingEntity {
-
-}
+public interface EnderDragon extends ComplexLivingEntity, BossEntity {}

--- a/src/main/java/org/bukkit/entity/Wither.java
+++ b/src/main/java/org/bukkit/entity/Wither.java
@@ -3,5 +3,4 @@ package org.bukkit.entity;
 /**
  * Represents a Wither boss
  */
-public interface Wither extends Monster {
-}
+public interface Wither extends Monster, BossEntity {}


### PR DESCRIPTION
Added a boss entity interface. This helps developers to search for bosses without requiring to search for every boss type (EnderDragon and Wither)
This will become more usefull when more bosses are added to minecraft.
And helps identifing "enemies" because EnderDragon is no Monster or a Creature.

https://bukkit.atlassian.net/browse/BUKKIT-2830
