### PR TITLE
Add getMinecraftVersion

### DIFF
--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -679,4 +679,11 @@ public interface Server extends PluginMessageRecipient {
      * @return The configured WarningState
      */
     public WarningState getWarningState();
+    
+    /**
+     * Gets the current version of Minecraft running on this server
+     *
+     * @return version of Minecraft
+     */
+    public String getMinecraftVersion();
 }


### PR DESCRIPTION
This adds the method getMinecraftVersion to get the version of Minecraft that's running on the server.

Use cases:
- Easier (and "safer") version checking with plugins that have NMS or OBC access
- Easier way to get the version of Minecraft without parsing Server.getVersion()
- Compatible with other server implementations that do not include the Minecraft version in Server.getVersion()

See https://github.com/Bukkit/CraftBukkit/pull/956 for the CraftBukkit PR.
