### PR TITLE
Add API for Client Difficulty & Render Distance

### DIFF
--- a/src/main/java/org/bukkit/RenderDistance.java
+++ b/src/main/java/org/bukkit/RenderDistance.java
@@ -1,0 +1,51 @@
+package org.bukkit;
+
+import java.util.Map;
+
+import com.google.common.collect.Maps;
+
+/**
+ * Represents the various render distances that are available.
+ */
+public enum RenderDistance {
+    TINY(3),
+    SHORT(2),
+    NORMAL(1),
+    FAR(0);
+
+    private final int value;
+    private final static Map<Integer, RenderDistance> BY_ID = Maps.newHashMap();
+
+    /**
+     * Constructs a new RenderDistance enum with the specified value
+     * @param value Value sent in Packet 204 for the render distance
+     */
+    private RenderDistance(final int value) {
+        this.value = value;
+    }
+
+    /**
+     * Gets the render distance value associated with this RenderDistance.
+     *
+     * @return An integer value of this render distance
+     */
+    public int getValue() {
+        return value;
+    }
+
+    /**
+     * Gets the RenderDistance represented by the specified value
+     *
+     * @param value Value to check
+     * @return Associative {@link RenderDistance} with the given value, or null if it doesn't exist
+     */
+    public static RenderDistance getByValue(final int value) {
+        return BY_ID.get(value);
+    }
+
+    static {
+        for (RenderDistance renderDistance : values()) {
+            BY_ID.put(renderDistance.value, renderDistance);
+        }
+    }
+}

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -4,12 +4,14 @@ import java.net.InetSocketAddress;
 
 import org.bukkit.Achievement;
 import org.bukkit.ChatColor;
+import org.bukkit.Difficulty;
 import org.bukkit.Effect;
 import org.bukkit.Instrument;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Note;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.RenderDistance;
 import org.bukkit.Sound;
 import org.bukkit.Statistic;
 import org.bukkit.command.CommandSender;
@@ -569,4 +571,18 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      * @return The current allowed speed, from -1 to 1
      */
     public float getWalkSpeed();
+
+    /**
+     * Gets the difficulty setting that the client has set in their options, or null if
+     * the value is unknown.  
+     * @return The difficulty setting in the client's options if known, otherwise null
+     */
+	Difficulty getDifficulty();
+
+	/**
+	 * Gets the current render distance that the client has set in their video settings,
+	 * or null if the value is unknown.
+	 * @return The render distance in the client's options if known, otherwise null
+	 */
+	RenderDistance getRenderDistance();
 }


### PR DESCRIPTION
This adds an API to retrieve the client's difficulty setting & render distance set in their options.

Currently, it is impossible for plugins to retrieve that data, although it is sent by the client.

The get() methods return null if the (modified) client sends a value with an invalid number, or if the client doesn't send Packet204LocaleAndViewDistance().
