### PR TITLE
Added API to set the name of an inventory

### DIFF
--- a/src/main/java/org/bukkit/inventory/Inventory.java
+++ b/src/main/java/org/bukkit/inventory/Inventory.java
@@ -48,6 +48,13 @@ public interface Inventory extends Iterable<ItemStack> {
     public String getName();
 
     /**
+     * Sets the name (title) of the inventory
+     * 
+     * @param name The new name (title) of the inventory
+     */
+    public void setName(String name);
+    
+    /**
      * Get the ItemStack found in the slot at the given index
      *
      * @param index The index of the Slot's ItemStack to return


### PR DESCRIPTION
This does not work for all types of Inventories due to a minecraft limitation (Such as Furnaces). This commit will allow players to change the name (title) of inventories.

CraftBukkit PR: https://github.com/Bukkit/CraftBukkit/pull/992
Jira: https://bukkit.atlassian.net/browse/BUKKIT-3432
Test Plugin (all chests titles will be renamed): http://www.box.net/s/azf35yocux0tog4liifh
