### PR TITLE
[B+C] Add MetadataProvider for on-demand metadata [BUKKIT-3625]

### DIFF
--- a/src/main/java/org/bukkit/Bukkit.java
+++ b/src/main/java/org/bukkit/Bukkit.java
@@ -12,6 +12,7 @@ import org.bukkit.Warning.WarningState;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.command.PluginCommand;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.help.HelpMap;
@@ -20,6 +21,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.map.MapView;
+import org.bukkit.metadata.MetadataProvider;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.ServicesManager;
 import org.bukkit.plugin.messaging.Messenger;
@@ -394,5 +396,19 @@ public final class Bukkit {
 
     public static ItemFactory getItemFactory() {
         return server.getItemFactory();
+    }
+    
+    
+    public static boolean registerPlayerMetadataProvider(String metadataKey, MetadataProvider<OfflinePlayer> provider) {
+        return server.registerPlayerMetadataProvider(metadataKey, provider);
+    }
+    
+    
+    public static boolean registerWorldMetadataProvider(String metadataKey, MetadataProvider<World> provider) {
+        return server.registerWorldMetadataProvider(metadataKey, provider);
+    }
+    
+    public static boolean registerEntityMetadataProvider(String metadataKey, MetadataProvider<Entity> provider) {
+        return server.registerEntityMetadataProvider(metadataKey, provider);
     }
 }

--- a/src/main/java/org/bukkit/Bukkit.java
+++ b/src/main/java/org/bukkit/Bukkit.java
@@ -12,7 +12,6 @@ import org.bukkit.Warning.WarningState;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.command.PluginCommand;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.help.HelpMap;

--- a/src/main/java/org/bukkit/Bukkit.java
+++ b/src/main/java/org/bukkit/Bukkit.java
@@ -21,6 +21,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.map.MapView;
+import org.bukkit.metadata.Metadatable;
 import org.bukkit.metadata.MetadataProvider;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.ServicesManager;
@@ -398,15 +399,11 @@ public final class Bukkit {
         return server.getItemFactory();
     }
 
