### PR TITLE
- Add API to get vehicle creation reason, and make VehicleCreateEvent cancellable. Adds Bukkit-3074

### DIFF
--- a/src/main/java/org/bukkit/event/vehicle/VehicleCreateEvent.java
+++ b/src/main/java/org/bukkit/event/vehicle/VehicleCreateEvent.java
@@ -1,18 +1,58 @@
 package org.bukkit.event.vehicle;
 
 import org.bukkit.entity.Vehicle;
+import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
 /**
  * Raised when a vehicle is created.
  */
-public class VehicleCreateEvent extends VehicleEvent {
+public class VehicleCreateEvent extends VehicleEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
-
-    public VehicleCreateEvent(final Vehicle vehicle) {
+    private boolean cancelled;
+    private final Object creator;
+    private final VehicleCreateReason reason;
+    
+    public VehicleCreateEvent(final Vehicle vehicle, final Object creator, final VehicleCreateReason reason) {
         super(vehicle);
+        
+        this.creator = creator;
+        this.reason = reason;
     }
 
+    
+    /**
+     * Returns the creator of this minecart. Minecarts can
+     * be created a number of ways, which is the reason why
+     * the creator is represented by a generic Object.
+     * 
+     * This can represent one of the following:
+     * 
+     * Dispenser = it was created by a dispenser
+     * Player = A player created this vehicle
+     * null = This was created using the <b>CraftWorld.spawn()</b> method
+     * @return The generic object representing the creator of this vehicle
+     */
+    public Object getCreator() {
+        return creator;
+    }
+    
+    /**
+     * Returns the reason this vehicle was created
+     * @return Reason for vehicle's creation
+     */
+    public VehicleCreateReason getReason() {
+        return reason;
+    }
+
+    public void setCancelled(boolean cancel) {
+        cancelled = cancel;
+    }
+    
+    public boolean isCancelled() {
+        return cancelled;
+    }
+    
     @Override
     public HandlerList getHandlers() {
         return handlers;

--- a/src/main/java/org/bukkit/event/vehicle/VehicleCreateReason.java
+++ b/src/main/java/org/bukkit/event/vehicle/VehicleCreateReason.java
@@ -1,0 +1,22 @@
+package org.bukkit.event.vehicle;
+
+/**
+ * An enum that describes how a vehicle was created
+ */
+
+public enum VehicleCreateReason {
+    /*
+     * This vehicle was created from a player placing a vehicle in the world 
+     */
+    PLAYER_PLACED,
+    
+    /*
+     * This vehicle was created by a dispenser
+     */
+    DISPENSED,
+    
+    /*
+     * This vehicle was created by being spawned
+     */
+    SPAWNED;
+}


### PR DESCRIPTION
Firstly, this includes a reason for a Vehicle's creation, but the heart of this PR is in its implementation.

It was previously impossible to cancel this event because of how this was handled on the server. I made the appropriate changes in the server code, so this needed some additional changes.

CraftBukkit commit here: https://github.com/Bukkit/CraftBukkit/pull/942
