### PR TITLE
 Added negative id check to Material.getMaterial(int). Fixes BUKKIT-3414

### DIFF
--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -528,7 +528,7 @@ public enum Material {
      * @return Material if found, or null
      */
     public static Material getMaterial(final int id) {
-        if (byId.length > id) {
+        if (byId.length > id && id >= 0) {
             return byId[id];
         } else {
             return null;

--- a/src/test/java/org/bukkit/MaterialTest.java
+++ b/src/test/java/org/bukkit/MaterialTest.java
@@ -33,6 +33,7 @@ public class MaterialTest {
     @Test
     public void getByOutOfRangeId() {
         assertThat(Material.getMaterial(Integer.MAX_VALUE), is(nullValue()));
+        assertThat(Material.getMaterial(Integer.MIN_VALUE), is(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
Negative id values would try to access the array out of bounds and throw an java.lang.ArrayIndexOutOfBoundsException.

Adding a check for negative values fixes this issue, and makes the method behave as expected from the documentation.
I also updated the test case, to also check for negative out of bounds.

[BUKKIT-3414](https://bukkit.atlassian.net/browse/BUKKIT-3414)
