### PR TITLE
Fix site menus for relative paths

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -21,8 +21,8 @@
       <item name="Maven Repo" href="http://repo.bukkit.org/" />
     </menu>
     <menu name="API Documentation">
-      <item name="JavaDocs" href="http://jd.bukkit.org/apidocs/" />
-      <item name="Doxygen" href="http://jd.bukkit.org/doxygen/" />
+      <item name="JavaDocs" href="apidocs/" />
+      <item name="Doxygen" href="doxygen/" />
     </menu>
     <menu ref="reports" />
   </body>


### PR DESCRIPTION
This fixes the Maven generated site so the paths are relative. This is required so that multiple generations of the javadocs can be hosted at once, and so no cross-linking occurs.

This commit was Sponsored By EvilSeph(tm).
