### PR TITLE
Added new Skeleton and Zombie API

### DIFF
--- a/src/main/java/org/bukkit/entity/Skeleton.java
+++ b/src/main/java/org/bukkit/entity/Skeleton.java
@@ -3,4 +3,58 @@ package org.bukkit.entity;
 /**
  * Represents a Skeleton.
  */
-public interface Skeleton extends Monster {}
+public interface Skeleton extends Monster {
+    /**
+     * Gets the current type of this skeleton.
+     * 
+     * @return Current type
+     */
+    public SkeletonType getSkeletonType();
+    
+    /**
+     * Sets the new type of this skeleton.
+     * 
+     * @param type New type
+     */
+    public void setSkeletonType(SkeletonType type);
+    
+    /*
+     * Represents the various different Skeleton types there may be.
+     */
+    public enum SkeletonType {
+        NORMAL(0),
+        WITHER(1);
+        
+        private static final SkeletonType[] types = new SkeletonType[SkeletonType.values().length];
+        private final int id;
+        
+        static {
+            for (SkeletonType type : values()) {
+                types[type.getId()] = type;
+            }
+        }
+        
+        private SkeletonType(int id) {
+            this.id = id;
+        }
+        
+        /**
+         * Gets the ID of this skeleton type.
+         * 
+         * @return Skeleton type ID
+         */
+        public int getId() {
+            return id;
+        }
+        
+        /**
+         * Gets a skeleton type by its ID.
+         * 
+         * @param id ID of the skeleton type to get.
+         * @return Resulting skeleton type, or null if not found.
+         */
+        public static SkeletonType getType(int id) {
+            return (id >= types.length) ? null : types[id]; 
+        }
+    }
+}

--- a/src/main/java/org/bukkit/entity/Zombie.java
+++ b/src/main/java/org/bukkit/entity/Zombie.java
@@ -3,4 +3,32 @@ package org.bukkit.entity;
 /**
  * Represents a Zombie.
  */
-public interface Zombie extends Monster {}
+public interface Zombie extends Monster {
+    /**
+     * Gets whether the zombie is a baby
+     * 
+     * @return Whether the zombie is a baby
+     */
+    public boolean isBaby();
+
+    /**
+     * Sets whether the zombie is a baby
+     * 
+     * @param flag Whether the zombie is a baby
+     */
+    public void setBaby(boolean flag);
+
+    /**
+     * Gets whether the zombie is a villager
+     * 
+     * @return Whether the zombie is a villager
+     */
+    public boolean isVillager();
+
+    /**
+     * Sets whether the zombie is a villager
+     * 
+     * @param flag Whether the zombie is a villager
+     */
+    public void setVillager(boolean flag);
+}


### PR DESCRIPTION
Currently there is no way to distinguish between normal skeletons and Wither skeletons without hooking into CraftBukkit itself. This pull request adds `getSkeletonType()` and `setSkeletonType()` to the Skeleton interface, and a new `SkeletonType` enum for ease of use. I also added `isVillager`, `setVillager`, `getBaby` and `setBaby` to the Zombie interface.

Corresponding CraftBukkit Pull Request: https://github.com/Bukkit/CraftBukkit/pull/918
Ticket: https://bukkit.atlassian.net/browse/BUKKIT-2818