-    public static boolean registerPlayerMetadataProvider(String metadataKey, MetadataProvider<OfflinePlayer> provider) {
-        return server.registerPlayerMetadataProvider(metadataKey, provider);
+    public static <T extends Metadatable> boolean registerMetadataProvider(Class<T> clazz, String metadataKey, MetadataProvider<T> provider) {
+        return server.registerMetadataProvider(clazz, metadataKey, provider);
     }
 
-    public static boolean registerWorldMetadataProvider(String metadataKey, MetadataProvider<World> provider) {
-        return server.registerWorldMetadataProvider(metadataKey, provider);
-    }
-
-    public static boolean registerEntityMetadataProvider(String metadataKey, MetadataProvider<Entity> provider) {
-        return server.registerEntityMetadataProvider(metadataKey, provider);
+    public static <T extends Metadatable> void unregisterMetadataProvider(Class<T> clazz, String metadataKey) {
+        server.unregisterMetadataProvider(clazz, metadataKey);
     }
 }

--- a/src/main/java/org/bukkit/Bukkit.java
+++ b/src/main/java/org/bukkit/Bukkit.java
@@ -23,6 +23,7 @@ import org.bukkit.inventory.Recipe;
 import org.bukkit.map.MapView;
 import org.bukkit.metadata.Metadatable;
 import org.bukkit.metadata.MetadataProvider;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.ServicesManager;
 import org.bukkit.plugin.messaging.Messenger;
@@ -399,11 +400,11 @@ public final class Bukkit {
         return server.getItemFactory();
     }
 
-    public static <T extends Metadatable> boolean registerMetadataProvider(Class<T> clazz, String metadataKey, MetadataProvider<T> provider) {
-        return server.registerMetadataProvider(clazz, metadataKey, provider);
+    public static <T extends Metadatable> void registerMetadataProvider(Class<T> clazz, Plugin plugin, MetadataProvider<T> provider) {
+        server.registerMetadataProvider(clazz, plugin, provider);
     }
 
-    public static <T extends Metadatable> void unregisterMetadataProvider(Class<T> clazz, String metadataKey) {
-        server.unregisterMetadataProvider(clazz, metadataKey);
+    public static <T extends Metadatable> void unregisterMetadataProvider(Class<T> clazz, Plugin plugin) {
+        server.unregisterMetadataProvider(clazz, plugin);
     }
 }

--- a/src/main/java/org/bukkit/Bukkit.java
+++ b/src/main/java/org/bukkit/Bukkit.java
@@ -397,17 +397,15 @@ public final class Bukkit {
     public static ItemFactory getItemFactory() {
         return server.getItemFactory();
     }
-    
-    
+
     public static boolean registerPlayerMetadataProvider(String metadataKey, MetadataProvider<OfflinePlayer> provider) {
         return server.registerPlayerMetadataProvider(metadataKey, provider);
     }
-    
-    
+
     public static boolean registerWorldMetadataProvider(String metadataKey, MetadataProvider<World> provider) {
         return server.registerWorldMetadataProvider(metadataKey, provider);
     }
-    
+
     public static boolean registerEntityMetadataProvider(String metadataKey, MetadataProvider<Entity> provider) {
         return server.registerEntityMetadataProvider(metadataKey, provider);
     }

--- a/src/main/java/org/bukkit/OfflinePlayer.java
+++ b/src/main/java/org/bukkit/OfflinePlayer.java
@@ -3,9 +3,10 @@ package org.bukkit;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.entity.AnimalTamer;
 import org.bukkit.entity.Player;
+import org.bukkit.metadata.Metadatable;
 import org.bukkit.permissions.ServerOperator;
 
-public interface OfflinePlayer extends ServerOperator, AnimalTamer, ConfigurationSerializable {
+public interface OfflinePlayer extends ServerOperator, Metadatable, AnimalTamer, ConfigurationSerializable {
     /**
      * Checks if this player is currently online
      *

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -24,6 +24,7 @@ import org.bukkit.inventory.Recipe;
 import org.bukkit.map.MapView;
 import org.bukkit.metadata.Metadatable;
 import org.bukkit.metadata.MetadataProvider;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.ServicesManager;
 import org.bukkit.plugin.messaging.Messenger;
@@ -696,17 +697,16 @@ public interface Server extends PluginMessageRecipient {
     /**
      * Register a metadata provider for on-demand metadata.
      * @param clazz The class type of metadata this provider accepts
-     * @param metadataKey The key to respond to
      * @param provider A metadata provider
+     * @param plugin The plugin which is registering this
      * @return true if we were the first to register, false if another plugin was registered.
      */
-    public <T extends Metadatable> boolean registerMetadataProvider(Class<T> clazz, String metadataKey, MetadataProvider<T> provider);
+    public <T extends Metadatable> void registerMetadataProvider(Class<T> clazz, Plugin plugin, MetadataProvider<T> provider);
 
     /**
      * Unregister a metadata provider.
      * @param clazz The class type of metadata this provider accepts
-     * @param metadataKey The key to respond to
-     * @return true if we were the first to register, false if another plugin was registered.
+     * @param plugin the plugin which this provider is registered to
      */
-    public <T extends Metadatable> void unregisterMetadataProvider(Class<T> clazz, String metadataKey);
+    public <T extends Metadatable> void unregisterMetadataProvider(Class<T> clazz, Plugin plugin);
 }

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -13,6 +13,7 @@ import org.bukkit.command.CommandException;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.command.PluginCommand;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.help.HelpMap;
@@ -21,6 +22,7 @@ import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.map.MapView;
+import org.bukkit.metadata.MetadataProvider;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.ServicesManager;
 import org.bukkit.plugin.messaging.Messenger;
@@ -689,4 +691,28 @@ public interface Server extends PluginMessageRecipient {
      * @see ItemFactory
      */
     ItemFactory getItemFactory();
+    
+    /**
+     * Register a Player metadata provider for on-demand metadata.
+     * @param metadataKey The key to respond to
+     * @param provider A metadata provider
+     * @return true if we were the first to register, false if another plugin was registered.
+     */
+    public boolean registerPlayerMetadataProvider(String metadataKey, MetadataProvider<OfflinePlayer> provider);
+    
+    /**
+     * Register a World metadata provider for on-demand metadata.
+     * @param metadataKey The key to respond to
+     * @param provider A metadata provider
+     * @return true if we were the first to register, false if another plugin was registered.
+     */
+    public boolean registerWorldMetadataProvider(String metadataKey, MetadataProvider<World> provider);
+    
+    /**
+     * Register a Entity metadata provider for on-demand metadata.
+     * @param metadataKey The key to respond to
+     * @param provider A metadata provider
+     * @return true if we were the first to register, false if another plugin was registered.
+     */
+    public boolean registerEntityMetadataProvider(String metadataKey, MetadataProvider<Entity> provider);
 }

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -13,7 +13,6 @@ import org.bukkit.command.CommandException;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.command.PluginCommand;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.help.HelpMap;

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -691,7 +691,7 @@ public interface Server extends PluginMessageRecipient {
      * @see ItemFactory
      */
     ItemFactory getItemFactory();
-    
+
     /**
      * Register a Player metadata provider for on-demand metadata.
      * @param metadataKey The key to respond to
@@ -699,7 +699,7 @@ public interface Server extends PluginMessageRecipient {
      * @return true if we were the first to register, false if another plugin was registered.
      */
     public boolean registerPlayerMetadataProvider(String metadataKey, MetadataProvider<OfflinePlayer> provider);
-    
+
     /**
      * Register a World metadata provider for on-demand metadata.
      * @param metadataKey The key to respond to
@@ -707,7 +707,7 @@ public interface Server extends PluginMessageRecipient {
      * @return true if we were the first to register, false if another plugin was registered.
      */
     public boolean registerWorldMetadataProvider(String metadataKey, MetadataProvider<World> provider);
-    
+
     /**
      * Register a Entity metadata provider for on-demand metadata.
      * @param metadataKey The key to respond to

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -22,6 +22,7 @@ import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.map.MapView;
+import org.bukkit.metadata.Metadatable;
 import org.bukkit.metadata.MetadataProvider;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.ServicesManager;
@@ -693,26 +694,19 @@ public interface Server extends PluginMessageRecipient {
     ItemFactory getItemFactory();
 
     /**
-     * Register a Player metadata provider for on-demand metadata.
+     * Register a metadata provider for on-demand metadata.
+     * @param clazz The class type of metadata this provider accepts
      * @param metadataKey The key to respond to
      * @param provider A metadata provider
      * @return true if we were the first to register, false if another plugin was registered.
      */
-    public boolean registerPlayerMetadataProvider(String metadataKey, MetadataProvider<OfflinePlayer> provider);
+    public <T extends Metadatable> boolean registerMetadataProvider(Class<T> clazz, String metadataKey, MetadataProvider<T> provider);
 
     /**
-     * Register a World metadata provider for on-demand metadata.
+     * Unregister a metadata provider.
+     * @param clazz The class type of metadata this provider accepts
      * @param metadataKey The key to respond to
-     * @param provider A metadata provider
      * @return true if we were the first to register, false if another plugin was registered.
      */
-    public boolean registerWorldMetadataProvider(String metadataKey, MetadataProvider<World> provider);
-
-    /**
-     * Register a Entity metadata provider for on-demand metadata.
-     * @param metadataKey The key to respond to
-     * @param provider A metadata provider
-     * @return true if we were the first to register, false if another plugin was registered.
-     */
-    public boolean registerEntityMetadataProvider(String metadataKey, MetadataProvider<Entity> provider);
+    public <T extends Metadatable> void unregisterMetadataProvider(Class<T> clazz, String metadataKey);
 }

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -13,6 +13,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.*;
 import org.bukkit.generator.BlockPopulator;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.metadata.MetadataProvider;
 import org.bukkit.metadata.Metadatable;
 import org.bukkit.plugin.messaging.PluginMessageRecipient;
 import org.bukkit.util.Vector;
@@ -1061,6 +1062,14 @@ public interface World extends PluginMessageRecipient, Metadatable {
      * @return True if rule exists
      */
     public boolean isGameRule(String rule);
+    
+    /**
+     * Register a Block metadata provider for on-demand metadata.
+     * @param metadataKey The key to respond to
+     * @param provider a metadata provider
+     * @return true if we were the first to register, false if another plugin was registered.
+     */
+    public boolean registerBlockMetadataProvider(String metadataKey, MetadataProvider<Block> provider);
 
     /**
      * Represents various map environment types that a world may be

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -1062,14 +1062,6 @@ public interface World extends PluginMessageRecipient, Metadatable {
      * @return True if rule exists
      */
     public boolean isGameRule(String rule);
-    
-    /**
-     * Register a Block metadata provider for on-demand metadata.
-     * @param metadataKey The key to respond to
-     * @param provider a metadata provider
-     * @return true if we were the first to register, false if another plugin was registered.
-     */
-    public boolean registerBlockMetadataProvider(String metadataKey, MetadataProvider<Block> provider);
 
     /**
      * Represents various map environment types that a world may be

--- a/src/main/java/org/bukkit/metadata/MetadataProvider.java
+++ b/src/main/java/org/bukkit/metadata/MetadataProvider.java
@@ -1,6 +1,5 @@
 package org.bukkit.metadata;
 
-import org.bukkit.plugin.Plugin;
 
 /**
  * Provide "On-Demand" Metadata lookup.
@@ -11,7 +10,7 @@ import org.bukkit.plugin.Plugin;
  *
  * @param <T> A supplied class which can receive Metadata.
  */
-public interface MetadataProvider<T> {
+public interface MetadataProvider<T extends Metadatable> {
     /**
      * Get a Metadata value for a subject.
      * @param subject The object for which we're requesting metadata

--- a/src/main/java/org/bukkit/metadata/MetadataProvider.java
+++ b/src/main/java/org/bukkit/metadata/MetadataProvider.java
@@ -1,0 +1,29 @@
+package org.bukkit.metadata;
+
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Provide "On-Demand" Metadata lookup.
+ * 
+ * The purpose of this is to allow plugin authors to define a way for
+ * Metadata to be generated on request for a key, rather than having to
+ * predefine it.
+ *
+ * @param <T> A supplied class which can receive Metadata.
+ */
+public interface MetadataProvider<T> {
+    
+    /**
+     * Get the plugin which owns this provider.
+     * @return A Bukkit plugin.
+     */
+    public Plugin getOwningPlugin();
+    
+    /**
+     * Get a Metadata value for a subject. 
+     * @param subject The object for which we're requesting metadata
+     * @param key The key on which metadata is being requested.
+     * @return A MetadataValue, or null
+     */
+    public MetadataValue getValue(T subject, String key);
+}

--- a/src/main/java/org/bukkit/metadata/MetadataProvider.java
+++ b/src/main/java/org/bukkit/metadata/MetadataProvider.java
@@ -4,7 +4,7 @@ import org.bukkit.plugin.Plugin;
 
 /**
  * Provide "On-Demand" Metadata lookup.
- * 
+ *
  * The purpose of this is to allow plugin authors to define a way for
  * Metadata to be generated on request for a key, rather than having to
  * predefine it.
@@ -12,15 +12,8 @@ import org.bukkit.plugin.Plugin;
  * @param <T> A supplied class which can receive Metadata.
  */
 public interface MetadataProvider<T> {
-    
     /**
-     * Get the plugin which owns this provider.
-     * @return A Bukkit plugin.
-     */
-    public Plugin getOwningPlugin();
-    
-    /**
-     * Get a Metadata value for a subject. 
+     * Get a Metadata value for a subject.
      * @param subject The object for which we're requesting metadata
      * @param key The key on which metadata is being requested.
      * @return A MetadataValue, or null

--- a/src/main/java/org/bukkit/metadata/MetadataStore.java
+++ b/src/main/java/org/bukkit/metadata/MetadataStore.java
@@ -60,7 +60,7 @@ public interface MetadataStore<T> {
      * @return true if provider was added, false if there was already a provider.
      */
     public boolean registerProvider(String metadataKey, MetadataProvider<T> provider);
-    
+
     /**
      * Unregister provider for this key.
      * @param metadataKey The key for which this provider is answering for.

--- a/src/main/java/org/bukkit/metadata/MetadataStore.java
+++ b/src/main/java/org/bukkit/metadata/MetadataStore.java
@@ -52,4 +52,19 @@ public interface MetadataStore<T> {
      * @throws IllegalArgumentException If plugin is null
      */
     public void invalidateAll(Plugin owningPlugin);
+
+    /**
+     * Register a provider to do on-demand metadata.
+     * @param metadataKey The key for which this provider is answering for.
+     * @param provider A metadata provider.
+     * @return true if provider was added, false if there was already a provider.
+     */
+    public boolean registerProvider(String metadataKey, MetadataProvider<T> provider);
+    
+    /**
+     * Unregister provider for this key.
+     * @param metadataKey The key for which this provider is answering for.
+     * @return true if provider unregistered, false otherwise.
+     */
+    public boolean unregisterProvider(String metadataKey);
 }

--- a/src/main/java/org/bukkit/metadata/MetadataStore.java
+++ b/src/main/java/org/bukkit/metadata/MetadataStore.java
@@ -52,19 +52,4 @@ public interface MetadataStore<T> {
      * @throws IllegalArgumentException If plugin is null
      */
     public void invalidateAll(Plugin owningPlugin);
-
-    /**
-     * Register a provider to do on-demand metadata.
-     * @param metadataKey The key for which this provider is answering for.
-     * @param provider A metadata provider.
-     * @return true if provider was added, false if there was already a provider.
-     */
-    public boolean registerProvider(String metadataKey, MetadataProvider<T> provider);
-
-    /**
-     * Unregister provider for this key.
-     * @param metadataKey The key for which this provider is answering for.
-     * @return true if provider unregistered, false otherwise.
-     */
-    public boolean unregisterProvider(String metadataKey);
 }

--- a/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
+++ b/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
@@ -10,7 +10,11 @@ import java.util.*;
 public abstract class MetadataStoreBase<T> {
     private Map<String, List<MetadataValue>> metadataMap = new HashMap<String, List<MetadataValue>>();
     private WeakHashMap<T, Map<String, String>> disambiguationCache = new WeakHashMap<T, Map<String, String>>();
-    private Map<String, MetadataProvider<T>> providers = new HashMap<String, MetadataProvider<T>>();
+    private final Map<String, MetadataProvider<T>> providers;
+
+    protected MetadataStoreBase(Map<String, MetadataProvider<T>> providers) {
+        this.providers = providers;
+    }
 
     /**
      * Adds a metadata value to an object. Each metadata value is owned by a specific{@link Plugin}.
@@ -110,8 +114,9 @@ public abstract class MetadataStoreBase<T> {
     }
 
     /**
-     * Invalidates all metadata in the metadata store that originates from the given plugin. Doing this will force
-     * each invalidated metadata item to be recalculated the next time it is accessed.
+     * Invalidates all metadata in the metadata store that originates from the given plugin.
+     * Doing this will force each invalidated metadata item to be recalculated
+     * the next time it is accessed.
      *
      * @param owningPlugin the plugin requesting the invalidation.
      * @see MetadataStore#invalidateAll(org.bukkit.plugin.Plugin)

--- a/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
+++ b/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
@@ -5,7 +5,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -16,9 +15,9 @@ import java.util.logging.Level;
 public abstract class MetadataStoreBase<T extends Metadatable> implements MetadataStore<T> {
     private Map<String, List<MetadataValue>> metadataMap = new HashMap<String, List<MetadataValue>>();
     private WeakHashMap<T, Map<String, String>> disambiguationCache = new WeakHashMap<T, Map<String, String>>();
-    private final Collection<MetadataProvider<T>> providers;
+    private final Map<Class<? extends Metadatable>, List<MetadataProvider<T>>> providers;
 
-    protected MetadataStoreBase(Collection<MetadataProvider<T>> providers) {
+    protected MetadataStoreBase(Map<Class<? extends Metadatable>, List<MetadataProvider<T>>> providers) {
         this.providers = providers;
     }
 
@@ -180,7 +179,7 @@ public abstract class MetadataStoreBase<T extends Metadatable> implements Metada
      */
     private boolean buildProviderData(T subject, String metadataKey) {
         boolean success = false;
-        for (MetadataProvider<T> provider : providers) {
+        for (MetadataProvider<T> provider : providers.get(subject.getClass())) {
             MetadataValue providedValue = null;
             try {
                 providedValue = provider.getValue(subject, metadataKey);

--- a/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
+++ b/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
@@ -198,7 +198,7 @@ public abstract class MetadataStoreBase<T> {
             providedValue = provider.getValue(subject, metadataKey);
         } catch (Exception ex) {
             String message = String.format("Error occurred while calling metadata provider %s in plugin %s for key %s", provider.getClass(), getProviderPluginName(provider), metadataKey);
-            Bukkit.getServer().getLogger().log(Level.SEVERE, message, ex);
+            Bukkit.getLogger().log(Level.SEVERE, message, ex);
         }
         if (providedValue != null) {
             setMetadata(subject, metadataKey, providedValue);

--- a/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
+++ b/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
@@ -56,7 +56,6 @@ public abstract class MetadataStoreBase<T> {
      * @see MetadataStore#getMetadata(Object, String)
      */
     public synchronized List<MetadataValue> getMetadata(T subject, String metadataKey) {
-       
         String key = cachedDisambiguate(subject, metadataKey);
         if (metadataMap.containsKey(key)) {
             return Collections.unmodifiableList(metadataMap.get(key));
@@ -184,8 +183,7 @@ public abstract class MetadataStoreBase<T> {
      * @return a unique metadata key for the given subject.
      */
     protected abstract String disambiguate(T subject, String metadataKey);
-    
-    
+
     /**
      * Retrieve provider data for this key, and set it if it's not null.
      * @param subject The context for which we're getting this metadata

--- a/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
+++ b/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
@@ -4,8 +4,14 @@ import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
-import java.util.*;
 
 public abstract class MetadataStoreBase<T> {
     private Map<String, List<MetadataValue>> metadataMap = new HashMap<String, List<MetadataValue>>();

--- a/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
+++ b/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
@@ -134,28 +134,6 @@ public abstract class MetadataStoreBase<T> {
     }
 
     /**
-     * Register a provider to do on-demand metadata.
-     * @param metadataKey The key for which this provider is answering for.
-     * @param provider A metadata provider.
-     * @return true if provider was added, false if there was already a provider.
-     */
-    public boolean registerProvider(String metadataKey, MetadataProvider<T> provider) {
-        Validate.notNull(metadataKey, "metadataKey cannot be null");
-        Validate.notNull(provider, "Provider cannot be null");
-        Validate.notNull(provider.getOwningPlugin(), "provider.owningPlugin() cannot be null");
-        return (providers.put(metadataKey, provider) == null);
-    }
-
-    /**
-     * Unregister an on-demand provider.
-     * @param metadataKey The key for which this provider is answering for.
-     * @return true if a provider was removed, false otherwise
-     */
-    public boolean unregisterProvider(String metadataKey) {
-        return (providers.remove(metadataKey) != null);
-    }
-
-    /**
      * Caches the results of calls to {@link MetadataStoreBase#disambiguate(Object, String)} in a {@link WeakHashMap}. Doing so maintains a
      * <a href="http://www.codeinstructions.com/2008/09/weakhashmap-is-not-cache-understanding.html">canonical list</a>
      * of disambiguation strings for objects in memory. When those objects are garbage collected, the disambiguation string

--- a/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
+++ b/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.logging.Level;
 
-public abstract class MetadataStoreBase<T> {
+public abstract class MetadataStoreBase<T extends Metadatable> implements MetadataStore<T> {
     private Map<String, List<MetadataValue>> metadataMap = new HashMap<String, List<MetadataValue>>();
     private WeakHashMap<T, Map<String, String>> disambiguationCache = new WeakHashMap<T, Map<String, String>>();
     private final Collection<MetadataProvider<T>> providers;

--- a/src/test/java/org/bukkit/metadata/MetadataStoreTest.java
+++ b/src/test/java/org/bukkit/metadata/MetadataStoreTest.java
@@ -114,14 +114,14 @@ public class MetadataStoreTest {
         assertEquals(1, subject.getMetadata("subject", "key").size());
         assertEquals(10, subject.getMetadata("subject", "key").get(0).value());
     }
-    
+
     @Test
     public void testHasMetadata() {
         subject.setMetadata("subject", "key", new FixedMetadataValue(pluginX, 10));
         assertTrue(subject.hasMetadata("subject", "key"));
         assertFalse(subject.hasMetadata("subject", "otherKey"));
     }
-    
+
     @Test
     public void testRegisterUnregisterProvider() {
         StringMetadataProvider p = new StringMetadataProvider();
@@ -133,7 +133,7 @@ public class MetadataStoreTest {
         assertEquals(subject.unregisterProvider("uppercased"), true);
         assertEquals(subject.unregisterProvider("uppercased"), false);
     }
-    
+
     @Test
     public void testProviderUsage() {
         assertEquals(subject.getMetadata("foobar", "uppercased").size(), 0);
@@ -161,10 +161,10 @@ public class MetadataStoreTest {
             return subject + ":" + metadataKey;
         }
     }
-    
+
     private class StringMetadataProvider implements MetadataProvider<String> {
         public final Counter counter = new Counter();
-        
+
         public Plugin getOwningPlugin() {
             return pluginX;
         }
@@ -177,7 +177,7 @@ public class MetadataStoreTest {
                 return new FixedMetadataValue(pluginX, subject.toUpperCase());
             }
         }
-        
+
     }
 
     private class Counter {

--- a/src/test/java/org/bukkit/metadata/MetadataStoreTest.java
+++ b/src/test/java/org/bukkit/metadata/MetadataStoreTest.java
@@ -13,7 +13,6 @@ import org.bukkit.plugin.TestPlugin;
 import org.junit.Test;
 
 public class MetadataStoreTest {
-
     private Plugin pluginX = new TestPlugin("x");
     private Plugin pluginY = new TestPlugin("y");
 
@@ -165,10 +164,6 @@ public class MetadataStoreTest {
 
     private class StringMetadataProvider implements MetadataProvider<String> {
         public final Counter counter = new Counter();
-
-        public Plugin getOwningPlugin() {
-            return pluginX;
-        }
 
         public MetadataValue getValue(String subject, String key) {
             counter.increment();

--- a/src/test/java/org/bukkit/metadata/MetadataStoreTest.java
+++ b/src/test/java/org/bukkit/metadata/MetadataStoreTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -126,11 +126,11 @@ public class MetadataStoreTest {
 
     @Test
     public void testProviderUsage() {
-        HashMap<String, MetadataProvider<String>> mapping = new HashMap<String, MetadataProvider<String>>();
+        List<MetadataProvider<String>> mapping = new ArrayList<MetadataProvider<String>>();
         StringMetadataStore store = new StringMetadataStore(mapping);
         assertEquals(store.getMetadata("foobar", "uppercased").size(), 0);
         StringMetadataProvider p = new StringMetadataProvider();
-        mapping.put("uppercased", p);
+        mapping.add(p);
         assertEquals(0, p.counter.value());
         List<MetadataValue> values = store.getMetadata("foobar", "uppercased");
         assertEquals(1, values.size());
@@ -150,9 +150,10 @@ public class MetadataStoreTest {
 
     private class StringMetadataStore extends MetadataStoreBase<String> implements MetadataStore<String> {
         public StringMetadataStore() {
-            this(new HashMap<String, MetadataProvider<String>>());
+            this(new ArrayList<MetadataProvider<String>>());
         }
-        public StringMetadataStore(HashMap<String, MetadataProvider<String>> mapping) {
+
+        public StringMetadataStore(List<MetadataProvider<String>> mapping) {
             super(mapping);
         }
 

--- a/src/test/java/org/bukkit/metadata/MetadataStoreTest.java
+++ b/src/test/java/org/bukkit/metadata/MetadataStoreTest.java
@@ -5,7 +5,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 
 import org.bukkit.plugin.Plugin;
@@ -16,21 +18,21 @@ public class MetadataStoreTest {
     private Plugin pluginX = new TestPlugin("x");
     private Plugin pluginY = new TestPlugin("y");
 
-    StringMetadataStore subject = new StringMetadataStore();
+    TValueStore store = new TValueStore();
 
     @Test
     public void testMetadataStore() {
-        subject.setMetadata("subject", "key", new FixedMetadataValue(pluginX, 10));
+        store.setMetadata(new TValue("subject"), "key", new FixedMetadataValue(pluginX, 10));
 
-        assertTrue(subject.hasMetadata("subject", "key"));
-        List<MetadataValue> values = subject.getMetadata("subject", "key");
+        assertTrue(store.hasMetadata(new TValue("subject"), "key"));
+        List<MetadataValue> values = store.getMetadata(new TValue("subject"), "key");
         assertEquals(10, values.get(0).value());
     }
 
     @Test
     public void testMetadataNotPresent() {
-        assertFalse(subject.hasMetadata("subject", "key"));
-        List<MetadataValue> values = subject.getMetadata("subject", "key");
+        assertFalse(store.hasMetadata(new TValue("subject"), "key"));
+        List<MetadataValue> values = store.getMetadata(new TValue("subject"), "key");
         assertTrue(values.isEmpty());
     }
 
@@ -38,17 +40,17 @@ public class MetadataStoreTest {
     public void testInvalidateAll() {
         final Counter counter = new Counter();
 
-        subject.setMetadata("subject", "key", new LazyMetadataValue(pluginX, new Callable<Object>() {
+        store.setMetadata(new TValue("subject"), "key", new LazyMetadataValue(pluginX, new Callable<Object>() {
             public Object call() throws Exception {
                 counter.increment();
                 return 10;
             }
         }));
 
-        assertTrue(subject.hasMetadata("subject", "key"));
-        subject.getMetadata("subject", "key").get(0).value();
-        subject.invalidateAll(pluginX);
-        subject.getMetadata("subject", "key").get(0).value();
+        assertTrue(store.hasMetadata(new TValue("subject"), "key"));
+        store.getMetadata(new TValue("subject"), "key").get(0).value();
+        store.invalidateAll(pluginX);
+        store.getMetadata(new TValue("subject"), "key").get(0).value();
         assertEquals(2, counter.value());
     }
 
@@ -56,27 +58,27 @@ public class MetadataStoreTest {
     public void testInvalidateAllButActuallyNothing() {
         final Counter counter = new Counter();
 
-        subject.setMetadata("subject", "key", new LazyMetadataValue(pluginX, new Callable<Object>() {
+        store.setMetadata(new TValue("subject"), "key", new LazyMetadataValue(pluginX, new Callable<Object>() {
             public Object call() throws Exception {
                 counter.increment();
                 return 10;
             }
         }));
 
-        assertTrue(subject.hasMetadata("subject", "key"));
-        subject.getMetadata("subject", "key").get(0).value();
-        subject.invalidateAll(pluginY);
-        subject.getMetadata("subject", "key").get(0).value();
+        assertTrue(store.hasMetadata(new TValue("subject"), "key"));
+        store.getMetadata(new TValue("subject"), "key").get(0).value();
+        store.invalidateAll(pluginY);
+        store.getMetadata(new TValue("subject"), "key").get(0).value();
         assertEquals(1, counter.value());
     }
 
     @Test
     public void testMetadataReplace() {
-        subject.setMetadata("subject", "key", new FixedMetadataValue(pluginX, 10));
-        subject.setMetadata("subject", "key", new FixedMetadataValue(pluginY, 10));
-        subject.setMetadata("subject", "key", new FixedMetadataValue(pluginX, 20));
+        store.setMetadata(new TValue("subject"), "key", new FixedMetadataValue(pluginX, 10));
+        store.setMetadata(new TValue("subject"), "key", new FixedMetadataValue(pluginY, 10));
+        store.setMetadata(new TValue("subject"), "key", new FixedMetadataValue(pluginX, 20));
 
-        for (MetadataValue mv : subject.getMetadata("subject", "key")) {
+        for (MetadataValue mv : store.getMetadata(new TValue("subject"), "key")) {
             if (mv.getOwningPlugin().equals(pluginX)) {
                 assertEquals(20, mv.value());
             }
@@ -88,89 +90,134 @@ public class MetadataStoreTest {
 
     @Test
     public void testMetadataRemove() {
-        subject.setMetadata("subject", "key", new FixedMetadataValue(pluginX, 10));
-        subject.setMetadata("subject", "key", new FixedMetadataValue(pluginY, 20));
-        subject.removeMetadata("subject", "key", pluginX);
+        store.setMetadata(new TValue("subject"), "key", new FixedMetadataValue(pluginX, 10));
+        store.setMetadata(new TValue("subject"), "key", new FixedMetadataValue(pluginY, 20));
+        store.removeMetadata(new TValue("subject"), "key", pluginX);
 
-        assertTrue(subject.hasMetadata("subject", "key"));
-        assertEquals(1, subject.getMetadata("subject", "key").size());
-        assertEquals(20, subject.getMetadata("subject", "key").get(0).value());
+        assertTrue(store.hasMetadata(new TValue("subject"), "key"));
+        assertEquals(1, store.getMetadata(new TValue("subject"), "key").size());
+        assertEquals(20, store.getMetadata(new TValue("subject"), "key").get(0).value());
     }
 
     @Test
     public void testMetadataRemoveLast() {
-        subject.setMetadata("subject", "key", new FixedMetadataValue(pluginX, 10));
-        subject.removeMetadata("subject", "key", pluginX);
+        store.setMetadata(new TValue("subject"), "key", new FixedMetadataValue(pluginX, 10));
+        store.removeMetadata(new TValue("subject"), "key", pluginX);
 
-        assertFalse(subject.hasMetadata("subject", "key"));
-        assertEquals(0, subject.getMetadata("subject", "key").size());
+        assertFalse(store.hasMetadata(new TValue("subject"), "key"));
+        assertEquals(0, store.getMetadata(new TValue("subject"), "key").size());
     }
 
     @Test
     public void testMetadataRemoveForNonExistingPlugin() {
-        subject.setMetadata("subject", "key", new FixedMetadataValue(pluginX, 10));
-        subject.removeMetadata("subject", "key", pluginY);
+        store.setMetadata(new TValue("subject"), "key", new FixedMetadataValue(pluginX, 10));
+        store.removeMetadata(new TValue("subject"), "key", pluginY);
 
-        assertTrue(subject.hasMetadata("subject", "key"));
-        assertEquals(1, subject.getMetadata("subject", "key").size());
-        assertEquals(10, subject.getMetadata("subject", "key").get(0).value());
+        assertTrue(store.hasMetadata(new TValue("subject"), "key"));
+        assertEquals(1, store.getMetadata(new TValue("subject"), "key").size());
+        assertEquals(10, store.getMetadata(new TValue("subject"), "key").get(0).value());
     }
 
     @Test
     public void testHasMetadata() {
-        subject.setMetadata("subject", "key", new FixedMetadataValue(pluginX, 10));
-        assertTrue(subject.hasMetadata("subject", "key"));
-        assertFalse(subject.hasMetadata("subject", "otherKey"));
+        store.setMetadata(new TValue("subject"), "key", new FixedMetadataValue(pluginX, 10));
+        assertTrue(store.hasMetadata(new TValue("subject"), "key"));
+        assertFalse(store.hasMetadata(new TValue("subject"), "otherKey"));
     }
 
     @Test
     public void testProviderUsage() {
-        List<MetadataProvider<String>> mapping = new ArrayList<MetadataProvider<String>>();
-        StringMetadataStore store = new StringMetadataStore(mapping);
-        assertEquals(store.getMetadata("foobar", "uppercased").size(), 0);
-        StringMetadataProvider p = new StringMetadataProvider();
+        List<MetadataProvider<TValue>> mapping = new ArrayList<MetadataProvider<TValue>>();
+        TValueStore store = new TValueStore(mapping);
+        assertEquals(store.getMetadata(new TValue("foobar"), "uppercased").size(), 0);
+        TValueProvider p = new TValueProvider();
         mapping.add(p);
         assertEquals(0, p.counter.value());
-        List<MetadataValue> values = store.getMetadata("foobar", "uppercased");
+        List<MetadataValue> values = store.getMetadata(new TValue("foobar"), "uppercased");
         assertEquals(1, values.size());
         assertEquals("FOOBAR", values.get(0).asString());
         assertEquals(1, p.counter.value());
         // Check we still get a single value only
-        values = store.getMetadata("foobar", "uppercased");
+        values = store.getMetadata(new TValue("foobar"), "uppercased");
         assertEquals(1, values.size());
         assertEquals("FOOBAR", values.get(0).asString());
         // Check the provider wasn't called twice.
         assertEquals(1, p.counter.value());
         // Try a new previously un-seen value through the provider.
-        assertEquals(1, store.getMetadata("hello", "uppercased").size());
+        assertEquals(1, store.getMetadata(new TValue("hello"), "uppercased").size());
         assertEquals(2, p.counter.value());
         mapping.clear();
     }
 
-    private class StringMetadataStore extends MetadataStoreBase<String> implements MetadataStore<String> {
-        public StringMetadataStore() {
-            this(new ArrayList<MetadataProvider<String>>());
-        }
+    private static class TValue implements Metadatable {
+        public String value;
 
-        public StringMetadataStore(List<MetadataProvider<String>> mapping) {
-            super(mapping);
+        public TValue(String value) {
+            this.value = value;
         }
 
         @Override
-        protected String disambiguate(String subject, String metadataKey) {
-            return subject + ":" + metadataKey;
+        public boolean equals(Object other) {
+            if (other instanceof TValue) {
+                return value.equals(((TValue) other).value);
+            } else if (other instanceof String) {
+                return value.equals(other);
+            } else {
+                return false;
+            }
+        }
+        
+        @Override
+        public int hashCode() {
+            return value.hashCode();
+        }
+
+        public void setMetadata(String metadataKey, MetadataValue newMetadataValue) {
+        }
+
+        public List<MetadataValue> getMetadata(String metadataKey) {
+            return null;
+        }
+
+        public boolean hasMetadata(String metadataKey) {
+            return false;
+        }
+
+        public void removeMetadata(String metadataKey, Plugin owningPlugin) {
+        }
+
+    }
+
+    private static class TValueStore extends MetadataStoreBase<TValue> implements MetadataStore<TValue> {
+        public TValueStore() {
+            this(new ArrayList<MetadataProvider<TValue>>());
+        }
+
+        public TValueStore(List<MetadataProvider<TValue>> mapping) {
+            super(convertMap(mapping));
+        }
+
+        private static Map<Class<? extends Metadatable>, List<MetadataProvider<TValue>>> convertMap(List<MetadataProvider<TValue>> mapping) {
+            Map<Class<? extends Metadatable>, List<MetadataProvider<TValue>>> lookup = new HashMap<Class<? extends Metadatable>, List<MetadataProvider<TValue>>>();
+            lookup.put(TValue.class, mapping);
+            return lookup;
+        }
+
+        @Override
+        protected String disambiguate(TValue subject, String metadataKey) {
+            return subject.value + ":" + metadataKey;
         }
     }
 
-    private class StringMetadataProvider implements MetadataProvider<String> {
+    private class TValueProvider implements MetadataProvider<TValue> {
         public final Counter counter = new Counter();
 
-        public MetadataValue getValue(String subject, String key) {
+        public MetadataValue getValue(TValue subject, String key) {
             counter.increment();
             if (subject.equals("nodata")) {
                 return null;
             } else {
-                return new FixedMetadataValue(pluginX, subject.toUpperCase());
+                return new FixedMetadataValue(pluginX, subject.value.toUpperCase());
             }
         }
 

--- a/src/test/java/org/bukkit/metadata/MetadataStoreTest.java
+++ b/src/test/java/org/bukkit/metadata/MetadataStoreTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -156,6 +157,10 @@ public class MetadataStoreTest {
     }
 
     private class StringMetadataStore extends MetadataStoreBase<String> implements MetadataStore<String> {
+        public StringMetadataStore() {
+            super(new HashMap<String, MetadataProvider<String>>());
+        }
+
         @Override
         protected String disambiguate(String subject, String metadataKey) {
             return subject + ":" + metadataKey;

--- a/src/test/java/org/bukkit/metadata/MetadataStoreTest.java
+++ b/src/test/java/org/bukkit/metadata/MetadataStoreTest.java
@@ -126,12 +126,12 @@ public class MetadataStoreTest {
     public void testRegisterUnregisterProvider() {
         StringMetadataProvider p = new StringMetadataProvider();
         // Test adding provider once
-        assertEquals(subject.registerProvider("uppercased", p), true);
+        assertEquals(true, subject.registerProvider("uppercased", p));
         // Test adding provider again
-        assertEquals(subject.registerProvider("uppercased", p), false);
+        assertEquals(false, subject.registerProvider("uppercased", p));
         // Now removal
-        assertEquals(subject.unregisterProvider("uppercased"), true);
-        assertEquals(subject.unregisterProvider("uppercased"), false);
+        assertEquals(true, subject.unregisterProvider("uppercased"));
+        assertEquals(false, subject.unregisterProvider("uppercased"));
     }
 
     @Test
@@ -171,7 +171,7 @@ public class MetadataStoreTest {
 
         public MetadataValue getValue(String subject, String key) {
             counter.increment();
-            if(subject.equals("nodata")) {
+            if (subject.equals("nodata")) {
                 return null;
             } else {
                 return new FixedMetadataValue(pluginX, subject.toUpperCase());

--- a/src/test/java/org/bukkit/metadata/MetadataStoreTest.java
+++ b/src/test/java/org/bukkit/metadata/MetadataStoreTest.java
@@ -13,6 +13,7 @@ import org.bukkit.plugin.TestPlugin;
 import org.junit.Test;
 
 public class MetadataStoreTest {
+
     private Plugin pluginX = new TestPlugin("x");
     private Plugin pluginY = new TestPlugin("y");
 
@@ -124,41 +125,35 @@ public class MetadataStoreTest {
     }
 
     @Test
-    public void testRegisterUnregisterProvider() {
-        StringMetadataProvider p = new StringMetadataProvider();
-        // Test adding provider once
-        assertEquals(true, subject.registerProvider("uppercased", p));
-        // Test adding provider again
-        assertEquals(false, subject.registerProvider("uppercased", p));
-        // Now removal
-        assertEquals(true, subject.unregisterProvider("uppercased"));
-        assertEquals(false, subject.unregisterProvider("uppercased"));
-    }
-
-    @Test
     public void testProviderUsage() {
-        assertEquals(subject.getMetadata("foobar", "uppercased").size(), 0);
+        HashMap<String, MetadataProvider<String>> mapping = new HashMap<String, MetadataProvider<String>>();
+        StringMetadataStore store = new StringMetadataStore(mapping);
+        assertEquals(store.getMetadata("foobar", "uppercased").size(), 0);
         StringMetadataProvider p = new StringMetadataProvider();
-        subject.registerProvider("uppercased", p);
+        mapping.put("uppercased", p);
         assertEquals(0, p.counter.value());
-        List<MetadataValue> values = subject.getMetadata("foobar", "uppercased");
+        List<MetadataValue> values = store.getMetadata("foobar", "uppercased");
         assertEquals(1, values.size());
         assertEquals("FOOBAR", values.get(0).asString());
         assertEquals(1, p.counter.value());
         // Check we still get a single value only
-        values = subject.getMetadata("foobar", "uppercased");
+        values = store.getMetadata("foobar", "uppercased");
         assertEquals(1, values.size());
         assertEquals("FOOBAR", values.get(0).asString());
         // Check the provider wasn't called twice.
         assertEquals(1, p.counter.value());
         // Try a new previously un-seen value through the provider.
-        assertEquals(1, subject.getMetadata("hello", "uppercased").size());
+        assertEquals(1, store.getMetadata("hello", "uppercased").size());
         assertEquals(2, p.counter.value());
+        mapping.clear();
     }
 
     private class StringMetadataStore extends MetadataStoreBase<String> implements MetadataStore<String> {
         public StringMetadataStore() {
-            super(new HashMap<String, MetadataProvider<String>>());
+            this(new HashMap<String, MetadataProvider<String>>());
+        }
+        public StringMetadataStore(HashMap<String, MetadataProvider<String>> mapping) {
+            super(mapping);
         }
 
         @Override


### PR DESCRIPTION
At the very core of the metadata system is the idea of asking a question. A plugin asks a question, like “What is this player’s chat prefix?” and some other plugin is able to provide an answer. 

The way it’s currently designed, for some plugin (say a chat plugin) to ask what a prefix is, some other plugin (say a permissions plugin or user manager) would have to set the "chatPrefix" key on every user before it's asked. (say when they log in.) This isn’t very effective, and it isn’t quite as “lazy” as one would hope, what if the value is never asked for? Then we've done all that work for nothing.

What would be useful, instead, if the metadata system provided a way for a plugin to register a metadata ‘provider’ for a key. Calling <object>.getMetadata(key) would query the provider if no value is set, passing it the object, for an appropriate metadata value.

To use the chatPrefix example from before, MyAwesomePermissions would register a provider for chatPrefix. Then at some point, BobsChatPlugin calls player.getMetadata("chatPrefix") which asks the provider for the chatPrefix. This also means if the chatPrefix is never requested (say you don't have a chat plugin to use it), there's no work done or memory used in creating the values.

**More Info**
full description at https://bukkit.atlassian.net/browse/BUKKIT-3625
Also see companion pull request https://github.com/Bukkit/CraftBukkit/pull/1032

**Full list of changes**
    \* Created provider interface
    \* Added provider registration to MetadataStore
    \* Added unit tests for provider usage
    \* Updated bukkit.Server interface with methods for registering
    Player/Entity/World providers
    \* Updated bukkit.Bukkit with static implementations
    \* Updated World with way to register Block providers
