### PR TITLE
Player Weather API adds BUKKIT-812

### DIFF
--- a/src/main/java/org/bukkit/WeatherType.java
+++ b/src/main/java/org/bukkit/WeatherType.java
@@ -1,0 +1,11 @@
+package org.bukkit;
+
+/**
+* An enum of all current weather types
+*/
+public enum WeatherType {
+    
+    DOWNFALL,
+    CLEAR;
+
+}

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -12,6 +12,7 @@ import org.bukkit.Note;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.Sound;
 import org.bukkit.Statistic;
+import org.bukkit.WeatherType
 import org.bukkit.command.CommandSender;
 import org.bukkit.conversations.Conversable;
 import org.bukkit.map.MapView;
@@ -362,6 +363,26 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      * Equivalent to calling setPlayerTime(0, true).
      */
     public void resetPlayerTime();
+
+    /**
+     * Sets the type of weather the player will see.  When used, the weather status of the player is locked
+     * until resetPlayerWeather() is used.
+     *
+     * @param type The WeatherType enum type the player should experience
+     */
+    public void setPlayerWeather(WeatherType type);
+
+    /**
+     * Returns the type of weather the player is currently experiencing
+     *
+     * @return The WeatherType that the player is currently experiencing
+     */
+    public WeatherType getPlayerWeather();
+
+    /**
+     * Restores the normal condition where the player's weather is controlled by server conditions.
+     */
+    public void resetPlayerWeather();
 
     /**
      * Gives the player the amount of experience specified.


### PR DESCRIPTION
Adds the ability for plugins to set a specific players weather, when a plugin is setting weather it is locked from server weather changes until reset.

Ticket: https://bukkit.atlassian.net/browse/BUKKIT-812
Craftbukkit PR: https://github.com/Bukkit/CraftBukkit/pull/947
