### PR TITLE
Spawnable ThrownPotion. Adds BUKKIT-2542.

### DIFF
--- a/src/main/java/org/bukkit/entity/ThrownPotion.java
+++ b/src/main/java/org/bukkit/entity/ThrownPotion.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionType;
 
 /**
  * Represents a thrown potion bottle
@@ -20,7 +21,8 @@ public interface ThrownPotion extends Projectile {
      * <p>
      * Altering this copy will not alter the thrown potion directly.
      * If you want to alter the thrown potion, you must use the
-     * {@link #setItemStack(ItemStack) setItemStack} method.
+     * {@link addEffect}, {@link addEffects}, {@link setEffects} or
+     * {@link removeEffect} methods.
      *
      * @return A copy of the ItemStack for this thrown potion.
      */
@@ -34,4 +36,41 @@ public interface ThrownPotion extends Projectile {
      * @param item New ItemStack
      */
     public void setItem(ItemStack item);
+
+    /**
+     * Adds a new effect to be applied by this potion.
+     *
+     * @param pe new {@link PotionEffect}
+     */
+    public void addEffect(PotionEffect pe);
+
+    /**
+     * Adds a {@link Collection} of new {@link PotionEffect}s to be applied
+     * by this potion.
+     *
+     * @param pe {@link Collection} of new {@link PotionEffect}s
+     */
+    public void addEffects(Collection<PotionEffect> pe);
+
+    /**
+     * Replaces all effects to be applied by this potion.
+     *
+     * @param pe {@link Collection} of {@link PotionEffect}s
+     */
+    public void setEffects(Collection<PotionEffect> cpe);
+
+    /**
+     * Removes a single {@link PotionEffect}s from this potion.
+     *
+     * @param pe {@link PotionEffect}
+     */
+    public void removeEffect(PotionEffect pe);
+
+    /**
+     * Sets this potion {@link PotionType}.
+     *
+     * @param pt the {@link Potion}s to copy from its {@link PotionEffect}s
+     * to this {@link ThrownPotion}
+     */
+    public void setPotionType(PotionType pt);
 }


### PR DESCRIPTION
Requires: https://github.com/Bukkit/CraftBukkit/pull/1031
JIRA ticket: https://bukkit.atlassian.net/browse/BUKKIT-2542

Modifies `ThrownPotion` interface to use new methods from CraftThrownPotion.

Allows splash potions to be thrown to a location, just like Arrows, Fireballs and such.
