### PR TITLE
Account for spacing in MapFont.getWidth()

### DIFF
--- a/src/main/java/org/bukkit/map/MapFont.java
+++ b/src/main/java/org/bukkit/map/MapFont.java
@@ -50,10 +50,16 @@ public class MapFont {
             throw new IllegalArgumentException("text contains invalid characters");
         }
 
+        if (text.length() == 0) {
+            return 0;
+        }
+
         int result = 0;
         for (int i = 0; i < text.length(); ++i) {
             result += chars.get(text.charAt(i)).getWidth();
         }
+        result += text.length() - 1; // Account for one-pixel spaces between characters
+
         return result;
     }
 


### PR DESCRIPTION
The previous MapFont.getWidth() implementation did not account for
the one-pixel spacing between characters.
