### PR TITLE
[B] Support inverted TrapDoor (Fixes BUKKIT-3390)

### DIFF
--- a/src/main/java/org/bukkit/material/TrapDoor.java
+++ b/src/main/java/org/bukkit/material/TrapDoor.java
@@ -43,6 +43,26 @@ public class TrapDoor extends SimpleAttachableMaterialData implements Openable {
         setData(data);
     }
 
+    /**
+     * Test if trapdoor is inverted
+     * @return true if inverted (top half), false if normal (bottom half)
+     */
+    public boolean isInverted() {
+        return ((getData() & 0x8) != 0);
+    }
+
+    /**
+     * Set trapdoor inverted state
+     * @param inv - true if inverted (top half), false if normal (bottom half)
+     */
+    public void setInverted(boolean inv) {
+        int dat = getData() & 0x7;
+        if (inv) {
+            dat |= 0x8;
+        }
+        setData((byte) dat);
+    }
+
     public BlockFace getAttachedFace() {
         byte data = (byte) (getData() & 0x3);
 
@@ -65,7 +85,7 @@ public class TrapDoor extends SimpleAttachableMaterialData implements Openable {
     }
 
     public void setFacingDirection(BlockFace face) {
-        byte data = (byte) (getData() & 0x4);
+        byte data = (byte) (getData() & 0xC);
 
         switch (face) {
             case SOUTH:
@@ -84,7 +104,7 @@ public class TrapDoor extends SimpleAttachableMaterialData implements Openable {
 
     @Override
     public String toString() {
-        return (isOpen() ? "OPEN " : "CLOSED ") + super.toString() + " with hinges set " + getAttachedFace();
+        return (isOpen() ? "OPEN " : "CLOSED ") + super.toString() + " with hinges set " + getAttachedFace() + (isInverted() ? " inverted" : "");
     }
 
     @Override


### PR DESCRIPTION
## The Issue:

Similar to Steps and Stairs, TrapDoors now have the ability to be inverted controlled by the fourth bit (0x08)
http://www.minecraftwiki.net/wiki/Data_values#Trapdoors

Feature added in Minecraft 1.4.2
http://www.minecraftwiki.net/wiki/Version_history#1.4.2

```
Trapdoors
Can now be placed on the top half of blocks [34]
Placement works similar to that of slabs and stairs
```

Added logic pulled from Step.java and Stairs.java
## JIRA Ticket:

BUKKIT-3390 - https://bukkit.atlassian.net/browse/BUKKIT-3390
