### PR TITLE
Use .toLowerCase() also in the removePermission(String perm) method

### DIFF
--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -581,11 +581,11 @@ public final class SimplePluginManager implements PluginManager {
     }
 
     public void removePermission(Permission perm) {
-        removePermission(perm.getName().toLowerCase());
+        removePermission(perm.getName());
     }
 
     public void removePermission(String name) {
-        permissions.remove(name);
+        permissions.remove(name.toLowerCase());
     }
 
     public void recalculatePermissionDefaults(Permission perm) {


### PR DESCRIPTION
I just noticed that the .toLowerCase() method is not used removePermission(String perm) method. It is always used in every method like getPermission(String name).
Because they are case insensetive every method should lower case it. It can be confusing if getPermission("ASDF") != null returns for example true but removePermission("ASDF") does nothing.

Ticket: https://bukkit.atlassian.net/browse/BUKKIT-3424
