### PR TITLE
Fixed sub-cardinal BlockFaces having invalid data values in MaterialData classes, Fixes Bukkit-3160

### DIFF
--- a/src/main/java/org/bukkit/material/Door.java
+++ b/src/main/java/org/bukkit/material/Door.java
@@ -58,14 +58,14 @@ public class Door extends MaterialData implements Directional, Openable {
         byte d = getData();
 
         if ((d & 0x3) == 0x3) {
-            return BlockFace.NORTH_WEST;
-        } else if ((d & 0x1) == 0x1) {
-            return BlockFace.SOUTH_EAST;
-        } else if ((d & 0x2) == 0x2) {
             return BlockFace.SOUTH_WEST;
+        } else if ((d & 0x1) == 0x1) {
+            return BlockFace.NORTH_EAST;
+        } else if ((d & 0x2) == 0x2) {
+            return BlockFace.SOUTH_EAST;
         }
 
-        return BlockFace.NORTH_EAST;
+        return BlockFace.NORTH_WEST;
     }
 
     @Override

--- a/src/main/java/org/bukkit/material/Rails.java
+++ b/src/main/java/org/bukkit/material/Rails.java
@@ -77,16 +77,16 @@ public class Rails extends MaterialData {
             return BlockFace.SOUTH;
 
         case 0x6:
-            return BlockFace.NORTH_EAST;
+            return BlockFace.NORTH_WEST;
 
         case 0x7:
-            return BlockFace.SOUTH_EAST;
+            return BlockFace.NORTH_EAST;
 
         case 0x8:
-            return BlockFace.SOUTH_WEST;
+            return BlockFace.SOUTH_EAST;
 
         case 0x9:
-            return BlockFace.NORTH_WEST;
+            return BlockFace.SOUTH_WEST;
         }
     }
 
@@ -132,19 +132,19 @@ public class Rails extends MaterialData {
             setData((byte) (isOnSlope ? 0x5 : 0x0));
             break;
 
-        case NORTH_EAST:
+        case NORTH_WEST:
             setData((byte) 0x6);
             break;
 
-        case SOUTH_EAST:
+        case NORTH_EAST:
             setData((byte) 0x7);
             break;
 
-        case SOUTH_WEST:
+        case SOUTH_EAST:
             setData((byte) 0x8);
             break;
 
-        case NORTH_WEST:
+        case SOUTH_WEST:
             setData((byte) 0x9);
             break;
         }

--- a/src/main/java/org/bukkit/material/Sign.java
+++ b/src/main/java/org/bukkit/material/Sign.java
@@ -80,49 +80,49 @@ public class Sign extends MaterialData implements Attachable {
                 return BlockFace.SOUTH;
 
             case 0x1:
-                return BlockFace.WEST_NORTH_WEST;
+                return BlockFace.SOUTH_SOUTH_WEST;
 
             case 0x2:
-                return BlockFace.NORTH_WEST;
+                return BlockFace.SOUTH_WEST;
 
             case 0x3:
-                return BlockFace.NORTH_NORTH_WEST;
+                return BlockFace.WEST_SOUTH_WEST;
 
             case 0x4:
                 return BlockFace.WEST;
 
             case 0x5:
-                return BlockFace.NORTH_NORTH_EAST;
+                return BlockFace.WEST_NORTH_WEST;
 
             case 0x6:
-                return BlockFace.NORTH_EAST;
+                return BlockFace.NORTH_WEST;
 
             case 0x7:
-                return BlockFace.EAST_NORTH_EAST;
+                return BlockFace.NORTH_NORTH_WEST;
 
             case 0x8:
                 return BlockFace.NORTH;
 
             case 0x9:
-                return BlockFace.EAST_SOUTH_EAST;
+                return BlockFace.NORTH_NORTH_EAST;
 
             case 0xA:
-                return BlockFace.SOUTH_EAST;
+                return BlockFace.NORTH_EAST;
 
             case 0xB:
-                return BlockFace.SOUTH_SOUTH_EAST;
+                return BlockFace.EAST_NORTH_EAST;
 
             case 0xC:
                 return BlockFace.EAST;
 
             case 0xD:
-                return BlockFace.SOUTH_SOUTH_WEST;
+                return BlockFace.EAST_SOUTH_EAST;
 
             case 0xE:
-                return BlockFace.SOUTH_WEST;
+                return BlockFace.SOUTH_EAST;
 
             case 0xF:
-                return BlockFace.WEST_SOUTH_WEST;
+                return BlockFace.SOUTH_SOUTH_EAST;
             }
 
             return null;
