### PR TITLE
EnderSignalLaunchEvent - Implements BUKKIT-391

### DIFF
--- a/src/main/java/org/bukkit/event/entity/EnderSignalLaunchEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EnderSignalLaunchEvent.java
@@ -1,0 +1,40 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.EnderSignal;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Called when an ender signal is launched.
+ */
+public class EnderSignalLaunchEvent extends EntityEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancelled;
+
+    public EnderSignalLaunchEvent(Entity what) {
+        super(what);
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(boolean cancel) {
+        cancelled = cancel;
+    }
+
+    @Override
+    public EnderSignal getEntity() {
+        return (EnderSignal) entity;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}


### PR DESCRIPTION
Added a new cancel-able event much like the current ProjectileLaunchEvent but for EnderSignals (which are not considered projectiles). Event is fired when an EnderSignal is added to the world (caused by a player right clicking anything but an end portal frame with an Eye of Ender in hand).

Implements:
https://bukkit.atlassian.net/browse/BUKKIT-391

Corresponding CraftBukkit PR:
https://github.com/Bukkit/CraftBukkit/pull/960

PS: This is my first pull request so comments and positive criticism greatly appreciated :)
