### PR TITLE
Access to allowedCharacters field adds Bukkit-3225

### DIFF
--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -379,6 +379,13 @@ public interface Server extends PluginMessageRecipient {
     public Logger getLogger();
 
     /**
+     * Returns the allowedCharacters string from server SharedConstants
+     *
+     * @return allowedCharacters from SharedConstants
+     */
+    public String getAllowedCharacters();
+
+    /**
      * Gets a {@link PluginCommand} with the given name or alias
      *
      * @param name Name of the command to retrieve


### PR DESCRIPTION
Adds method to retrieve allowedCharacters field from SharedConstants in net.minecraft.server

Ticket: https://bukkit.atlassian.net/browse/BUKKIT-3225
CraftBukkit PR:  https://github.com/Bukkit/CraftBukkit/pull/964
