### PR TITLE
Refactor conversions from LazyMetadataValue into abstract base class (BUKKIT-3624)

### DIFF
--- a/src/main/java/org/bukkit/metadata/LazyMetadataValue.java
+++ b/src/main/java/org/bukkit/metadata/LazyMetadataValue.java
@@ -5,7 +5,6 @@ import java.util.concurrent.Callable;
 
 import org.apache.commons.lang.Validate;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.util.NumberConversions;
 
 /**
  * The LazyMetadataValue class implements a type of metadata that is not computed until another plugin asks for it.
@@ -14,11 +13,10 @@ import org.bukkit.util.NumberConversions;
  * or invalidated at the individual or plugin level. Once invalidated, the LazyMetadataValue will recompute its value
  * when asked.
  */
-public class LazyMetadataValue implements MetadataValue {
+public class LazyMetadataValue extends MetadataValueAdapter implements MetadataValue {
     private Callable<Object> lazyValue;
     private CacheStrategy cacheStrategy;
     private SoftReference<Object> internalValue = new SoftReference<Object>(null);
-    private Plugin owningPlugin;
     private static final Object ACTUALLY_NULL = new Object();
 
     /**
@@ -39,17 +37,12 @@ public class LazyMetadataValue implements MetadataValue {
      * @param lazyValue the lazy value assigned to this metadata value.
      */
     public LazyMetadataValue(Plugin owningPlugin, CacheStrategy cacheStrategy, Callable<Object> lazyValue) {
-        Validate.notNull(owningPlugin, "owningPlugin cannot be null");
+        super(owningPlugin);
         Validate.notNull(cacheStrategy, "cacheStrategy cannot be null");
         Validate.notNull(lazyValue, "lazyValue cannot be null");
 
         this.lazyValue = lazyValue;
-        this.owningPlugin = owningPlugin;
         this.cacheStrategy = cacheStrategy;
-    }
-
-    public Plugin getOwningPlugin() {
-        return owningPlugin;
     }
 
     public Object value() {
@@ -61,55 +54,6 @@ public class LazyMetadataValue implements MetadataValue {
         return value;
     }
 
-    public int asInt() {
-        return NumberConversions.toInt(value());
-    }
-
-    public float asFloat() {
-        return NumberConversions.toFloat(value());
-    }
-
-    public double asDouble() {
-        return NumberConversions.toDouble(value());
-    }
-
-    public long asLong() {
-        return NumberConversions.toLong(value());
-    }
-
-    public short asShort() {
-        return NumberConversions.toShort(value());
-    }
-
-    public byte asByte() {
-        return NumberConversions.toByte(value());
-    }
-
-    public boolean asBoolean() {
-        Object value = value();
-        if (value instanceof Boolean) {
-            return (Boolean) value;
-        }
-
-        if (value instanceof Number) {
-            return ((Number) value).intValue() != 0;
-        }
-
-        if (value instanceof String) {
-            return Boolean.parseBoolean((String) value);
-        }
-
-        return value != null;
-    }
-
-    public String asString() {
-        Object value = value();
-
-        if (value == null) {
-            return "";
-        }
-        return value.toString();
-    }
 
     /**
      * Lazily evaluates the value of this metadata item.

--- a/src/main/java/org/bukkit/metadata/LazyMetadataValue.java
+++ b/src/main/java/org/bukkit/metadata/LazyMetadataValue.java
@@ -54,7 +54,6 @@ public class LazyMetadataValue extends MetadataValueAdapter implements MetadataV
         return value;
     }
 
-
     /**
      * Lazily evaluates the value of this metadata item.
      *

--- a/src/main/java/org/bukkit/metadata/MetadataValueAdapter.java
+++ b/src/main/java/org/bukkit/metadata/MetadataValueAdapter.java
@@ -9,7 +9,7 @@ import org.bukkit.util.NumberConversions;
  *
  * This provides all the conversion functions for MetadataValue
  * so that writing an implementation of MetadataValue is as simple
- * as implementing value() and invalidate()
+ * as implementing value() and invalidate().
  *
  */
 public abstract class MetadataValueAdapter implements MetadataValue {

--- a/src/main/java/org/bukkit/metadata/MetadataValueAdapter.java
+++ b/src/main/java/org/bukkit/metadata/MetadataValueAdapter.java
@@ -1,0 +1,77 @@
+package org.bukkit.metadata;
+
+import org.apache.commons.lang.Validate;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.util.NumberConversions;
+
+/**
+ * Optional base class for facilitating MetadataValue implementations.
+ * 
+ * This provides all the conversion functions for MetadataValue 
+ * so that writing an implementation of MetadataValue is as simple 
+ * as implementing value() and invalidate()
+ *
+ */
+public abstract class MetadataValueAdapter implements MetadataValue {
+    protected final Plugin owningPlugin;
+
+    protected MetadataValueAdapter(Plugin owningPlugin) {
+        Validate.notNull(owningPlugin, "owningPlugin cannot be null");
+        this.owningPlugin = owningPlugin;
+    }
+
+    public Plugin getOwningPlugin() {
+        return owningPlugin;
+    }
+
+    public int asInt() {
+        return NumberConversions.toInt(value());
+    }
+
+    public float asFloat() {
+        return NumberConversions.toFloat(value());
+    }
+
+    public double asDouble() {
+        return NumberConversions.toDouble(value());
+    }
+
+    public long asLong() {
+        return NumberConversions.toLong(value());
+    }
+
+    public short asShort() {
+        return NumberConversions.toShort(value());
+    }
+
+    public byte asByte() {
+        return NumberConversions.toByte(value());
+    }
+
+    public boolean asBoolean() {
+        Object value = value();
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+
+        if (value instanceof Number) {
+            return ((Number) value).intValue() != 0;
+        }
+
+        if (value instanceof String) {
+            return Boolean.parseBoolean((String) value);
+        }
+
+        return value != null;
+    }
+
+    public String asString() {
+        Object value = value();
+
+        if (value == null) {
+            return "";
+        }
+        return value.toString();
+    }
+
+}

--- a/src/main/java/org/bukkit/metadata/MetadataValueAdapter.java
+++ b/src/main/java/org/bukkit/metadata/MetadataValueAdapter.java
@@ -6,9 +6,9 @@ import org.bukkit.util.NumberConversions;
 
 /**
  * Optional base class for facilitating MetadataValue implementations.
- * 
- * This provides all the conversion functions for MetadataValue 
- * so that writing an implementation of MetadataValue is as simple 
+ *
+ * This provides all the conversion functions for MetadataValue
+ * so that writing an implementation of MetadataValue is as simple
  * as implementing value() and invalidate()
  *
  */

--- a/src/test/java/org/bukkit/metadata/MetadataValueAdapterTest.java
+++ b/src/test/java/org/bukkit/metadata/MetadataValueAdapterTest.java
@@ -1,0 +1,44 @@
+package org.bukkit.metadata;
+
+import static org.junit.Assert.assertEquals;
+
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.TestPlugin;
+import org.junit.Test;
+
+public class MetadataValueAdapterTest {
+    private TestPlugin plugin = new TestPlugin("x");
+
+    @Test
+    public void testIncrementingAdapter() {
+        IncrementingMetaValue mv = new IncrementingMetaValue(plugin);
+        // check getOwningPlugin
+        assertEquals(mv.getOwningPlugin(), this.plugin);
+
+        // check the various value-making methods
+        assertEquals(mv.asInt(), 1);
+        assertEquals(mv.asLong(), 2L);
+        assertEquals(mv.asFloat(), 3.0, 0.001);
+        assertEquals(mv.asByte(), 4);
+        assertEquals(mv.asDouble(), 5.0, 0.001);
+        assertEquals(mv.asShort(), 6);
+        assertEquals(mv.asString(), "7");
+    }
+
+    /** Silly Metadata implementation that increments every time value() is called */
+    class IncrementingMetaValue extends MetadataValueAdapter {
+        private int internalValue = 0;
+
+        protected IncrementingMetaValue(Plugin owningPlugin) {
+            super(owningPlugin);
+        }
+
+        public Object value() {
+            return ++internalValue;
+        }
+
+        public void invalidate() {
+            internalValue = 0;
+        }
+    }
+}

--- a/src/test/java/org/bukkit/metadata/MetadataValueAdapterTest.java
+++ b/src/test/java/org/bukkit/metadata/MetadataValueAdapterTest.java
@@ -10,22 +10,75 @@ public class MetadataValueAdapterTest {
     private TestPlugin plugin = new TestPlugin("x");
 
     @Test
-    public void testIncrementingAdapter() {
+    public void testAdapterBasics() {
         IncrementingMetaValue mv = new IncrementingMetaValue(plugin);
         // check getOwningPlugin
         assertEquals(mv.getOwningPlugin(), this.plugin);
 
-        // check the various value-making methods
-        assertEquals(mv.asInt(), 1);
-        assertEquals(mv.asLong(), 2L);
-        assertEquals(mv.asFloat(), 3.0, 0.001);
-        assertEquals(mv.asByte(), 4);
-        assertEquals(mv.asDouble(), 5.0, 0.001);
-        assertEquals(mv.asShort(), 6);
-        assertEquals(mv.asString(), "7");
+        // Check value-getting and invalidation.
+        assertEquals(new Integer(1), mv.value());
+        assertEquals(new Integer(2), mv.value());
+        mv.invalidate();
+        assertEquals(new Integer(1), mv.value());
     }
 
-    /** Silly Metadata implementation that increments every time value() is called */
+    @Test
+    public void testAdapterConversions() {
+        IncrementingMetaValue mv = new IncrementingMetaValue(plugin);
+
+        assertEquals(1, mv.asInt());
+        assertEquals(2L, mv.asLong());
+        assertEquals(3.0, mv.asFloat(), 0.001);
+        assertEquals(4, mv.asByte());
+        assertEquals(5.0, mv.asDouble(), 0.001);
+        assertEquals(6, mv.asShort());
+        assertEquals("7", mv.asString());
+    }
+
+    /** Boolean conversion is non-trivial, we want to test it thoroughly. */
+    @Test
+    public void testBooleanConversion() {
+        // null is False.
+        assertEquals(false, simpleValue(null).asBoolean());
+
+        // String to boolean.
+        assertEquals(true, simpleValue("True").asBoolean());
+        assertEquals(true, simpleValue("TRUE").asBoolean());
+        assertEquals(false, simpleValue("false").asBoolean());
+
+        // Number to boolean.
+        assertEquals(true, simpleValue(1).asBoolean());
+        assertEquals(true, simpleValue(5.0).asBoolean());
+        assertEquals(false, simpleValue(0).asBoolean());
+        assertEquals(false, simpleValue(0.1).asBoolean());
+
+        // Boolean as boolean, of course.
+        assertEquals(true, simpleValue(Boolean.TRUE).asBoolean());
+        assertEquals(false, simpleValue(Boolean.FALSE).asBoolean());
+
+        // any object that is not null and not a Boolean, String, or Number is true.
+        assertEquals(true, simpleValue(new Object()).asBoolean());
+    }
+
+    /** Test String conversions return an empty string when given null. */
+    @Test
+    public void testStringConversionNull() {
+        assertEquals("", simpleValue(null).asString());
+    }
+
+    /** Get a fixed value MetadataValue. */
+    private MetadataValue simpleValue(Object value) {
+        return new FixedMetadataValue(plugin, value);
+    }
+
+    /**
+     * A sample non-trivial MetadataValueAdapter implementation.
+     *
+     * The rationale for implementing an incrementing value is to have a value
+     * which changes with every call to value(). This is important for testing
+     * because we want to make sure all the tested conversions are calling the
+     * value() method exactly once and no caching is going on.
+     */
     class IncrementingMetaValue extends MetadataValueAdapter {
         private int internalValue = 0;
 


### PR DESCRIPTION
Implementing MetadataValue interface is significant work due to having to provide a large amount of conversion stub methods. This adds a new optional abstract base class to aid in implementation, and has LazyMetadataValue extend this.

Includes comprehensive unit tests including a sample adapted class, and all existing metadata tests pass as well.

This supercedes an older pull request https://github.com/Bukkit/Bukkit/pull/580

Also see associated Atlassian ticket: https://bukkit.atlassian.net/browse/BUKKIT-3624
