### PR TITLE
[B+C] Add QuitReason enum to PlayerQuitEvent + PlayerKickEvent. Fixes BUKKIT-429

### DIFF
--- a/src/main/java/org/bukkit/QuitReason.java
+++ b/src/main/java/org/bukkit/QuitReason.java
@@ -1,0 +1,103 @@
+package org.bukkit;
+
+/**
+ * Reasons logged in players leave the server (both voluntarily and forcibly)
+ */
+public enum QuitReason {
+    /**
+     * Reason player quit is unknown
+     */
+    UNKNOWN,
+    /**
+     * Player has quit the game using the ESC menu
+     */
+    QUITTING,
+    /**
+     * Player has stopped sending packets
+     */
+    END_OF_STREAM,
+    /**
+     * The player encountered an overflow
+     */
+    OVERFLOW,
+    /**
+     * No reason was given by the server
+     */
+    GENERIC_REASON,
+    /**
+     * The player did not send a response in a timely manner
+     */
+    TIMEOUT,
+    /**
+     * The player was disconnected for spamming
+     */
+    ILLEGAL_CHAT_RATE,
+    /**
+     * The player had an illegal stance
+     */
+    ILLEGAL_STANCE,
+    /**
+     * The player was disconnected for attempting to fly when disallowed (occurs if allow-flight is disabled in server.properties)
+     */
+    ILLEGAL_FLIGHT,
+    /**
+     * The player was disconnected being in a position they are not allowed
+     */
+    ILLEGAL_POSITION,
+    /**
+     * The player was dropping items too quickly
+     */
+    ILLEGAL_DROP_RATE,
+    /**
+     * The player was disconnected as the client sent a packet the server was not expecting
+     */
+    ILLEGAL_PROTOCOL,
+    /**
+     * The player tried to place an item that cannot be carried
+     */
+    ILLEGAL_ITEM,
+    /**
+     * The player sent an illegal character in chat
+     */
+    ILLEGAL_CHAT_CHARACTER,
+    /**
+     * The player tried to send a chat message that was too long
+     */
+    ILLEGAL_CHAT_LENGTH,
+    /**
+     * The player was disconnected for attempting to put illegal data into a book
+     */
+    ILLEGAL_BOOK_DATA,
+    /**
+     * The player was disconnected for attempting to perform a trade with illegal data
+     */
+    ILLEGAL_TRADE_DATA,
+    /**
+     * The player was disconnected for sending illegal Command Block data
+     */
+    ILLEGAL_COMMAND_BLOCK_DATA,
+    /**
+     * The player was disconnected for sending illegal Beacon data
+     */
+    ILLEGAL_BEACON_DATA,
+    /**
+     * The player attempted to attack an item, experience orb, or arrow (potential exploitaition)
+     */
+    ILLEGAL_ATTACK,
+    /**
+     * The player died in hardcore mode and was kicked
+     */
+    DIED_HARDCORE,
+    /**
+     * The player logged into the server from another client
+     */
+    LOGIN_LOCATION,
+    /**
+     * The player was kicked from the server as the server is shutting down
+     */
+    SERVER_SHUTDOWN,
+    /**
+     * The player was kicked from the server for other reasons (including via plugins)
+     */
+    KICKED;
+}

--- a/src/main/java/org/bukkit/event/player/PlayerKickEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerKickEvent.java
@@ -1,5 +1,6 @@
 package org.bukkit.event.player;
 
+import org.bukkit.QuitReason;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
@@ -12,11 +13,21 @@ public class PlayerKickEvent extends PlayerEvent implements Cancellable {
     private String leaveMessage;
     private String kickReason;
     private Boolean cancel;
+    private QuitReason reason;
 
+    /**
+     * @deprecated A new parameter has been included, QuitReason
+     */
+    @Deprecated
     public PlayerKickEvent(final Player playerKicked, final String kickReason, final String leaveMessage) {
+        this(playerKicked, kickReason, leaveMessage, QuitReason.KICKED);
+    }
+
+    public PlayerKickEvent(final Player playerKicked, final String kickReason, final String leaveMessage, final QuitReason reason) {
         super(playerKicked);
         this.kickReason = kickReason;
         this.leaveMessage = leaveMessage;
+        this.reason = reason;
         this.cancel = false;
     }
 
@@ -30,7 +41,18 @@ public class PlayerKickEvent extends PlayerEvent implements Cancellable {
     }
 
     /**
-     * Gets the leave message send to all online players
+     * Gets the reason the server kicked the player. This 
+     * method returns an enum, intended for use by other
+     * plugins. Use getReason() to obtain a text version.
+     *
+     * @return QuitReason reason
+     */
+    public QuitReason getQuitReason() {
+        return reason;
+    }
+
+    /**
+     * Gets the leave message sent to all online players
      *
      * @return string kick reason
      */

--- a/src/main/java/org/bukkit/event/player/PlayerQuitEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerQuitEvent.java
@@ -1,5 +1,6 @@
 package org.bukkit.event.player;
 
+import org.bukkit.QuitReason;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 
@@ -9,10 +10,20 @@ import org.bukkit.event.HandlerList;
 public class PlayerQuitEvent extends PlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     private String quitMessage;
+    private QuitReason reason;
 
+    /**
+     * @deprecated A new parameter has been included, QuitReason
+     */
+    @Deprecated
     public PlayerQuitEvent(final Player who, final String quitMessage) {
+        this(who, quitMessage, QuitReason.UNKNOWN);
+    }
+
+    public PlayerQuitEvent(final Player who, final String quitMessage, final QuitReason reason) {
         super(who);
         this.quitMessage = quitMessage;
+        this.reason = reason;
     }
 
     /**
@@ -22,6 +33,15 @@ public class PlayerQuitEvent extends PlayerEvent {
      */
     public String getQuitMessage() {
         return quitMessage;
+    }
+
+    /**
+     * Gets the reason the player left the server
+     *
+     * @return QuitReason reason
+     */
+    public QuitReason getQuitReason() {
+        return reason;
     }
 
     /**


### PR DESCRIPTION
Adds feature requested in BUKKIT-429. https://bukkit.atlassian.net/browse/BUKKIT-429
CraftBukkit PR: Bukkit/CraftBukkit#944

This change adds a QuitReason to the PlayerQuitEvent and PlayerKickEvent as an enum. When the event is called, CraftBukkit passes the reason for the disconnect to the events - and it'll fallback to QuitReason.UNKNOWN if the reason is not known.

Plugins can then access the reason the player quit through the event.getQuitReason() method. A fallback constructor remains in place, just in case another plugin is calling the event, this defaults to "QuitReason.UNKNOWN" or "QuitReason.KICKED" every time, dependant on the event called.

A small test plugin is available for this change, source code can be found at dualspiral/quittest@58af03d99ce28f75b83bb0bc8e5e690bd57c8e91

The motivation for this change arises from developing a plugin to customize quit messages dependent on the reason a player quit. Currently, the only method that I've seen that has done this is through scraping the console, and sometimes, it does not catch the disconnect reason. Embedding this in Bukkit and CraftBukkit will solve this issue, should it be allowed.

(This description has been altered (PlayerQuitEvent -> QuitEvent) to reflect the state of the PR)
### Status
- [ ] Waiting for author (@dualspiral)
- [ ] Waiting for PRH (@riking)
- [x] Waiting for core
