### PR TITLE
[B+C] Added BrewRecipe, PotionIngredientMeta, and BrewEndEvent. Added getPotions() to Brew(End)Event, which returns an array of Potion objects. Fixes Bukkit-2441 and BUKKIT-1604.

### DIFF
--- a/src/main/java/org/bukkit/event/inventory/BrewEndEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/BrewEndEvent.java
@@ -5,16 +5,19 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.block.BlockEvent;
 import org.bukkit.inventory.BrewerInventory;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.Potion;
 
-public class BrewEvent extends BlockEvent implements Cancellable {
+public class BrewEndEvent extends BlockEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private BrewerInventory contents;
     private boolean cancelled;
+    private ItemStack ingredient;
 
-    public BrewEvent(Block brewer, BrewerInventory contents) {
+    public BrewEndEvent(Block brewer, BrewerInventory contents, ItemStack ingredient) {
         super(brewer);
         this.contents = contents;
+        this.ingredient = ingredient;
     }
 
     public BrewerInventory getContents() {
@@ -31,7 +34,11 @@ public class BrewEvent extends BlockEvent implements Cancellable {
             potions[2] = Potion.fromItemStack(contents.getContents()[2]);
         return potions;
     }
-    
+
+    public ItemStack getIngredient() {
+        return ingredient;
+    }
+
     public boolean isCancelled() {
         return cancelled;
     }

--- a/src/main/java/org/bukkit/inventory/BrewRecipe.java
+++ b/src/main/java/org/bukkit/inventory/BrewRecipe.java
@@ -1,7 +1,7 @@
 package org.bukkit.inventory;
 
 import org.bukkit.Material;
-import org.bukkit.potion.PotionBitSet;
+import org.bukkit.potion.PotionIngredientMeta;
 
 /**
  * Represents a brewing recipe.
@@ -10,7 +10,7 @@ public class BrewRecipe implements Recipe {
 
     private String bitString;
     private Material ingredient;
-    private PotionBitSet bitSet;
+    private PotionIngredientMeta bitSet;
 
     /**
      * Create a brewing recipe to brew the desired bit modifications into a
@@ -31,7 +31,7 @@ public class BrewRecipe implements Recipe {
      */
     public BrewRecipe(String bitModifier, Material input) {
         bitString = bitModifier;
-        bitSet = new PotionBitSet(bitModifier);
+        bitSet = new PotionIngredientMeta(bitModifier);
         ingredient = input;
     }
 
@@ -44,7 +44,7 @@ public class BrewRecipe implements Recipe {
      * @param input
      *            The ingredient to add.
      */
-    public BrewRecipe(PotionBitSet bitSet, Material input) {
+    public BrewRecipe(PotionIngredientMeta bitSet, Material input) {
         bitString = bitSet.getBitString();
         this.bitSet = bitSet;
         ingredient = input;
@@ -58,7 +58,7 @@ public class BrewRecipe implements Recipe {
      */
     @Override
     public ItemStack getResult() {
-        return new ItemStack(Material.POTION, 1, PotionBitSet.getFinalBits(16, bitString));
+        return new ItemStack(Material.POTION, 1, PotionIngredientMeta.getFinalBits(16, bitString));
     }
 
     /**
@@ -84,7 +84,7 @@ public class BrewRecipe implements Recipe {
      * 
      * @return Returns the bit modifier as a PotionBitSet
      */
-    public PotionBitSet getPotionBitSet() {
+    public PotionIngredientMeta getPotionBitSet() {
         return bitSet;
     }
 

--- a/src/main/java/org/bukkit/inventory/BrewRecipe.java
+++ b/src/main/java/org/bukkit/inventory/BrewRecipe.java
@@ -1,0 +1,91 @@
+package org.bukkit.inventory;
+
+import org.bukkit.Material;
+import org.bukkit.potion.PotionBitSet;
+
+/**
+ * Represents a brewing recipe.
+ */
+public class BrewRecipe implements Recipe {
+
+    private String bitString;
+    private Material ingredient;
+    private PotionBitSet bitSet;
+
+    /**
+     * Create a brewing recipe to brew the desired bit modifications into a
+     * potion. The bit string modifies the different bit values in the potion's
+     * damage, which is stored as a short. The bit modifier string syntax is as
+     * follows: [+/-/&/!][number]. + sets bit, - retracts. & checks if bit is
+     * set, ! checks if it isn't.
+     * 
+     * If a check fails, the potion will refuse to brew. Most recipes have an &4
+     * to check if the potion is an awkward potion. For more info on different
+     * potion bits, see http://tinyurl.com/potionbits
+     * 
+     * @param bitModifier
+     *            The bits to modify. Example: +0-1-2-3&4-4+13 creates a potion
+     *            of regeneration.
+     * @param input
+     *            The ingredient to add.
+     */
+    public BrewRecipe(String bitModifier, Material input) {
+        bitString = bitModifier;
+        bitSet = new PotionBitSet(bitModifier);
+        ingredient = input;
+    }
+
+    /**
+     * Create a brewing recipe to brew the desired bit modifications into a
+     * potion.
+     * 
+     * @param bitSet
+     *            A PotionBitSet which sets what the potion will brew into.
+     * @param input
+     *            The ingredient to add.
+     */
+    public BrewRecipe(PotionBitSet bitSet, Material input) {
+        bitString = bitSet.getBitString();
+        this.bitSet = bitSet;
+        ingredient = input;
+    }
+
+    /**
+     * Returns the resulting potion with the added ingredient.
+     * 
+     * @return Returns the most basic level potion that can be created with this
+     *         recipe as an ItemStack.
+     */
+    @Override
+    public ItemStack getResult() {
+        return new ItemStack(Material.POTION, 1, PotionBitSet.getFinalBits(16, bitString));
+    }
+
+    /**
+     * Returns the ingredient to be added to the potion.
+     * 
+     * @return Returns the added ingredient as a Material
+     */
+    public Material getInput() {
+        return ingredient;
+    }
+
+    /**
+     * Returns the bit modifier string passed to NMS
+     * 
+     * @return Returns the bit modifier string passed to NMS as a String
+     */
+    public String getBitModifier() {
+        return bitString;
+    }
+
+    /**
+     * Returns the bit modifier as a PotionBitSet
+     * 
+     * @return Returns the bit modifier as a PotionBitSet
+     */
+    public PotionBitSet getPotionBitSet() {
+        return bitSet;
+    }
+
+}

--- a/src/main/java/org/bukkit/potion/PotionBitSet.java
+++ b/src/main/java/org/bukkit/potion/PotionBitSet.java
@@ -1,0 +1,670 @@
+package org.bukkit.potion;
+
+public class PotionBitSet {
+
+    private boolean[] bitArray = new boolean[16];
+    private boolean[] setFalse = new boolean[16];
+    private boolean[] bitCheckIf = new boolean[16];
+    private boolean[] bitCheckNot = new boolean[16];
+    public int baseID = 0;
+
+    public enum PotionBase {
+        /**
+         * Represents a water bottle
+         */
+        WATER,
+        /**
+         * Represents an awkward potion
+         */
+        AWKWARD, 
+        /**
+         * Represents a thick potion.
+         */
+        THICK, 
+        /**
+         * Represents a mundane potion
+         */
+        MUNDANE,
+    }
+
+    public enum PotionBit {
+        /**
+         * Represents bit 0
+         */
+        ZERO(0), 
+
+        /**
+         * Represents bit 1
+         */
+        ONE(1),
+
+        /**
+         * Represents bit 2
+         */
+        TWO(2), 
+
+        /**
+         * Represents bit 3
+         */
+        THREE(3), 
+
+        /**
+         * Represents the effect bits (bits 0-3)
+         */
+        EFFECT(new int[] { 0, 1, 2, 3 }), 
+
+        /**
+         * Represents the bit that modifies whether the potion is a level II potion or not
+         */
+        LEVELII(5), 
+
+        /**
+         * Represents the bit that modifies whether the potion is an extended potion or not
+         */
+        EXTENDED(6), 
+
+        /**
+         * Represents the bit that sets a potion as drinkable
+         */
+        DRINKABLE(13),
+
+        /**
+         * Represents the bit that sets a potion as throwable
+         */
+        THROWABLE(14), 
+
+        /**
+         * Represents the bit that is set when a potion is an awkward potion
+         */
+        AWKWARD(4),
+
+        /**
+         * Represents the bit that is set when a potion is an thick potion
+         */
+        THICK(5), 
+
+        /**
+         * Represents the bit that is set when a potion is an mundane potion
+         */
+        MUNDANE(6), 
+
+        /**
+         * Represents the unused bits, (bits 7-12, 15)
+         */
+        UNKNOWN(new int[] { 7, 8, 9, 10, 11, 12, 15 });
+
+        private int[] bits;
+
+        PotionBit(int[] bits) {
+            this.bits = bits.clone();
+        }
+
+        PotionBit(int bit) {
+            this.bits = new int[] { bit };
+        }
+
+        public int[] getBits() {
+            return bits.clone();
+        }
+
+        public int getBit() {
+            if (this != UNKNOWN && this != EFFECT)
+                return getBits()[0]; // Only return bit if it doesn't consist of multiple bits
+            else
+                return -1; // Return -1 on bit arrays
+        }
+    }
+
+    /**
+     * Instantiates a PotionBitSet class to be used with BrewRecipe.
+     * 
+     * @param type
+     *            Type of the potion to be brewed as an integer less than 16
+     * @param levelII
+     *            Sets whether the potion is a level II or not
+     * @param extended
+     *            Sets whether the potion is extended or not
+     * @param splash
+     *            Sets whether the potion is a splash potion or not
+     * @param base
+     *            Sets whether the potion is based upon an awkward potion
+     *            or not.
+     */
+    public PotionBitSet(int type, boolean levelII, boolean extended, boolean splash, PotionBase base) {
+        baseID = type;
+        String bits = Integer.toBinaryString(type);
+        while(bits.length() < 4)
+            bits = "0" + bits;
+        int count = 0;
+        for (int i = 3; i >= 0; i--) {
+            if (bits.charAt(i) == '1')
+                bitArray[count] = true;
+            else
+                setFalse[count] = true;
+            count++;
+        }
+
+        if (levelII)
+            bitArray[5] = true;
+        if (extended)
+            bitArray[6] = true;
+        if (splash)
+            bitArray[14] = true;
+        else
+            bitArray[13] = true;
+
+        switch (base) {
+            case AWKWARD:
+                bitCheckIf[4] = true;
+                setFalse[4] = true;
+                break;
+            case THICK:
+                bitCheckIf[5] = true;
+                setFalse[5] = true;
+                break;
+            case MUNDANE:
+                bitCheckIf[6] = true;
+                setFalse[6] = true;
+                break;
+            case WATER:
+            default:
+                break;
+        }
+    }
+
+    /**
+     * Instantiates a PotionBitSet class to be used with BrewRecipe.
+     * 
+     * @param type
+     *            Type of the potion to be brewed
+     * @param levelII
+     *            Sets whether the potion is a level II or not
+     * @param extended
+     *            Sets whether the potion is extended or not
+     * @param splash
+     *            Sets whether the potion is a splash potion
+     */
+    public PotionBitSet(int type, boolean levelII, boolean extended, boolean splash) {
+        this(type, levelII, extended, splash, true);
+    }
+
+    /**
+     * Instantiates a PotionBitSet class to be used with BrewRecipe.
+     * 
+     * @param type
+     *            Type of the potion to be brewed
+     * @param levelII
+     *            Sets whether the potion is a level II or not
+     * @param extended
+     *            Sets whether the potion is extended or not
+     * @param splash
+     *            Sets whether the potion is a splash potion
+     * @param awkwardBase
+     *            Sets whether the potion is based upon an awkward potion
+     *            or not.
+     */
+    public PotionBitSet(int type, boolean levelII, boolean extended, boolean splash, boolean awkwardBase) {
+        this(type, levelII, extended, splash, PotionBase.AWKWARD);
+    }
+
+    /**
+     * Instantiates a PotionBitSet class to be used with BrewRecipe.
+     * 
+     * @param type
+     *            Type of the potion to be brewed
+     * @param levelII
+     *            Sets whether the potion is a level II or not
+     * @param extended
+     *            Sets whether the potion is extended or not
+     * @param splash
+     *            Sets whether the potion is a splash potion
+     * @param base
+     *            Sets whether the potion is based upon an awkward potion
+     *            or not.
+     */
+    public PotionBitSet(PotionType type, boolean levelII, boolean extended, boolean splash, PotionBase base) {
+        this(type.getDamageValue(), levelII, extended, splash, base);
+    }
+
+    /**
+     * Instantiates a PotionBitSet class to be used with BrewRecipe.
+     * 
+     * @param type
+     *            Type of the potion to be brewed
+     * @param levelII
+     *            Sets whether the potion is a level II or not
+     * @param extended
+     *            Sets whether the potion is extended or not
+     * @param splash
+     *            Sets whether the potion is a splash potion
+     */
+    public PotionBitSet(PotionType type, boolean levelII, boolean extended, boolean splash) {
+        this(type, levelII, extended, splash, true);
+    }
+
+    /**
+     * Instantiates a PotionBitSet class to be used with BrewRecipe.
+     * 
+     * @param type
+     *            Type of the potion to be brewed
+     * @param levelII
+     *            Sets whether the potion is a level II or not
+     * @param extended
+     *            Sets whether the potion is extended or not
+     * @param splash
+     *            Sets whether the potion is a splash potion
+     * @param awkwardBase
+     *            Sets whether the potion is based upon an awkward potion
+     *            or not.
+     */
+    public PotionBitSet(PotionType type, boolean levelII, boolean extended, boolean splash, boolean awkwardBase) {
+        this(type, levelII, extended, splash, PotionBase.AWKWARD);
+    }
+
+    /**
+     * Instantiates a PotionBitSet class to be used with BrewRecipe with a bit
+     * string
+     * 
+     * @param bitString
+     *            The bit string to be used
+     */
+    public PotionBitSet(String bitString) {
+        PotionBase base = PotionBase.WATER;
+        if (bitString.contains("&4-4"))
+            base = PotionBase.AWKWARD;
+        if (bitString.contains("&5-5"))
+            base = PotionBase.THICK;
+        if (bitString.contains("&6-6"))
+            base = PotionBase.MUNDANE;
+
+        String bits;
+        if (base == PotionBase.AWKWARD)
+            bits = Integer.toBinaryString(getFinalBits(16, bitString));
+        else if (base == PotionBase.THICK)
+            bits = Integer.toBinaryString(getFinalBits(32, bitString));
+        else if (base == PotionBase.MUNDANE)
+            bits = Integer.toBinaryString(getFinalBits(64, bitString));
+        else
+            bits = Integer.toBinaryString(getFinalBits(0, bitString));
+        for (int i = 0; i < bits.length(); i++)
+            if (bits.charAt(i) == '1')
+                bitArray[i] = true;
+            else
+                setFalse[i] = true;
+
+        bits = "" + bits.charAt(0) + bits.charAt(1) + bits.charAt(2) + bits.charAt(3);
+        baseID = Integer.parseInt(bits,2);
+    }
+
+    /**
+     * Instantiates a PotionBitSet class to be used with BrewRecipe with a bit
+     * string.
+     * 
+     * @param bitString
+     *            The bit string to be used
+     * @param awkwardBase
+     *            Sets whether the potion is based upon an awkward potion or
+     *            not.
+     */
+    public PotionBitSet(String bitString, boolean awkwardBase) {
+        String bits;
+        if (awkwardBase)
+            bits = Integer.toBinaryString(getFinalBits(16, bitString));
+        else
+            bits = Integer.toBinaryString(getFinalBits(0, bitString));
+        while(bits.length() < 17)
+            bits = "0" + bits;
+        for (int i = 0; i < 17; i++)
+            if (bits.charAt(i) == '1')
+                bitArray[i] = true;
+            else
+                setFalse[i] = true;
+
+        bits = "" + bits.charAt(0) + bits.charAt(1) + bits.charAt(2) + bits.charAt(3);
+        baseID = Integer.parseInt(bits,2);
+    }
+
+    /**
+     * Instantiates a PotionBitSet class to be used with BrewRecipe with a bit
+     * string.
+     * 
+     * @param bitString
+     *            The bit string to be used
+     * @param base
+     *            Which type of potion this one will base off of.
+     */
+    public PotionBitSet(String bitString, PotionBase base) {
+        String bits;
+        if (base == PotionBase.AWKWARD)
+            bits = Integer.toBinaryString(getFinalBits(16, bitString));
+        else if (base == PotionBase.THICK)
+            bits = Integer.toBinaryString(getFinalBits(32, bitString));
+        else if (base == PotionBase.MUNDANE)
+            bits = Integer.toBinaryString(getFinalBits(64, bitString));
+        else
+            bits = Integer.toBinaryString(getFinalBits(0, bitString));
+
+        while(bits.length() < 17)
+            bits = "0" + bits;
+
+        for (int i = 0; i < 17; i++)
+            if (bits.charAt(i) == '1')
+                bitArray[i] = true;
+            else
+                setFalse[i] = true;
+
+        bits = "" + bits.charAt(0) + bits.charAt(1) + bits.charAt(2) + bits.charAt(3);
+        baseID = Integer.parseInt(bits,2);
+    }
+
+    public String getBitString() {
+        String bits = "";
+        for (int i = 0; i < 16; i++) {
+            if (bitCheckIf[i] == bitCheckNot[i])
+                bitCheckIf[i] = bitCheckNot[i] = false;
+
+            if (bitCheckIf[i])
+                bits += "&" + i;
+            if (bitCheckNot[i])
+                bits += "!" + i;
+
+            if (bitArray[i])
+                bits += "+" + i;
+            else if (!bitArray[i] && (i < 4 || setFalse[i]))
+                bits += "-" + i;
+
+        }
+        return bits;
+    }
+
+    /**
+     * Sets a specified bit as set or unset
+     * 
+     * @param i
+     *            Bit to set
+     * @param set
+     *            Value (true as set or false as unset) to set them to
+     */
+    public PotionBitSet setBit(int i, boolean set) {
+        if (!set)
+            setFalse[i] = true;
+        bitArray[i] = set;
+        return this;
+    }
+
+    /**
+     * Checks a specified bit as set
+     * 
+     * @param i
+     *            Bit to set
+     * @param set
+     *            Value (true as set or false as unset) to set them to
+     */
+    public PotionBitSet setCheckIf(int i, boolean check) {
+        bitCheckIf[i] = check;
+        return this;
+    }
+
+    /**
+     * Sets a specified bit as unset
+     * 
+     * @param i
+     *            Bit to set
+     * @param set
+     *            Value (true as set or false as unset) to set them to
+     */
+    public PotionBitSet setCheckNot(int i, boolean check) {
+        bitCheckNot[i] = check;
+        return this;
+    }
+
+    /**
+     * Sets multiple bits to a single value
+     * 
+     * @param ia
+     *            Integer Array of the different bits to set
+     * @param set
+     *            Value (true as set or false as unset) to set them to
+     */
+    public PotionBitSet setBits(int[] ia, boolean set) {
+        for (int i : ia) {
+            if (!set)
+                setFalse[i] = true;
+            bitArray[i] = set;
+        }
+        return this;
+    }
+
+    /**
+     * Sets multiple bits to be checked as set
+     * 
+     * @param ia
+     *            Integer Array of the different bits to set
+     * @param set
+     *            Value (true as set or false as unset) to set them to
+     */
+    public PotionBitSet setCheckIf(int[] ia, boolean check) {
+        for (int i : ia)
+            bitCheckIf[i] = check;
+        return this;
+    }
+
+    /**
+     * Sets multiple bits to be checked as unset
+     * 
+     * @param ia
+     *            Integer Array of the different bits to set
+     * @param set
+     *            Value (true as set or false as unset) to set them to
+     */
+    public PotionBitSet setCheckNot(int[] ia, boolean check) {
+        for (int i : ia)
+            bitCheckNot[i] = check;
+        return this;
+    }
+
+    /**
+     * Sets a specified bit as set or unset
+     * 
+     * @param i
+     *            Bit to set
+     * @param set
+     *            Value (true as set or false as unset) to set them to
+     */
+    public PotionBitSet setBit(PotionBit bit, boolean set) {
+        if (!set)
+            setFalse[bit.getBit()] = true;
+
+        if (bit != PotionBit.EFFECT)
+            bitArray[bit.getBit()] = set;
+        return this;
+    }
+
+    /**
+     * Checks a specified bit as set
+     * 
+     * @param i
+     *            Bit to set
+     * @param set
+     *            Value (true as set or false as unset) to set them to
+     */
+    public PotionBitSet setCheckIf(PotionBit bit, boolean check) {
+        if (bit != PotionBit.EFFECT)
+            bitCheckIf[bit.getBit()] = check;
+        return this;
+    }
+
+    /**
+     * Sets a specified bit as unset
+     * 
+     * @param i
+     *            Bit to set
+     * @param set
+     *            Value (true as set or false as unset) to set them to
+     */
+    public PotionBitSet setCheckNot(PotionBit bit, boolean check) {
+        if (bit != PotionBit.EFFECT)
+            bitCheckNot[bit.getBit()] = check;
+        return this;
+    }
+
+    /**
+     * Sets multiple bits to a single value
+     * 
+     * @param ia
+     *            Integer Array of the different bits to set
+     * @param set
+     *            Value (true as set or false as unset) to set them to
+     */
+    public PotionBitSet setBits(PotionBit[] bits, boolean set) {
+        int length = bits.length;
+        for (PotionBit bit : bits)
+            if (bit == PotionBit.EFFECT)
+                length += 4;
+
+        int[] ia = new int[length];
+        for (int i = 0; i < length; i++) {
+            if (!set)
+                setFalse[bits[i].getBit()] = true;
+
+            if (bits[i] == PotionBit.EFFECT) {
+                ia[i] = bits[i].bits[0];
+                ia[i + 1] = bits[i].bits[1];
+                ia[i + 2] = bits[i].bits[2];
+                ia[i + 3] = bits[i].bits[3];
+                i += 3;
+            } else
+                ia[i] = bits[i].getBit();
+        }
+
+        for (int i : ia)
+            bitArray[i] = set;
+        return this;
+    }
+
+    /**
+     * Sets multiple bits to be checked as set
+     * 
+     * @param ia
+     *            Integer Array of the different bits to set
+     * @param set
+     *            Value (true as set or false as unset) to set them to
+     */
+    public PotionBitSet setCheckIf(PotionBit[] bits, boolean check) {
+        int[] ia = new int[bits.length];
+        for (int i = 0; i < bits.length; i++)
+            ia[i] = bits[i].getBit();
+
+        for (int i : ia)
+            bitCheckIf[i] = check;
+        return this;
+    }
+
+    /**
+     * Sets multiple bits to be checked as unset
+     * 
+     * @param ia
+     *            Integer Array of the different bits to set
+     * @param set
+     *            Value (true as set or false as unset) to set them to
+     */
+    public PotionBitSet setCheckNot(PotionBit[] bits, boolean check) {
+        int[] ia = new int[bits.length];
+        for (int i = 0; i < bits.length; i++)
+            ia[i] = bits[i].getBit();
+
+        for (int i : ia)
+            bitCheckNot[i] = check;
+        return this;
+    }
+
+    /**
+     * This code was borrowed from PotionBrewer.java from NMS to be used for
+     * getResult().
+     */
+    public static short getFinalBits(int paramInt, String paramString) {
+        int m = 0;
+        int n = paramString.length();
+
+        int i1 = 0;
+        boolean bool1 = false;
+        boolean bool2 = false;
+        boolean bool3 = false;
+        int i2 = 0;
+        for (int i3 = m; i3 < n; i3++) {
+            int i4 = paramString.charAt(i3);
+            if ((i4 >= 48) && (i4 <= 57)) {
+                i2 *= 10;
+                i2 += i4 - 48;
+                i1 = 1;
+            } else if (i4 == 33) {
+                if (i1 != 0) {
+                    paramInt = a(paramInt, i2, bool2, bool1, bool3);
+                    i1 = 0;
+                    bool3 = bool2 = bool1 = false;
+                    i2 = 0;
+                }
+
+                bool1 = true;
+            } else if (i4 == 45) {
+                if (i1 != 0) {
+                    paramInt = a(paramInt, i2, bool2, bool1, bool3);
+                    i1 = 0;
+                    bool3 = bool2 = bool1 = false;
+                    i2 = 0;
+                }
+
+                bool2 = true;
+            } else if (i4 == 43) {
+                if (i1 != 0) {
+                    paramInt = a(paramInt, i2, bool2, bool1, bool3);
+                    i1 = 0;
+                    bool3 = bool2 = bool1 = false;
+                    i2 = 0;
+                }
+            } else if (i4 == 38) {
+                if (i1 != 0) {
+                    paramInt = a(paramInt, i2, bool2, bool1, bool3);
+                    i1 = 0;
+                    bool3 = bool2 = bool1 = false;
+                    i2 = 0;
+                }
+                bool3 = true;
+            }
+        }
+        if (i1 != 0) {
+            paramInt = a(paramInt, i2, bool2, bool1, bool3);
+        }
+
+        return (short) (paramInt & 0x7FFF);
+    }
+
+    /**
+     * This code was borrowed from PotionBrewer.java from NMS to be used for
+     * getResult().
+     */
+    private static int a(int paramInt1, int paramInt2, boolean paramBoolean1, boolean paramBoolean2, boolean paramBoolean3) {
+        if (paramBoolean3) {
+            if (!a(paramInt1, paramInt2))
+                return 0;
+        } else if (paramBoolean1)
+            paramInt1 &= (1 << paramInt2 ^ 0xFFFFFFFF);
+        else if (paramBoolean2) {
+            if ((paramInt1 & 1 << paramInt2) == 0)
+                paramInt1 |= 1 << paramInt2;
+            else
+                paramInt1 &= (1 << paramInt2 ^ 0xFFFFFFFF);
+        } else {
+            paramInt1 |= 1 << paramInt2;
+        }
+        return paramInt1;
+    }
+
+    /**
+     * This code was borrowed from PotionBrewer.java from NMS to be used for
+     * getResult().
+     */
+    private static boolean a(int paramInt1, int paramInt2) {
+        return (paramInt1 & 1 << paramInt2) != 0;
+    }
+}

--- a/src/main/java/org/bukkit/potion/PotionEffectType.java
+++ b/src/main/java/org/bukkit/potion/PotionEffectType.java
@@ -10,6 +10,11 @@ import org.apache.commons.lang.Validate;
  */
 public abstract class PotionEffectType {
     /**
+     * No effect
+     */
+    public static final PotionEffectType NONE = new PotionEffectTypeWrapper(0);
+    
+    /**
      * Increases movement speed.
      */
     public static final PotionEffectType SPEED = new PotionEffectTypeWrapper(1);

--- a/src/main/java/org/bukkit/potion/PotionIngredientMeta.java
+++ b/src/main/java/org/bukkit/potion/PotionIngredientMeta.java
@@ -1,6 +1,6 @@
 package org.bukkit.potion;
 
-public class PotionBitSet {
+public class PotionIngredientMeta {
 
     private boolean[] bitArray = new boolean[16];
     private boolean[] setFalse = new boolean[16];
@@ -18,14 +18,14 @@ public class PotionBitSet {
          */
         AWKWARD, 
         /**
-         * Represents a thick potion.
+         * Represents a thick potion
          */
         THICK, 
         /**
          * Represents a mundane potion
          */
         MUNDANE,
-    }
+    }   
 
     public enum PotionBit {
         /**
@@ -107,6 +107,10 @@ public class PotionBitSet {
             return bits.clone();
         }
 
+        /**
+         * Gets the specified bit as an integer. Returns -1 on arrays.
+         * @return
+         */
         public int getBit() {
             if (this != UNKNOWN && this != EFFECT)
                 return getBits()[0]; // Only return bit if it doesn't consist of multiple bits
@@ -116,7 +120,7 @@ public class PotionBitSet {
     }
 
     /**
-     * Instantiates a PotionBitSet class to be used with BrewRecipe.
+     * Instantiates a PotionIngredientMeta class to be used with BrewRecipe.
      * 
      * @param type
      *            Type of the potion to be brewed as an integer less than 16
@@ -127,10 +131,9 @@ public class PotionBitSet {
      * @param splash
      *            Sets whether the potion is a splash potion or not
      * @param base
-     *            Sets whether the potion is based upon an awkward potion
-     *            or not.
+     *            Sets the base potion this ingredient will require 
      */
-    public PotionBitSet(int type, boolean levelII, boolean extended, boolean splash, PotionBase base) {
+    public PotionIngredientMeta(int type, boolean levelII, boolean extended, boolean splash, PotionBase base) {
         baseID = type;
         String bits = Integer.toBinaryString(type);
         while(bits.length() < 4)
@@ -173,7 +176,7 @@ public class PotionBitSet {
     }
 
     /**
-     * Instantiates a PotionBitSet class to be used with BrewRecipe.
+     * Instantiates a PotionIngredientMeta class to be used with BrewRecipe.
      * 
      * @param type
      *            Type of the potion to be brewed
@@ -184,12 +187,12 @@ public class PotionBitSet {
      * @param splash
      *            Sets whether the potion is a splash potion
      */
-    public PotionBitSet(int type, boolean levelII, boolean extended, boolean splash) {
+    public PotionIngredientMeta(int type, boolean levelII, boolean extended, boolean splash) {
         this(type, levelII, extended, splash, true);
     }
 
     /**
-     * Instantiates a PotionBitSet class to be used with BrewRecipe.
+     * Instantiates a PotionIngredientMeta class to be used with BrewRecipe.
      * 
      * @param type
      *            Type of the potion to be brewed
@@ -203,12 +206,12 @@ public class PotionBitSet {
      *            Sets whether the potion is based upon an awkward potion
      *            or not.
      */
-    public PotionBitSet(int type, boolean levelII, boolean extended, boolean splash, boolean awkwardBase) {
+    public PotionIngredientMeta(int type, boolean levelII, boolean extended, boolean splash, boolean awkwardBase) {
         this(type, levelII, extended, splash, PotionBase.AWKWARD);
     }
 
     /**
-     * Instantiates a PotionBitSet class to be used with BrewRecipe.
+     * Instantiates a PotionIngredientMeta class to be used with BrewRecipe.
      * 
      * @param type
      *            Type of the potion to be brewed
@@ -219,15 +222,14 @@ public class PotionBitSet {
      * @param splash
      *            Sets whether the potion is a splash potion
      * @param base
-     *            Sets whether the potion is based upon an awkward potion
-     *            or not.
+     *            Sets the base potion this ingredient will require
      */
-    public PotionBitSet(PotionType type, boolean levelII, boolean extended, boolean splash, PotionBase base) {
+    public PotionIngredientMeta(PotionType type, boolean levelII, boolean extended, boolean splash, PotionBase base) {
         this(type.getDamageValue(), levelII, extended, splash, base);
     }
 
     /**
-     * Instantiates a PotionBitSet class to be used with BrewRecipe.
+     * Instantiates a PotionIngredientMeta class to be used with BrewRecipe.
      * 
      * @param type
      *            Type of the potion to be brewed
@@ -238,12 +240,12 @@ public class PotionBitSet {
      * @param splash
      *            Sets whether the potion is a splash potion
      */
-    public PotionBitSet(PotionType type, boolean levelII, boolean extended, boolean splash) {
+    public PotionIngredientMeta(PotionType type, boolean levelII, boolean extended, boolean splash) {
         this(type, levelII, extended, splash, true);
     }
 
     /**
-     * Instantiates a PotionBitSet class to be used with BrewRecipe.
+     * Instantiates a PotionIngredientMeta class to be used with BrewRecipe.
      * 
      * @param type
      *            Type of the potion to be brewed
@@ -257,18 +259,18 @@ public class PotionBitSet {
      *            Sets whether the potion is based upon an awkward potion
      *            or not.
      */
-    public PotionBitSet(PotionType type, boolean levelII, boolean extended, boolean splash, boolean awkwardBase) {
+    public PotionIngredientMeta(PotionType type, boolean levelII, boolean extended, boolean splash, boolean awkwardBase) {
         this(type, levelII, extended, splash, PotionBase.AWKWARD);
     }
 
     /**
-     * Instantiates a PotionBitSet class to be used with BrewRecipe with a bit
+     * Instantiates a PotionIngredientMeta class to be used with BrewRecipe with a bit
      * string
      * 
      * @param bitString
      *            The bit string to be used
      */
-    public PotionBitSet(String bitString) {
+    public PotionIngredientMeta(String bitString) {
         PotionBase base = PotionBase.WATER;
         if (bitString.contains("&4-4"))
             base = PotionBase.AWKWARD;
@@ -297,7 +299,7 @@ public class PotionBitSet {
     }
 
     /**
-     * Instantiates a PotionBitSet class to be used with BrewRecipe with a bit
+     * Instantiates a PotionIngredientMeta class to be used with BrewRecipe with a bit
      * string.
      * 
      * @param bitString
@@ -306,7 +308,7 @@ public class PotionBitSet {
      *            Sets whether the potion is based upon an awkward potion or
      *            not.
      */
-    public PotionBitSet(String bitString, boolean awkwardBase) {
+    public PotionIngredientMeta(String bitString, boolean awkwardBase) {
         String bits;
         if (awkwardBase)
             bits = Integer.toBinaryString(getFinalBits(16, bitString));
@@ -325,15 +327,15 @@ public class PotionBitSet {
     }
 
     /**
-     * Instantiates a PotionBitSet class to be used with BrewRecipe with a bit
+     * Instantiates a PotionIngredientMeta class to be used with BrewRecipe with a bit
      * string.
      * 
      * @param bitString
      *            The bit string to be used
      * @param base
-     *            Which type of potion this one will base off of.
+     *            Sets the base potion this ingredient will require
      */
-    public PotionBitSet(String bitString, PotionBase base) {
+    public PotionIngredientMeta(String bitString, PotionBase base) {
         String bits;
         if (base == PotionBase.AWKWARD)
             bits = Integer.toBinaryString(getFinalBits(16, bitString));
@@ -385,7 +387,7 @@ public class PotionBitSet {
      * @param set
      *            Value (true as set or false as unset) to set them to
      */
-    public PotionBitSet setBit(int i, boolean set) {
+    public PotionIngredientMeta setBit(int i, boolean set) {
         if (!set)
             setFalse[i] = true;
         bitArray[i] = set;
@@ -393,27 +395,27 @@ public class PotionBitSet {
     }
 
     /**
-     * Checks a specified bit as set
+     * Sets if a specified bit should be checked as set
      * 
      * @param i
      *            Bit to set
      * @param set
      *            Value (true as set or false as unset) to set them to
      */
-    public PotionBitSet setCheckIf(int i, boolean check) {
+    public PotionIngredientMeta setCheckIfSet(int i, boolean check) {
         bitCheckIf[i] = check;
         return this;
     }
 
     /**
-     * Sets a specified bit as unset
+     * Sets if a specified bit should be checked as unset
      * 
      * @param i
      *            Bit to set
      * @param set
      *            Value (true as set or false as unset) to set them to
      */
-    public PotionBitSet setCheckNot(int i, boolean check) {
+    public PotionIngredientMeta setCheckNotSet(int i, boolean check) {
         bitCheckNot[i] = check;
         return this;
     }
@@ -426,7 +428,7 @@ public class PotionBitSet {
      * @param set
      *            Value (true as set or false as unset) to set them to
      */
-    public PotionBitSet setBits(int[] ia, boolean set) {
+    public PotionIngredientMeta setBits(int[] ia, boolean set) {
         for (int i : ia) {
             if (!set)
                 setFalse[i] = true;
@@ -436,28 +438,28 @@ public class PotionBitSet {
     }
 
     /**
-     * Sets multiple bits to be checked as set
+     * Checks an array of bits as set
      * 
      * @param ia
      *            Integer Array of the different bits to set
      * @param set
      *            Value (true as set or false as unset) to set them to
      */
-    public PotionBitSet setCheckIf(int[] ia, boolean check) {
+    public PotionIngredientMeta setCheckIfSet(int[] ia, boolean check) {
         for (int i : ia)
             bitCheckIf[i] = check;
         return this;
     }
 
     /**
-     * Sets multiple bits to be checked as unset
+     * Checks an array of bits as unset
      * 
      * @param ia
      *            Integer Array of the different bits to set
      * @param set
      *            Value (true as set or false as unset) to set them to
      */
-    public PotionBitSet setCheckNot(int[] ia, boolean check) {
+    public PotionIngredientMeta setCheckNotSet(int[] ia, boolean check) {
         for (int i : ia)
             bitCheckNot[i] = check;
         return this;
@@ -471,7 +473,7 @@ public class PotionBitSet {
      * @param set
      *            Value (true as set or false as unset) to set them to
      */
-    public PotionBitSet setBit(PotionBit bit, boolean set) {
+    public PotionIngredientMeta setBit(PotionBit bit, boolean set) {
         if (!set)
             setFalse[bit.getBit()] = true;
 
@@ -481,28 +483,28 @@ public class PotionBitSet {
     }
 
     /**
-     * Checks a specified bit as set
+     * Sets if a specified bit should be checked as set
      * 
      * @param i
      *            Bit to set
      * @param set
      *            Value (true as set or false as unset) to set them to
      */
-    public PotionBitSet setCheckIf(PotionBit bit, boolean check) {
+    public PotionIngredientMeta setCheckIfSet(PotionBit bit, boolean check) {
         if (bit != PotionBit.EFFECT)
             bitCheckIf[bit.getBit()] = check;
         return this;
     }
 
     /**
-     * Sets a specified bit as unset
+     * Sets if a specified bit should be checked as unset
      * 
      * @param i
      *            Bit to set
      * @param set
      *            Value (true as set or false as unset) to set them to
      */
-    public PotionBitSet setCheckNot(PotionBit bit, boolean check) {
+    public PotionIngredientMeta setCheckNotSet(PotionBit bit, boolean check) {
         if (bit != PotionBit.EFFECT)
             bitCheckNot[bit.getBit()] = check;
         return this;
@@ -516,7 +518,7 @@ public class PotionBitSet {
      * @param set
      *            Value (true as set or false as unset) to set them to
      */
-    public PotionBitSet setBits(PotionBit[] bits, boolean set) {
+    public PotionIngredientMeta setBits(PotionBit[] bits, boolean set) {
         int length = bits.length;
         for (PotionBit bit : bits)
             if (bit == PotionBit.EFFECT)
@@ -550,7 +552,7 @@ public class PotionBitSet {
      * @param set
      *            Value (true as set or false as unset) to set them to
      */
-    public PotionBitSet setCheckIf(PotionBit[] bits, boolean check) {
+    public PotionIngredientMeta setCheckIfSet(PotionBit[] bits, boolean check) {
         int[] ia = new int[bits.length];
         for (int i = 0; i < bits.length; i++)
             ia[i] = bits[i].getBit();
@@ -561,14 +563,14 @@ public class PotionBitSet {
     }
 
     /**
-     * Sets multiple bits to be checked as unset
+     * Sets if multiple bits should be checked as unset
      * 
      * @param ia
      *            Integer Array of the different bits to set
      * @param set
      *            Value (true as set or false as unset) to set them to
      */
-    public PotionBitSet setCheckNot(PotionBit[] bits, boolean check) {
+    public PotionIngredientMeta setCheckNot(PotionBit[] bits, boolean check) {
         int[] ia = new int[bits.length];
         for (int i = 0; i < bits.length; i++)
             ia[i] = bits[i].getBit();

--- a/src/main/java/org/bukkit/potion/PotionIngredientMeta.java
+++ b/src/main/java/org/bukkit/potion/PotionIngredientMeta.java
@@ -25,7 +25,7 @@ public class PotionIngredientMeta {
          * Represents a mundane potion
          */
         MUNDANE,
-    }   
+    }
 
     public enum PotionBit {
         /**

--- a/src/main/java/org/bukkit/potion/PotionRecipes.java
+++ b/src/main/java/org/bukkit/potion/PotionRecipes.java
@@ -33,7 +33,7 @@ public class PotionRecipes {
      * Registers a new ingredient to the specified bit modifier
      * 
      * @param bitModifier
-     *            The PotionBitSet to register with the ingredient
+     *            The PotionIngredientMeta to register with the ingredient
      * @param material
      *            The Material data of the ingredient
      */
@@ -93,18 +93,18 @@ public class PotionRecipes {
      *            The potion ingredient to retrieve the bit string with
      * @return The potion's bit string
      */
-    public static String getBitsforMaterial(Material material) {
+    public static String getMetaforMaterial(Material material) {
         return recipes.get(material);
     }
 
     /**
-     * Returns the PotionBitSet for the specified potion ingredient
+     * Returns the PotionIngredientMeta for the specified potion ingredient
      * 
      * @param material
      *            The potion ingredient to retrieve the bit string with
-     * @return The potion's PotionBitSet
+     * @return The potion's PotionIngredientMeta
      */
-    public static PotionIngredientMeta getPotionBitSetforMaterial(Material material) {
+    public static PotionIngredientMeta getPotionIngredientMetaforMaterial(Material material) {
         return new PotionIngredientMeta(recipes.get(material));
     }
 
@@ -116,19 +116,19 @@ public class PotionRecipes {
      *            with
      * @return The potion's bit string
      */
-    public static String getBitsforId(int material) {
+    public static String getMetaforId(int material) {
         return recipes.get(material);
     }
 
     /**
-     * Returns the PotionBitSet for the specified potion ingredient
+     * Returns the PotionIngredientMeta for the specified potion ingredient
      * 
      * @param material
      *            The potion ingredient's integer ID to retrieve the bit string
      *            with
-     * @return The potion's PotionBitSet
+     * @return The potion's PotionIngredientMeta
      */
-    public static PotionIngredientMeta getPotionBitSetforId(int material) {
+    public static PotionIngredientMeta getPotionIngredientMetaforId(int material) {
         return new PotionIngredientMeta(recipes.get(material));
     }
 

--- a/src/main/java/org/bukkit/potion/PotionRecipes.java
+++ b/src/main/java/org/bukkit/potion/PotionRecipes.java
@@ -37,7 +37,7 @@ public class PotionRecipes {
      * @param material
      *            The Material data of the ingredient
      */
-    public static void addRecipe(PotionBitSet bitModifier, Material material) {
+    public static void addRecipe(PotionIngredientMeta bitModifier, Material material) {
         recipes.put(material.getId(), bitModifier.getBitString());
         if (!newIngredients.contains(material.getId()))
             newIngredients.add(material.getId());
@@ -104,8 +104,8 @@ public class PotionRecipes {
      *            The potion ingredient to retrieve the bit string with
      * @return The potion's PotionBitSet
      */
-    public static PotionBitSet getPotionBitSetforMaterial(Material material) {
-        return new PotionBitSet(recipes.get(material));
+    public static PotionIngredientMeta getPotionBitSetforMaterial(Material material) {
+        return new PotionIngredientMeta(recipes.get(material));
     }
 
     /**
@@ -128,8 +128,8 @@ public class PotionRecipes {
      *            with
      * @return The potion's PotionBitSet
      */
-    public static PotionBitSet getPotionBitSetforId(int material) {
-        return new PotionBitSet(recipes.get(material));
+    public static PotionIngredientMeta getPotionBitSetforId(int material) {
+        return new PotionIngredientMeta(recipes.get(material));
     }
 
     /**

--- a/src/main/java/org/bukkit/potion/PotionRecipes.java
+++ b/src/main/java/org/bukkit/potion/PotionRecipes.java
@@ -1,0 +1,162 @@
+package org.bukkit.potion;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.BrewRecipe;
+import org.bukkit.potion.PotionEffect;
+
+public class PotionRecipes {
+    private PotionRecipes() {
+    }
+
+    private static HashMap<Integer, String> recipes = new HashMap<Integer, String>();
+    private static ArrayList<Integer> newIngredients = new ArrayList<Integer>();
+    private static HashMap<Integer, ArrayList<PotionEffect>> customEffects = new HashMap<Integer, ArrayList<PotionEffect>>();
+
+    /**
+     * Registers a new ingredient to the specified bit modifier
+     * 
+     * @param bitModifier
+     *            The bit modifier string to register with the ingredient
+     * @param material
+     *            The Material data of the ingredient
+     */
+    public static void addRecipe(String bitModifier, Material material) {
+        recipes.put(material.getId(), bitModifier);
+        if (!newIngredients.contains(material.getId()))
+            newIngredients.add(material.getId());
+    }
+
+    /**
+     * Registers a new ingredient to the specified bit modifier
+     * 
+     * @param bitModifier
+     *            The PotionBitSet to register with the ingredient
+     * @param material
+     *            The Material data of the ingredient
+     */
+    public static void addRecipe(PotionBitSet bitModifier, Material material) {
+        recipes.put(material.getId(), bitModifier.getBitString());
+        if (!newIngredients.contains(material.getId()))
+            newIngredients.add(material.getId());
+    }
+
+    /**
+     * Overrides an existing potion's PotionEffect with a different PotionEffect
+     * 
+     * @param recipe
+     *            The potion recipe to register the effect to
+     * @param neweffects
+     *            An ArrayList of effects to overwrite onto the specified potion
+     */
+    public static void overrideEffect(BrewRecipe recipe, PotionEffect neweffect) {
+        overrideEffect(recipe.getResult().getDurability(), neweffect);
+    }
+
+    /**
+     * Overrides an existing potion's PotionEffect with a different PotionEffect
+     * 
+     * @param potiondata
+     *            The integer value of the potion to override
+     * @param neweffects
+     *            A PotionEffect to overwrite onto the specified potion
+     */
+    public static void overrideEffect(int potiondata, PotionEffect neweffect) {
+        ArrayList<PotionEffect> effect = new ArrayList<PotionEffect>();
+        effect.add(neweffect);
+
+        int data = potiondata;
+        if (data > 15)
+            data = (data << 12) >> 12;
+
+        overrideEffect(data, effect);
+    }
+
+    /**
+     * Overrides an existing potion's PotionEffect with a different PotionEffect
+     * 
+     * @param potiondata
+     *            The integer value of the potion to override
+     * @param neweffects
+     *            An ArrayList of effects to overwrite onto the specified potion
+     */
+    public static void overrideEffect(int potiondata, ArrayList<PotionEffect> neweffects) {
+        customEffects.put(potiondata, neweffects);
+    }
+
+    /**
+     * Returns the bit string for the specified potion ingredient
+     * 
+     * @param material
+     *            The potion ingredient to retrieve the bit string with
+     * @return The potion's bit string
+     */
+    public static String getBitsforMaterial(Material material) {
+        return recipes.get(material);
+    }
+
+    /**
+     * Returns the PotionBitSet for the specified potion ingredient
+     * 
+     * @param material
+     *            The potion ingredient to retrieve the bit string with
+     * @return The potion's PotionBitSet
+     */
+    public static PotionBitSet getPotionBitSetforMaterial(Material material) {
+        return new PotionBitSet(recipes.get(material));
+    }
+
+    /**
+     * Returns the bit string for the specified potion ingredient
+     * 
+     * @param material
+     *            The potion ingredient's integer ID to retrieve the bit string
+     *            with
+     * @return The potion's bit string
+     */
+    public static String getBitsforId(int material) {
+        return recipes.get(material);
+    }
+
+    /**
+     * Returns the PotionBitSet for the specified potion ingredient
+     * 
+     * @param material
+     *            The potion ingredient's integer ID to retrieve the bit string
+     *            with
+     * @return The potion's PotionBitSet
+     */
+    public static PotionBitSet getPotionBitSetforId(int material) {
+        return new PotionBitSet(recipes.get(material));
+    }
+
+    /**
+     * Returns an ArrayList of custom ingredients registered
+     * 
+     * @return An ArrayList of ingredient ID's
+     */
+    public static ArrayList<Integer> getNewIngredients() {
+        return newIngredients;
+    }
+
+    /**
+     * Returns an HashMap of custom effects linked with their associated
+     * potion's ID
+     * 
+     * @return
+     */
+    public static HashMap<Integer, ArrayList<PotionEffect>> getCustomEffectsTable() {
+        return customEffects;
+    }
+
+    /**
+     * Returns a HashMap of bit strings linked with their associated potion's ID
+     * 
+     * @return
+     */
+    public static HashMap<Integer, String> getRecipes() {
+        return recipes;
+    }
+}

--- a/src/main/java/org/bukkit/potion/PotionType.java
+++ b/src/main/java/org/bukkit/potion/PotionType.java
@@ -8,11 +8,15 @@ public enum PotionType {
     POISON(4, PotionEffectType.POISON, 2),
     INSTANT_HEAL(5, PotionEffectType.HEAL, 2),
     NIGHT_VISION(6, PotionEffectType.NIGHT_VISION, 1),
+    CLEAR(7, PotionEffectType.NONE, 1),
     WEAKNESS(8, PotionEffectType.WEAKNESS, 1),
     STRENGTH(9, PotionEffectType.INCREASE_DAMAGE, 2),
     SLOWNESS(10, PotionEffectType.SLOW, 1),
+    DIFFUSE(11, PotionEffectType.NONE, 1),
     INSTANT_DAMAGE(12, PotionEffectType.HARM, 2),
+    ARTLESS(13, PotionEffectType.NONE, 1),
     INVISIBILITY(14, PotionEffectType.INVISIBILITY, 1),
+    THIN(15, PotionEffectType.NONE, 1),
     ;
 
     private final int damageValue, maxLevel;


### PR DESCRIPTION
#### The Issue:

Potions have always been the gray area of Bukkit. There's no way to make new potions, no way to add new brewing recipes, and there's no way to override the effects of a potion. 
#### Justification for this PR:

Many plugins attempt to override potion effects or add new effects by using the item's right click event. While a consume event has been added, this PR tackles the issue at it's core by allowing the overriding of a potion effect, so you could essentially give a potion a new effect or nullify it (ie, removing potion of invisibility by replacing it with water breathing). This PR also adds the BrewRecipe class, which acts as a way to increase the number of ingredients, and to modify their behavior through the use of the PotionIngredientMeta class, a wrapper around Minecraft's powerful potion engine. Lastly, this PR adds BrewEndEvent to enable the modification of the resulting potions. This allows for the removal/banning of potions right when they are added, as well as the modification of potions (ie, rename Potion of Invisibility to Potion of Water Breathing.) This PR also adds a getPotions method to Brew(End)Event which returns an array of Bukkit Potion objects for each potion
#### PR Breakdown:

BrewRecipe is tied into CraftBukkit much like the other recipes (Furnace, Crafting). A PotionIngredientMeta is instantiated defining precisely what the ingredient does. These effects include:
- Base Potion Effect, 0-15
- Extended
- Level II
- Splash
- Potion Base (Awkward, Thick, Mundane, or Water)
  TileEntityBrewing and SlotBrewing were modified to allow for the new ingredients added in the BrewRecipe to be inserted into the ingredient slot. TileEntityBrewing was then modified to take the new ingredient and retrieve the appropriate bitstring from the potion registry and would then start brewing. Once the brewing is done, BrewEndEvent is called to allow for final modifications of the potions.

Once the potion is complete and the player goes to drink it, PotionBrewer's modifications come in. These modifications allow for the new effects and durations to override the potion's default effects, or if the potion has no effects previously, to add new effects. This can also be done using BrewEndEvent by modifying the Potion's metadata, but one may be desireable over the other.
#### Plugin Example Code:

``` java
PotionIngredientMeta underwater = new PotionIngredientMeta(PotionType.ARTLESS, false, false, false, PotionBase.THICK); //13 is the base potion type, extended/levelI/gunpowder as boolean, and the potion's base

BrewRecipe recipe = new BrewRecipe(underwater, Material.INK_SACK); //Registers our ingredient with the PotionIngredientMeta
this.getServer().addRecipe(recipe); //Register the recipe like any other recipe

PotionRecipes.overrideEffect(8205, new PotionEffect(PotionEffectType.WATER_BREATHING, (60 * 3) * 20, 0)); //Override the effect of the resulting potion with the underwater breathing effect
```
#### Relevant PR(s)

The corresponding CraftBukkit pull request is Bukkit/CraftBukkit#943
