### PR TITLE
Expose a world's travel agent. Fixes BUKKIT-3541.

### DIFF
--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -1,7 +1,6 @@
 package org.bukkit;
 
 import java.io.File;
-import org.bukkit.generator.ChunkGenerator;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -12,9 +11,11 @@ import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 import org.bukkit.entity.*;
 import org.bukkit.generator.BlockPopulator;
+import org.bukkit.generator.ChunkGenerator;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.Metadatable;
 import org.bukkit.plugin.messaging.PluginMessageRecipient;
+import org.bukkit.TravelAgent;
 import org.bukkit.util.Vector;
 
 /**
@@ -640,6 +641,13 @@ public interface World extends PluginMessageRecipient, Metadatable {
      * @return List containing any or none BlockPopulators
      */
     public List<BlockPopulator> getPopulators();
+
+    /**
+     * Gets the {@link TravelAgent} for this world
+     *
+     * @return TravelAgent associated with this world
+     */
+    public TravelAgent getTravelAgent();
 
     /**
      * Spawn an entity of a specific class at the given {@link Location}


### PR DESCRIPTION
Currently there is no way to create a travel agent without having your own implementation. This used not to be an issue, as PlayerPortalEvent would always return a valid travel agent. However, now it will return null for custom worlds, and so the default PortalTravelAgent/CraftTravelAgent implementation cannot be used for these worlds. By exposing a world's travel agent, plugins can easily replicate default functionality for custom worlds.

Leaky: https://bukkit.atlassian.net/browse/BUKKIT-3541
CraftBukkit PR: https://github.com/Bukkit/CraftBukkit/pull/1014
