### PR TITLE
Fixed BUKKIT-2613

### DIFF
--- a/src/main/java/org/bukkit/conversations/Conversation.java
+++ b/src/main/java/org/bukkit/conversations/Conversation.java
@@ -1,11 +1,13 @@
 package org.bukkit.conversations;
 
+import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
 
 /**
  * The Conversation class is responsible for tracking the current state of a conversation, displaying prompts to
@@ -197,7 +199,12 @@ public class Conversation {
             }
 
             // Not abandoned, output the next prompt
-            currentPrompt = currentPrompt.acceptInput(context, input);
+            try {
+                currentPrompt = currentPrompt.acceptInput(context, input);
+            } catch (Throwable t) {
+                Bukkit.getLogger().log(Level.SEVERE, "Could not pass prompt input to " + context.getPlugin().getDescription().getFullName(), t);
+                return;
+            }
             outputNextPrompt();
         }
     }
@@ -247,9 +254,23 @@ public class Conversation {
         if (currentPrompt == null) {
             abandon(new ConversationAbandonedEvent(this));
         } else {
-            context.getForWhom().sendRawMessage(prefix.getPrefix(context) + currentPrompt.getPromptText(context));
+            String message;
+            try {
+                message = prefix.getPrefix(context) + currentPrompt.getPromptText(context);
+            } catch (Throwable t) {
+                Bukkit.getLogger().log(Level.SEVERE, "Failed to get prompt text for "
+                        + context.getPlugin().getDescription().getFullName(), t);
+                return;
+            }
+            context.getForWhom().sendRawMessage(message);
             if (!currentPrompt.blocksForInput(context)) {
-                currentPrompt = currentPrompt.acceptInput(context, null);
+                try {
+                    currentPrompt = currentPrompt.acceptInput(context, null);
+                } catch (Throwable t) {
+                    Bukkit.getLogger().log(Level.SEVERE, "Could not pass prompt input to "
+                            + context.getPlugin().getDescription().getFullName(), t);
+                    return;
+                }
                 outputNextPrompt();
             }
         }


### PR DESCRIPTION
As described in [BUKKIT-2613](https://bukkit.atlassian.net/browse/BUKKIT-2613), uncaught exceptions in the conversations API lead to `End of stream` disconnects without any information. This pull request wraps `Prompt`-calls in try-blocks. When an exception is thrown, it will be logged and the conversation will be abandoned (instead of disconnecting the player).
