### PR TITLE
Added ability to change the Kick Message displayed to players

### DIFF
--- a/src/main/java/org/bukkit/Bukkit.java
+++ b/src/main/java/org/bukkit/Bukkit.java
@@ -250,6 +250,10 @@ public final class Bukkit {
     public static void shutdown() {
         server.shutdown();
     }
+    
+    public static void shutdown(String disconnectMessage) {
+        server.shutdown(disconnectMessage);
+    }
 
     public static int broadcast(String message, String permission) {
         return server.broadcast(message, permission);
@@ -385,5 +389,13 @@ public final class Bukkit {
 
     public static WarningState getWarningState() {
         return server.getWarningState();
+    }
+    
+    public static String getShutdownDisconnectMessage(){
+        return server.getShutdownDisconnectMessage();
+    }
+    
+    public static void setShutdownDisconnectMessage(String kickMessage){
+        server.setShutdownDisconnectMessage(kickMessage);
     }
 }

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -496,6 +496,13 @@ public interface Server extends PluginMessageRecipient {
      * Shutdowns the server, stopping everything.
      */
     public void shutdown();
+    
+    /**
+     * Shuts down the server, stopping everything
+     * 
+     * @param disconnectMessage The disconnect message to show to players
+     */
+    public void shutdown(String disconnectMessage);
 
     /**
      * Broadcasts the specified message to every user with the given permission
@@ -672,4 +679,17 @@ public interface Server extends PluginMessageRecipient {
      * @return The configured WarningState
      */
     public WarningState getWarningState();
+    
+    /**
+     * Gets the current disconnect message for when the server shuts down
+     *
+     * @return The shutdown disconnect message
+     */
+    public String getShutdownDisconnectMessage();
+    
+    /**
+     * Sets the disconnect message for when the server shuts down
+     * @param message The disconnect message to show to players when the server is shutdown
+     */
+    public void setShutdownDisconnectMessage(String message);
 }

--- a/src/main/java/org/bukkit/command/defaults/StopCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/StopCommand.java
@@ -2,6 +2,7 @@ package org.bukkit.command.defaults;
 
 import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
@@ -13,7 +14,7 @@ public class StopCommand extends VanillaCommand {
     public StopCommand() {
         super("stop");
         this.description = "Stops the server";
-        this.usageMessage = "/stop";
+        this.usageMessage = "/stop [kick-message]";
         this.setPermission("bukkit.command.stop");
     }
 
@@ -21,8 +22,9 @@ public class StopCommand extends VanillaCommand {
     public boolean execute(CommandSender sender, String currentAlias, String[] args) {
         if (!testPermission(sender)) return true;
 
+        String disconnectMessage = (args.length > 0 ? StringUtils.join(args, " ") : Bukkit.getShutdownDisconnectMessage());
         Command.broadcastCommandMessage(sender, "Stopping the server..");
-        Bukkit.shutdown();
+        Bukkit.shutdown(disconnectMessage);
 
         return true;
     }


### PR DESCRIPTION
Added ability to change the Kick Message displayed to players when the server is shutdown and expanded the /stop command to support this feature.

Also added a temp shutdown kick message which sets the shutdown kick
message for that session, this is mainly used for the /stop
[kick-message] command.

When the server shuts down the temporary kick message will be shown if
it has been set, otherwise the one set in Bukkit.yml will be shown.

JIRA Ticket: https://bukkit.atlassian.net/browse/BUKKIT-3031
CraftBukkit PR: https://github.com/Bukkit/CraftBukkit/pull/937
