### PR TITLE
Fixed invalid javadocs in ConfigurationSection

### DIFF
--- a/src/main/java/org/bukkit/configuration/ConfigurationSection.java
+++ b/src/main/java/org/bukkit/configuration/ConfigurationSection.java
@@ -297,7 +297,7 @@ public interface ConfigurationSection {
      * <p />
      * If the double does not exist but a default value has been specified, this
      * will return the default value. If the double does not exist and no default
-     * value was specified, this will return null.
+     * value was specified, this will return 0.
      *
      * @param path Path of the double to get.
      * @return Requested double.
@@ -334,7 +334,7 @@ public interface ConfigurationSection {
      * <p />
      * If the long does not exist but a default value has been specified, this
      * will return the default value. If the long does not exist and no default
-     * value was specified, this will return null.
+     * value was specified, this will return 0.
      *
      * @param path Path of the long to get.
      * @return Requested long.


### PR DESCRIPTION
Primitive datatypes cannot be null
https://bukkit.atlassian.net/browse/BUKKIT-3598

Current PR:
https://github.com/Bukkit/Bukkit-JavaDoc/pull/2