@@ -158,15 +158,15 @@ public class Sign extends MaterialData implements Attachable {
                 data = 0x0;
                 break;
 
-            case WEST_NORTH_WEST:
+            case SOUTH_SOUTH_WEST:
                 data = 0x1;
                 break;
 
-            case NORTH_WEST:
+            case SOUTH_WEST:
                 data = 0x2;
                 break;
 
-            case NORTH_NORTH_WEST:
+            case WEST_SOUTH_WEST:
                 data = 0x3;
                 break;
 
@@ -174,15 +174,15 @@ public class Sign extends MaterialData implements Attachable {
                 data = 0x4;
                 break;
 
-            case NORTH_NORTH_EAST:
+            case WEST_NORTH_WEST:
                 data = 0x5;
                 break;
 
-            case NORTH_EAST:
+            case NORTH_WEST:
                 data = 0x6;
                 break;
 
-            case EAST_NORTH_EAST:
+            case NORTH_NORTH_WEST:
                 data = 0x7;
                 break;
 
@@ -190,15 +190,15 @@ public class Sign extends MaterialData implements Attachable {
                 data = 0x8;
                 break;
 
-            case EAST_SOUTH_EAST:
+            case NORTH_NORTH_EAST:
                 data = 0x9;
                 break;
 
-            case SOUTH_EAST:
+            case NORTH_EAST:
                 data = 0xA;
                 break;
 
-            case SOUTH_SOUTH_EAST:
+            case EAST_NORTH_EAST:
                 data = 0xB;
                 break;
 
@@ -206,15 +206,15 @@ public class Sign extends MaterialData implements Attachable {
                 data = 0xC;
                 break;
 
-            case SOUTH_SOUTH_WEST:
+            case EAST_SOUTH_EAST:
                 data = 0xD;
                 break;
 
-            case WEST_SOUTH_WEST:
+            case SOUTH_SOUTH_EAST:
                 data = 0xF;
                 break;
 
-            case SOUTH_WEST:
+            case SOUTH_EAST:
             default:
                 data = 0xE;
             }

--- a/src/main/java/org/bukkit/material/Vine.java
+++ b/src/main/java/org/bukkit/material/Vine.java
@@ -59,7 +59,7 @@ public class Vine extends MaterialData {
 
     /**
      * Check if the vine is attached to the specified face of an adjacent block. You can
-     * check two faces at once by passing eg {@link BlockFace#NORTH_EAST}.
+     * check two faces at once by passing eg {@link BlockFace#NORTH_WEST}.
      *
      * @param face The face to check.
      * @return Whether it is attached to that face.
@@ -74,13 +74,13 @@ public class Vine extends MaterialData {
                 return (getData() & VINE_WEST) > 0;
             case EAST:
                 return (getData() & VINE_SOUTH) > 0;
-            case NORTH_EAST:
-                return isOnFace(BlockFace.WEST) && isOnFace(BlockFace.NORTH);
             case NORTH_WEST:
-                return isOnFace(BlockFace.WEST) && isOnFace(BlockFace.SOUTH);
-            case SOUTH_EAST:
-                return isOnFace(BlockFace.EAST) && isOnFace(BlockFace.NORTH);
+                return isOnFace(BlockFace.WEST) && isOnFace(BlockFace.NORTH);
             case SOUTH_WEST:
+                return isOnFace(BlockFace.WEST) && isOnFace(BlockFace.SOUTH);
+            case NORTH_EAST:
+                return isOnFace(BlockFace.EAST) && isOnFace(BlockFace.NORTH);
+            case SOUTH_EAST:
                 return isOnFace(BlockFace.EAST) && isOnFace(BlockFace.SOUTH);
             case UP: // It's impossible to be accurate with this since it's contextual
                 return true;
@@ -108,19 +108,19 @@ public class Vine extends MaterialData {
             case EAST:
                 setData((byte) (getData() | VINE_SOUTH));
                 break;
-            case NORTH_EAST:
-                putOnFace(BlockFace.WEST);
-                putOnFace(BlockFace.NORTH);
-                break;
             case NORTH_WEST:
                 putOnFace(BlockFace.WEST);
-                putOnFace(BlockFace.SOUTH);
-                break;
-            case SOUTH_EAST:
-                putOnFace(BlockFace.EAST);
                 putOnFace(BlockFace.NORTH);
                 break;
             case SOUTH_WEST:
+                putOnFace(BlockFace.WEST);
+                putOnFace(BlockFace.SOUTH);
+                break;
+            case NORTH_EAST:
+                putOnFace(BlockFace.EAST);
+                putOnFace(BlockFace.NORTH);
+                break;
+            case SOUTH_EAST:
                 putOnFace(BlockFace.EAST);
                 putOnFace(BlockFace.SOUTH);
                 break;
@@ -150,19 +150,19 @@ public class Vine extends MaterialData {
             case EAST:
                 setData((byte) (getData() &~ VINE_SOUTH));
                 break;
-            case NORTH_EAST:
-                removeFromFace(BlockFace.WEST);
-                removeFromFace(BlockFace.NORTH);
-                break;
             case NORTH_WEST:
                 removeFromFace(BlockFace.WEST);
-                removeFromFace(BlockFace.SOUTH);
-                break;
-            case SOUTH_EAST:
-                removeFromFace(BlockFace.EAST);
                 removeFromFace(BlockFace.NORTH);
                 break;
             case SOUTH_WEST:
+                removeFromFace(BlockFace.WEST);
+                removeFromFace(BlockFace.SOUTH);
+                break;
+            case NORTH_EAST:
+                removeFromFace(BlockFace.EAST);
+                removeFromFace(BlockFace.NORTH);
+                break;
+            case SOUTH_EAST:
                 removeFromFace(BlockFace.EAST);
                 removeFromFace(BlockFace.SOUTH);
                 break;


### PR DESCRIPTION
Signed-off-by: Irmo van den Berge bergerkiller@gmail.com

These BlockFace transformations were done to go from the old to the official Minecraft format:
- north -> west
- east -> north
- south -> east
- west -> south
- north_east -> north_west
- south_east -> north_east
- south_west -> south_east
- north_west -> south_west
- west_north_west -> south_south_west
- north_north_west -> west_south_west
- north_north_east -> west_north_west
- east_north_east -> north_north_west
- east_south_east -> north_north_east
- south_south_east -> east_north_east
- south_south_west -> east_south_east
- west_south_west -> south_south_east

The above transformations are based on the fact that the BlockFace 'rotated' horizontally.
It rotated 90 degrees to the left.
For example:
- north_east -> 45 -> -45 -> north_west
- north_north_east -> 22.5 -> -67.5 -> west_north_west

Luckily, an easier method could be used to come up with the above:

was: NORTH_NORTH_WEST
old: NORTH, NORTH_WEST
new: WEST, SOUTH_WEST
becomes: WEST_SOUTH_WEST

I have double-checked that this was indeed the case.

Only the top four were updated in the org.bukkit.material.\* classes.
This commit properly translates the other sub-cardinal and sub-sub-cardinal blockfaces as well.

Part of commit:
https://github.com/Bukkit/Bukkit/commit/49690f9620b7ed1ed9769cec35d095a3cac33ab0
