### PR TITLE
[B+C] Add Wake and Sleep API. Adds BUKKIT-3155

### DIFF
--- a/src/main/java/org/bukkit/SleepingResult.java
+++ b/src/main/java/org/bukkit/SleepingResult.java
@@ -1,0 +1,10 @@
+package org.bukkit;
+
+public enum SleepingResult {
+    OK,
+    NOT_POSSIBLE_IN_NETHER_OR_END,
+    NOT_POSSIBLE_DAYTIME,
+    TOO_FAR_AWAY,
+    ALREADY_SLEEPING_OR_DEAD,
+    MONSTERS_NEARBY;
+}

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -10,6 +10,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Note;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.SleepingResult;
 import org.bukkit.Sound;
 import org.bukkit.Statistic;
 import org.bukkit.WeatherType;
@@ -545,6 +546,30 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      * @param force whether to forcefully set the respawn location even if a valid bed is not present
      */
     public void setBedSpawnLocation(Location location, boolean force);
+
+    /**
+    * Attempts to put the player to sleep in the bed at given Location.
+    *
+    * @param bed the location of the bed.
+    * @return OK, if the player is put to sleep. Else the reason why not.
+    */
+    public SleepingResult sleep(Location bed);
+
+    /**
+    * Attempts to put the player to sleep in the bed at given Location.
+    *
+    * @param bed the location of the bed.
+    * @param overrideDistanceCheck whether to forcefully put the player in bed even if they are not in range.
+    * @return OK, if the player is put to sleep. Else the reason why not.
+    */
+    public SleepingResult sleep(Location bed, boolean overrideDistanceCheck);
+
+    /**
+    * If the player is currently sleeping, wakes up the player.
+    *
+    * @param setRespawn Whether to set the respawn location when being woken up.
+    */
+    public void wake(boolean setRespawn);
 
     /**
      * Determines if the Player is allowed to fly via jump key double-tap like in creative mode.


### PR DESCRIPTION
**The Issue:**
There is no way of waking players up, neither is there a way to put them in a bed.

**Justification for this PR:**
This feature was requested in the #bukkitdev IRC channel by a few plugin developers.

**PR Breakdown:**
Adds three new API calls to the Player Entity. 2 for sleeping, 1 for waking. Als adds a new Enum to allow checking if putting the player to sleep succeeded.

**Testing Results and Materials:**
This PR can be tested by the following test plugin: https://github.com/JadenKorr/SleepWakeTestPlugin

**Relevant PR(s):**
CB-953 - https://github.com/Bukkit/CraftBukkit/pull/953

**JIRA Ticket:**
BUKKIT-3155 - https://bukkit.atlassian.net/browse/BUKKIT-3155

**Pull Request Check List:**
_General_:
- [ ] Fits Bukkit's Goals
- [ ] Leaky Ticket Ready
- [ ] Code Meets Requirements
- [ ] Code is Documented
- [ ] Code Addresses Leaky Ticket
- [ ] Followed Pull Request Format
- [ ] Tested Code
- [ ] Included Test Material and Source
