### PR TITLE
Fix Sign.getAttachedFace() to reflect the new direction data values

### DIFF
--- a/src/main/java/org/bukkit/material/Sign.java
+++ b/src/main/java/org/bukkit/material/Sign.java
@@ -43,27 +43,7 @@ public class Sign extends MaterialData implements Attachable {
      * @return BlockFace attached to
      */
     public BlockFace getAttachedFace() {
-        if (isWallSign()) {
-            byte data = getData();
-
-            switch (data) {
-            case 0x2:
-                return BlockFace.SOUTH;
-
-            case 0x3:
-                return BlockFace.NORTH;
-
-            case 0x4:
-                return BlockFace.EAST;
-
-            case 0x5:
-                return BlockFace.WEST;
-            }
-
-            return null;
-        } else {
-            return BlockFace.DOWN;
-        }
+        return getFacing().getOppositeFace();
     }
 
     /**


### PR DESCRIPTION
This broke one of my plugins, so I peeked into the commits and saw that this was overlooked when the sign.getFacing() code was touched up.
