### PR TITLE
Update Maven Shade Plugin to version 2.0. Fixes BUKKIT-3213

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 # we use maven!
 /build.xml
+/dependency-reduced-pom.xml
 
 # maven
 /target

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>1.4</version>
+                <version>2.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
Corresponding CraftBukkit PR: https://github.com/Bukkit/CraftBukkit/pull/962
Leaky ticket: https://bukkit.atlassian.net/browse/BUKKIT-3213
