### PR TITLE
Update to new BlockItemSwitch packet standards, Fixes BUKKIT-3318

### DIFF
--- a/src/main/java/org/bukkit/event/player/PlayerItemHeldEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerItemHeldEvent.java
@@ -1,13 +1,15 @@
 package org.bukkit.event.player;
 
 import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
 /**
  * Fired when a player changes their currently held item
  */
-public class PlayerItemHeldEvent extends PlayerEvent {
+public class PlayerItemHeldEvent extends PlayerEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
+    private boolean cancel = false;
     private final int previous;
     private final int current;
 
@@ -33,6 +35,14 @@ public class PlayerItemHeldEvent extends PlayerEvent {
      */
     public int getNewSlot() {
         return current;
+    }
+
+    public boolean isCancelled(){
+        return cancel;
+    }
+
+    public void setCancelled(boolean cancel){
+        this.cancel = cancel;
     }
 
     @Override

--- a/src/main/java/org/bukkit/event/player/PlayerItemHeldEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerItemHeldEvent.java
@@ -37,11 +37,11 @@ public class PlayerItemHeldEvent extends PlayerEvent implements Cancellable {
         return current;
     }
 
-    public boolean isCancelled(){
+    public boolean isCancelled() {
         return cancel;
     }
 
-    public void setCancelled(boolean cancel){
+    public void setCancelled(boolean cancel) {
         this.cancel = cancel;
     }
 

--- a/src/main/java/org/bukkit/inventory/PlayerInventory.java
+++ b/src/main/java/org/bukkit/inventory/PlayerInventory.java
@@ -103,6 +103,15 @@ public interface PlayerInventory extends Inventory {
     public int getHeldItemSlot();
 
     /**
+     * Set the slot number of the currently held item
+     * This validates whether slot is between 0 and 8 inclusive
+     *
+     * @param slot The new slot number
+     * @throws IllegalArgumentException Thrown if slot is not between 0 and 8 inclusive
+     */
+    public void setHeldItemSlot(int slot);
+
+    /**
      * Clears all matching items from the inventory. Setting either value to -1 will skip it's check,
      *  while setting both to -1 will clear all items in your inventory unconditionally.
      *


### PR DESCRIPTION
This pull adds in player.getInventory().setHeldItemSlot(int) which allows plugins to change the active item slot. The int needs to be validated otherwise the player can not interact using an item in their hand (ex. Flint and Steel) and no PlayerItemHeldEvents are sent.

It also allows PlayerItemHeldEvent to implement Cancellable, sending a BlockItemSwitch packet to the client of the old index. 

Corresponding craftbukkit pull: https://github.com/Bukkit/CraftBukkit/pull/973
