### PR TITLE
[C+B] Add a world broadcast and broadcastMessage function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@
 /manifest.mf
 
 # Mac filesystem dust
-/.DS_Store
+.DS_Store
 
 # intellij
 *.iml

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.bukkit</groupId>
     <artifactId>bukkit</artifactId>
-    <version>1.5.1-R0.1</version>
+    <version>1.5.1-R0.2-SNAPSHOT</version>
     <name>Bukkit</name>
     <url>http://www.bukkit.org</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.bukkit</groupId>
     <artifactId>bukkit</artifactId>
-    <version>1.5.1-R0.1-SNAPSHOT</version>
+    <version>1.5.1-R0.1</version>
     <name>Bukkit</name>
     <url>http://www.bukkit.org</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.bukkit</groupId>
     <artifactId>bukkit</artifactId>
-    <version>1.5.1-R0.2-SNAPSHOT</version>
+    <version>1.5.1-R0.2</version>
     <name>Bukkit</name>
     <url>http://www.bukkit.org</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.bukkit</groupId>
     <artifactId>bukkit</artifactId>
-    <version>1.5.2-R0.1-SNAPSHOT</version>
+    <version>1.5.2-R0.1</version>
     <name>Bukkit</name>
     <url>http://www.bukkit.org</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.bukkit</groupId>
     <artifactId>bukkit</artifactId>
-    <version>1.5.1-R0.2</version>
+    <version>1.5.1-R0.3-SNAPSHOT</version>
     <name>Bukkit</name>
     <url>http://www.bukkit.org</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.bukkit</groupId>
     <artifactId>bukkit</artifactId>
-    <version>1.5.2-R0.1</version>
+    <version>1.5.2-R0.2-SNAPSHOT</version>
     <name>Bukkit</name>
     <url>http://www.bukkit.org</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.bukkit</groupId>
     <artifactId>bukkit</artifactId>
-    <version>1.5.1-R0.3-SNAPSHOT</version>
+    <version>1.5.2-R0.1-SNAPSHOT</version>
     <name>Bukkit</name>
     <url>http://www.bukkit.org</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.bukkit</groupId>
     <artifactId>bukkit</artifactId>
-    <version>1.5-R0.1-SNAPSHOT</version>
+    <version>1.5.1-R0.1-SNAPSHOT</version>
     <name>Bukkit</name>
     <url>http://www.bukkit.org</url>
 

--- a/src/main/java/org/bukkit/Achievement.java
+++ b/src/main/java/org/bukkit/Achievement.java
@@ -49,7 +49,7 @@ public enum Achievement {
 
     /**
      * Gets the ID for this achievement.
-     * <p />
+     * <p>
      * Note that this is offset using {@link #STATISTIC_OFFSET}
      *
      * @return ID of this achievement
@@ -60,7 +60,7 @@ public enum Achievement {
 
     /**
      * Gets the achievement associated with the given ID.
-     * <p />
+     * <p>
      * Note that the ID must already be offset using {@link #STATISTIC_OFFSET}
      *
      * @param id ID of the achievement to return

--- a/src/main/java/org/bukkit/Art.java
+++ b/src/main/java/org/bukkit/Art.java
@@ -86,7 +86,7 @@ public enum Art {
 
     /**
      * Get a painting by its unique name
-     * <p />
+     * <p>
      * This ignores underscores and capitalization
      *
      * @param name The name

--- a/src/main/java/org/bukkit/Bukkit.java
+++ b/src/main/java/org/bukkit/Bukkit.java
@@ -24,6 +24,7 @@ import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.ServicesManager;
 import org.bukkit.plugin.messaging.Messenger;
 import org.bukkit.scheduler.BukkitScheduler;
+import org.bukkit.scoreboard.ScoreboardManager;
 
 import com.avaje.ebean.config.ServerConfig;
 import org.bukkit.inventory.ItemFactory;
@@ -394,5 +395,9 @@ public final class Bukkit {
 
     public static ItemFactory getItemFactory() {
         return server.getItemFactory();
+    }
+
+    public static ScoreboardManager getScoreboardManager() {
+        return server.getScoreboardManager();
     }
 }

--- a/src/main/java/org/bukkit/Bukkit.java
+++ b/src/main/java/org/bukkit/Bukkit.java
@@ -65,338 +65,590 @@ public final class Bukkit {
         server.getLogger().info("This server is running " + getName() + " version " + getVersion() + " (Implementing API version " + getBukkitVersion() + ")");
     }
 
+    /**
+     * @see Server#getName()
+     */
     public static String getName() {
         return server.getName();
     }
 
+    /**
+     * @see Server#getVersion()
+     */
     public static String getVersion() {
         return server.getVersion();
     }
 
+    /**
+     * @see Server#getBukkitVersion()
+     */
     public static String getBukkitVersion() {
         return server.getBukkitVersion();
     }
 
+    /**
+     * @see Server#getOnlinePlayers()
+     */
     public static Player[] getOnlinePlayers() {
         return server.getOnlinePlayers();
     }
 
+    /**
+     * @see Server#getMaxPlayers()
+     */
     public static int getMaxPlayers() {
         return server.getMaxPlayers();
     }
 
+    /**
+     * @see Server#getPort()
+     */
     public static int getPort() {
         return server.getPort();
     }
 
+    /**
+     * @see Server#getViewDistance()
+     */
     public static int getViewDistance() {
         return server.getViewDistance();
     }
 
+    /**
+     * @see Server#getIp()
+     */
     public static String getIp() {
         return server.getIp();
     }
 
+    /**
+     * @see Server#getServerName()
+     */
     public static String getServerName() {
         return server.getServerName();
     }
 
+    /**
+     * @see Server#getServerId()
+     */
     public static String getServerId() {
         return server.getServerId();
     }
 
+    /**
+     * @see Server#getWorldType()
+     */
     public static String getWorldType() {
         return server.getWorldType();
     }
 
+    /**
+     * @see Server#getGenerateStructures()
+     */
     public static boolean getGenerateStructures() {
         return server.getGenerateStructures();
     }
 
+    /**
+     * @see Server#getAllowNether()
+     */
     public static boolean getAllowNether() {
         return server.getAllowNether();
     }
 
+    /**
+     * @see Server#hasWhitelist()
+     */
     public static boolean hasWhitelist() {
         return server.hasWhitelist();
     }
 
+    /**
+     * @see Server#broadcastMessage(String message)
+     */
     public static int broadcastMessage(String message) {
         return server.broadcastMessage(message);
     }
 
+    /**
+     * @see Server#getUpdateFolder()
+     */
     public static String getUpdateFolder() {
         return server.getUpdateFolder();
     }
 
+    /**
+     * @see Server#getPlayer(String name)
+     */
     public static Player getPlayer(String name) {
         return server.getPlayer(name);
     }
 
+    /**
+     * @see Server#matchPlayer(String name)
+     */
     public static List<Player> matchPlayer(String name) {
         return server.matchPlayer(name);
     }
 
+    /**
+     * @see Server#getPluginManager()
+     */
     public static PluginManager getPluginManager() {
         return server.getPluginManager();
     }
 
+    /**
+     * @see Server#getScheduler()
+     */
     public static BukkitScheduler getScheduler() {
         return server.getScheduler();
     }
 
+    /**
+     * @see Server#getServicesManager()
+     */
     public static ServicesManager getServicesManager() {
         return server.getServicesManager();
     }
 
+    /**
+     * @see Server#getWorlds()
+     */
     public static List<World> getWorlds() {
         return server.getWorlds();
     }
 
+    /**
+     * @see Server#createWorld(WorldCreator options)
+     */
     public static World createWorld(WorldCreator options) {
         return server.createWorld(options);
     }
 
+    /**
+     * @see Server#unloadWorld(String name, boolean save)
+     */
     public static boolean unloadWorld(String name, boolean save) {
         return server.unloadWorld(name, save);
     }
 
+    /**
+     * @see Server#unloadWorld(World world, boolean save)
+     */
     public static boolean unloadWorld(World world, boolean save) {
         return server.unloadWorld(world, save);
     }
 
+    /**
+     * @see Server#getWorld(String name)
+     */
     public static World getWorld(String name) {
         return server.getWorld(name);
     }
 
+    /**
+     * @see Server#getWorld(UUID uid)
+     */
     public static World getWorld(UUID uid) {
         return server.getWorld(uid);
     }
 
+    /**
+     * @see Server#getMap(short id)
+     */
     public static MapView getMap(short id) {
         return server.getMap(id);
     }
 
+    /**
+     * @see Server#createMap(World world)
+     */
     public static MapView createMap(World world) {
         return server.createMap(world);
     }
 
+    /**
+     * @see Server#reload()
+     */
     public static void reload() {
         server.reload();
     }
 
+    /**
+     * @see Server#getLogger()
+     */
     public static Logger getLogger() {
         return server.getLogger();
     }
 
+    /**
+     * @see Server#getPluginCommand(String name)
+     */
     public static PluginCommand getPluginCommand(String name) {
         return server.getPluginCommand(name);
     }
 
+    /**
+     * @see Server#savePlayers()
+     */
     public static void savePlayers() {
         server.savePlayers();
     }
 
+    /**
+     * @see Server#dispatchCommand(CommandSender sender, String commandLine)
+     */
     public static boolean dispatchCommand(CommandSender sender, String commandLine) {
         return server.dispatchCommand(sender, commandLine);
     }
 
+    /**
+     * @see Server#configureDbConfig(ServerConfig config)
+     */
     public static void configureDbConfig(ServerConfig config) {
         server.configureDbConfig(config);
     }
 
+    /**
+     * @see Server#addRecipe(Recipe recipe)
+     */
     public static boolean addRecipe(Recipe recipe) {
         return server.addRecipe(recipe);
     }
 
+    /**
+     * @see Server#getRecipesFor(ItemStack result)
+     */
     public static List<Recipe> getRecipesFor(ItemStack result) {
         return server.getRecipesFor(result);
     }
 
+    /**
+     * @see Server#recipeIterator()
+     */
     public static Iterator<Recipe> recipeIterator() {
         return server.recipeIterator();
     }
 
+    /**
+     * @see Server#clearRecipes()
+     */
     public static void clearRecipes() {
         server.clearRecipes();
     }
 
+    /**
+     * @see Server#resetRecipes()
+     */
     public static void resetRecipes() {
         server.resetRecipes();
     }
 
+    /**
+     * @see Server#getCommandAliases()
+     */
     public static Map<String, String[]> getCommandAliases() {
         return server.getCommandAliases();
     }
 
+    /**
+     * @see Server#getSpawnRadius()
+     */
     public static int getSpawnRadius() {
         return server.getSpawnRadius();
     }
 
+    /**
+     * @see Server#setSpawnRadius(int value)
+     */
     public static void setSpawnRadius(int value) {
         server.setSpawnRadius(value);
     }
 
+    /**
+     * @see Server#getOnlineMode()
+     */
     public static boolean getOnlineMode() {
         return server.getOnlineMode();
     }
 
+    /**
+     * @see Server#getAllowFlight()
+     */
     public static boolean getAllowFlight() {
         return server.getAllowFlight();
     }
 
+    /**
+     * @see Server#isHardcore()
+     */
     public static boolean isHardcore() {
         return server.isHardcore();
     }
 
+    /**
+     * @see Server#shutdown()
+     */
     public static void shutdown() {
         server.shutdown();
     }
 
+    /**
+     * @see Server#broadcast(String message, String permission)
+     */
     public static int broadcast(String message, String permission) {
         return server.broadcast(message, permission);
     }
 
+    /**
+     * @see Server#getOfflinePlayer(String name)
+     */
     public static OfflinePlayer getOfflinePlayer(String name) {
         return server.getOfflinePlayer(name);
     }
 
+    /**
+     * @see Server#getPlayerExact(String name)
+     */
     public static Player getPlayerExact(String name) {
         return server.getPlayerExact(name);
     }
 
+    /**
+     * @see Server#getIPBans()
+     */
     public static Set<String> getIPBans() {
         return server.getIPBans();
     }
 
+    /**
+     * @see Server#banIP(String address)
+     */
     public static void banIP(String address) {
         server.banIP(address);
     }
 
+    /**
+     * @see Server#unbanIP(String address)
+     */
     public static void unbanIP(String address) {
         server.unbanIP(address);
     }
 
+    /**
+     * @see Server#getBannedPlayers()
+     */
     public static Set<OfflinePlayer> getBannedPlayers() {
         return server.getBannedPlayers();
     }
 
+    /**
+     * @see Server#setWhitelist(boolean value)
+     */
     public static void setWhitelist(boolean value) {
         server.setWhitelist(value);
     }
 
+    /**
+     * @see Server#getWhitelistedPlayers()
+     */
     public static Set<OfflinePlayer> getWhitelistedPlayers() {
         return server.getWhitelistedPlayers();
     }
 
+    /**
+     * @see Server#reloadWhitelist()
+     */
     public static void reloadWhitelist() {
         server.reloadWhitelist();
     }
 
+    /**
+     * @see Server#getConsoleSender()
+     */
     public static ConsoleCommandSender getConsoleSender() {
         return server.getConsoleSender();
     }
 
+    /**
+     * @see Server#getOperators()
+     */
     public static Set<OfflinePlayer> getOperators() {
         return server.getOperators();
     }
 
+    /**
+     * @see Server#getWorldContainer()
+     */
     public static File getWorldContainer() {
         return server.getWorldContainer();
     }
 
+    /**
+     * @see Server#getMessenger()
+     */
     public static Messenger getMessenger() {
         return server.getMessenger();
     }
 
+    /**
+     * @see Server#getAllowEnd()
+     */
     public static boolean getAllowEnd() {
         return server.getAllowEnd();
     }
 
+    /**
+     * @see Server#getUpdateFolderFile()
+     */
     public static File getUpdateFolderFile() {
         return server.getUpdateFolderFile();
     }
 
+    /**
+     * @see Server#getConnectionThrottle()
+     */
     public static long getConnectionThrottle() {
         return server.getConnectionThrottle();
     }
 
+    /**
+     * @see Server#getTicksPerAnimalSpawns()
+     */
     public static int getTicksPerAnimalSpawns() {
         return server.getTicksPerAnimalSpawns();
     }
 
+    /**
+     * @see Server#getTicksPerMonsterSpawns()
+     */
     public static int getTicksPerMonsterSpawns() {
         return server.getTicksPerMonsterSpawns();
     }
 
+    /**
+     * @see Server#useExactLoginLocation()
+     */
     public static boolean useExactLoginLocation() {
         return server.useExactLoginLocation();
     }
 
+    /**
+     * @see Server#getDefaultGameMode()
+     */
     public static GameMode getDefaultGameMode() {
         return server.getDefaultGameMode();
     }
 
+    /**
+     * @see Server#setDefaultGameMode(GameMode mode)
+     */
     public static void setDefaultGameMode(GameMode mode) {
         server.setDefaultGameMode(mode);
     }
 
+    /**
+     * @see Server#getOfflinePlayers()
+     */
     public static OfflinePlayer[] getOfflinePlayers() {
         return server.getOfflinePlayers();
     }
 
+    /**
+     * @see Server#createInventory(InventoryHolder owner, InventoryType type)
+     */
     public static Inventory createInventory(InventoryHolder owner, InventoryType type) {
         return server.createInventory(owner, type);
     }
 
+    /**
+     * @see Server#createInventory(InventoryHolder owner, int size)
+     */
     public static Inventory createInventory(InventoryHolder owner, int size) {
         return server.createInventory(owner, size);
     }
 
+    /**
+     * @see Server#createInventory(InventoryHolder owner, int size, String title)
+     */
     public static Inventory createInventory(InventoryHolder owner, int size, String title) {
         return server.createInventory(owner, size, title);
     }
 
+    /**
+     * @see Server#getHelpMap()
+     */
     public static HelpMap getHelpMap() {
         return server.getHelpMap();
     }
 
+    /**
+     * @see Server#getMonsterSpawnLimit()
+     */
     public static int getMonsterSpawnLimit() {
         return server.getMonsterSpawnLimit();
     }
 
+    /**
+     * @see Server#getAnimalSpawnLimit()
+     */
     public static int getAnimalSpawnLimit() {
         return server.getAnimalSpawnLimit();
     }
 
+    /**
+     * @see Server#getWaterAnimalSpawnLimit()
+     */
     public static int getWaterAnimalSpawnLimit() {
         return server.getWaterAnimalSpawnLimit();
     }
 
+    /**
+     * @see Server#getAmbientSpawnLimit()
+     */
     public static int getAmbientSpawnLimit() {
         return server.getAmbientSpawnLimit();
     }
 
+    /**
+     * @see Server#isPrimaryThread()
+     */
     public static boolean isPrimaryThread() {
         return server.isPrimaryThread();
     }
 
+    /**
+     * @see Server#getMotd()
+     */
     public static String getMotd() {
         return server.getMotd();
     }
 
+    /**
+     * @see Server#getShutdownMessage()
+     */
     public static String getShutdownMessage() {
         return server.getShutdownMessage();
     }
 
+    /**
+     * @see Server#getWarningState()
+     */
     public static WarningState getWarningState() {
         return server.getWarningState();
     }
 
+    /**
+     * @see Server#getItemFactory()
+     */
     public static ItemFactory getItemFactory() {
         return server.getItemFactory();
     }
 
+    /**
+     * @see Server#getScoreboardManager()
+     */
     public static ScoreboardManager getScoreboardManager() {
         return server.getScoreboardManager();
     }

--- a/src/main/java/org/bukkit/Bukkit.java
+++ b/src/main/java/org/bukkit/Bukkit.java
@@ -50,7 +50,7 @@ public final class Bukkit {
 
     /**
      * Attempts to set the {@link Server} singleton.
-     * <p />
+     * <p>
      * This cannot be done if the Server is already set.
      *
      * @param server Server instance

--- a/src/main/java/org/bukkit/DyeColor.java
+++ b/src/main/java/org/bukkit/DyeColor.java
@@ -164,7 +164,7 @@ public enum DyeColor {
      */
     public static DyeColor getByWoolData(final byte data) {
         int i = 0xff & data;
-        if (i > BY_WOOL_DATA.length) {
+        if (i >= BY_WOOL_DATA.length) {
             return null;
         }
         return BY_WOOL_DATA[i];
@@ -179,7 +179,7 @@ public enum DyeColor {
      */
     public static DyeColor getByDyeData(final byte data) {
         int i = 0xff & data;
-        if (i > BY_DYE_DATA.length) {
+        if (i >= BY_DYE_DATA.length) {
             return null;
         }
         return BY_DYE_DATA[i];

--- a/src/main/java/org/bukkit/EntityEffect.java
+++ b/src/main/java/org/bukkit/EntityEffect.java
@@ -16,28 +16,28 @@ public enum EntityEffect {
 
     /**
      * When a mob dies.
-     * <p />
+     * <p>
      * <b>This will cause client-glitches!
      */
     DEATH(3),
 
     /**
      * The smoke when taming a wolf fails.
-     * <p />
+     * <p>
      * Without client-mods this will be ignored if the entity is not a wolf.
      */
     WOLF_SMOKE(6),
 
     /**
      * The hearts when taming a wolf succeeds.
-     * <p />
+     * <p>
      * Without client-mods this will be ignored if the entity is not a wolf.
      */
     WOLF_HEARTS(7),
 
     /**
      * When a wolf shakes (after being wet).
-     * <p />
+     * <p>
      * Without client-mods this will be ignored if the entity is not a wolf.
      */
     WOLF_SHAKE(8),

--- a/src/main/java/org/bukkit/FireworkEffect.java
+++ b/src/main/java/org/bukkit/FireworkEffect.java
@@ -59,7 +59,7 @@ public final class FireworkEffect implements ConfigurationSerializable {
     public static final class Builder {
         boolean flicker = false;
         boolean trail = false;
-        ImmutableList.Builder<Color> colors = ImmutableList.builder();
+        final ImmutableList.Builder<Color> colors = ImmutableList.builder();
         ImmutableList.Builder<Color> fadeColors = null;
         Type type = Type.BALL;
 
@@ -130,10 +130,6 @@ public final class FireworkEffect implements ConfigurationSerializable {
         public Builder withColor(Color color) throws IllegalArgumentException {
             Validate.notNull(color, "Cannot have null color");
 
-            if (colors == null) {
-                colors = ImmutableList.builder();
-            }
-
             colors.add(color);
 
             return this;
@@ -154,10 +150,6 @@ public final class FireworkEffect implements ConfigurationSerializable {
             }
 
             ImmutableList.Builder<Color> list = this.colors;
-            if (list == null) {
-                list = this.colors = ImmutableList.builder();
-            }
-
             for (Color color : colors) {
                 Validate.notNull(color, "Color cannot be null");
                 list.add(color);
@@ -178,10 +170,6 @@ public final class FireworkEffect implements ConfigurationSerializable {
             Validate.notNull(colors, "Cannot have null colors");
 
             ImmutableList.Builder<Color> list = this.colors;
-            if (list == null) {
-                list = this.colors = ImmutableList.builder();
-            }
-
             for (Object color : colors) {
                 if (!(color instanceof Color)) {
                     throw new IllegalArgumentException(color + " is not a Color in " + colors);

--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -952,4 +952,21 @@ public enum Material {
                 return false;
         }
     }
+
+    /**
+     * @return True if this material is affected by gravity.
+     */
+    public boolean hasGravity() {
+        if (!isBlock()) {
+            return false;
+        }
+        switch (this) {
+            case SAND:
+            case GRAVEL:
+            case ANVIL:
+                return true;
+            default:
+                return false;
+        }
+    }
 }

--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -16,6 +16,7 @@ import org.bukkit.material.Command;
 import org.bukkit.material.Crops;
 import org.bukkit.material.DetectorRail;
 import org.bukkit.material.Diode;
+import org.bukkit.material.DirectionalContainer;
 import org.bukkit.material.Dispenser;
 import org.bukkit.material.Door;
 import org.bukkit.material.Dye;
@@ -220,7 +221,7 @@ public enum Material {
     QUARTZ_BLOCK(155),
     QUARTZ_STAIRS(156, Stairs.class),
     ACTIVATOR_RAIL(157),
-    DROPPER(158),
+    DROPPER(158, DirectionalContainer.class),
     // ----- Item Separator -----
     IRON_SPADE(256, 1, 250),
     IRON_PICKAXE(257, 1, 250),

--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -220,8 +220,8 @@ public enum Material {
     HOPPER(154),
     QUARTZ_BLOCK(155),
     QUARTZ_STAIRS(156, Stairs.class),
-    ACTIVATOR_RAIL(157),
-    DROPPER(158, DirectionalContainer.class),
+    ACTIVATOR_RAIL(157, PoweredRail.class),
+    DROPPER(158, Dispenser.class),
     // ----- Item Separator -----
     IRON_SPADE(256, 1, 250),
     IRON_PICKAXE(257, 1, 250),

--- a/src/main/java/org/bukkit/OfflinePlayer.java
+++ b/src/main/java/org/bukkit/OfflinePlayer.java
@@ -50,7 +50,7 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
 
     /**
      * Gets a {@link Player} object that this represents, if there is one
-     * <p />
+     * <p>
      * If the player is online, this will return that player. Otherwise,
      * it will return null.
      *
@@ -60,7 +60,7 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
 
     /**
      * Gets the first date and time that this player was witnessed on this server.
-     * <p />
+     * <p>
      * If the player has never played before, this will return 0. Otherwise, it will be
      * the amount of milliseconds since midnight, January 1, 1970 UTC.
      *
@@ -70,7 +70,7 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
 
     /**
      * Gets the last date and time that this player was witnessed on this server.
-     * <p />
+     * <p>
      * If the player has never played before, this will return 0. Otherwise, it will be
      * the amount of milliseconds since midnight, January 1, 1970 UTC.
      *

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -26,6 +26,7 @@ import org.bukkit.plugin.ServicesManager;
 import org.bukkit.plugin.messaging.Messenger;
 import org.bukkit.plugin.messaging.PluginMessageRecipient;
 import org.bukkit.scheduler.BukkitScheduler;
+import org.bukkit.scoreboard.ScoreboardManager;
 
 import com.avaje.ebean.config.ServerConfig;
 import org.bukkit.inventory.ItemFactory;
@@ -689,4 +690,13 @@ public interface Server extends PluginMessageRecipient {
      * @see ItemFactory
      */
     ItemFactory getItemFactory();
+
+    /**
+     * Gets the instance of the scoreboard manager.
+     * <p>
+     * This will only exist after the first world has loaded.
+     *
+     * @return the scoreboard manager or null if no worlds are loaded.
+     */
+    ScoreboardManager getScoreboardManager();
 }

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -37,14 +37,14 @@ import org.bukkit.inventory.meta.ItemMeta;
 public interface Server extends PluginMessageRecipient {
     /**
      * Used for all administrative messages, such as an operator using a command.
-     * <p />
+     * <p>
      * For use in {@link #broadcast(java.lang.String, java.lang.String)}
      */
     public static final String BROADCAST_CHANNEL_ADMINISTRATIVE = "bukkit.broadcast.admin";
 
     /**
      * Used for all announcement messages, such as informing users that a player has joined.
-     * <p />
+     * <p>
      * For use in {@link #broadcast(java.lang.String, java.lang.String)}
      */
     public static final String BROADCAST_CHANNEL_USERS = "bukkit.broadcast.user";
@@ -176,7 +176,7 @@ public interface Server extends PluginMessageRecipient {
 
     /**
      * Broadcast a message to all players.
-     * <p />
+     * <p>
      * This is the same as calling {@link #broadcast(java.lang.String, java.lang.String)} to {@link #BROADCAST_CHANNEL_USERS}
      *
      * @param message the message
@@ -187,7 +187,7 @@ public interface Server extends PluginMessageRecipient {
     /**
      * Gets the name of the update folder. The update folder is used to safely update
      * plugins at the right moment on a plugin load.
-     * <p />
+     * <p>
      * The update folder name is relative to the plugins folder.
      *
      * @return The name of the update folder
@@ -211,17 +211,17 @@ public interface Server extends PluginMessageRecipient {
 
     /**
      * Gets default ticks per animal spawns value
-     * <p />
+     * <p>
      * <b>Example Usage:</b>
      * <ul>
      * <li>A value of 1 will mean the server will attempt to spawn monsters every tick.
      * <li>A value of 400 will mean the server will attempt to spawn monsters every 400th tick.
      * <li>A value below 0 will be reset back to Minecraft's default.
      * </ul>
-     * <p />
+     * <p>
      * <b>Note:</b>
      * If set to 0, animal spawning will be disabled. We recommend using spawn-animals to control this instead.
-     * <p />
+     * <p>
      * Minecraft default: 400.
      *
      * @return The default ticks per animal spawns value
@@ -230,17 +230,17 @@ public interface Server extends PluginMessageRecipient {
 
     /**
      * Gets the default ticks per monster spawns value
-     * <p />
+     * <p>
      * <b>Example Usage:</b>
      * <ul>
      * <li>A value of 1 will mean the server will attempt to spawn monsters every tick.
      * <li>A value of 400 will mean the server will attempt to spawn monsters every 400th tick.
      * <li>A value below 0 will be reset back to Minecraft's default.
      * </ul>
-     * <p />
+     * <p>
      * <b>Note:</b>
      * If set to 0, monsters spawning will be disabled. We recommend using spawn-monsters to control this instead.
-     * <p />
+     * <p>
      * Minecraft default: 1.
      *
      * @return The default ticks per monsters spawn value
@@ -249,7 +249,7 @@ public interface Server extends PluginMessageRecipient {
 
     /**
      * Gets a player object by the given username
-     * <p />
+     * <p>
      * This method may not return objects for offline players
      *
      * @param name Name to look up
@@ -268,7 +268,7 @@ public interface Server extends PluginMessageRecipient {
     /**
      * Attempts to match any players with the given name, and returns a list
      * of all possibly matches
-     * <p />
+     * <p>
      * This list is not sorted in any particular order. If an exact match is found,
      * the returned list will only contain a single result.
      *
@@ -307,7 +307,7 @@ public interface Server extends PluginMessageRecipient {
 
     /**
      * Creates or loads a world with the given name using the specified options.
-     * <p />
+     * <p>
      * If the world is already loaded, it will just return the equivalent of
      * getWorld(creator.name()).
      *
@@ -510,7 +510,7 @@ public interface Server extends PluginMessageRecipient {
 
     /**
      * Gets the player by the given name, regardless if they are offline or online.
-     * <p />
+     * <p>
      * This will return an object even if the player does not exist. To this method, all players will exist.
      *
      * @param name Name of the player to retrieve

--- a/src/main/java/org/bukkit/Sound.java
+++ b/src/main/java/org/bukkit/Sound.java
@@ -2,7 +2,7 @@ package org.bukkit;
 
 /**
  * An Enum of Sounds the server is able to send to players.
- * <p />
+ * <p>
  * WARNING: At any time, sounds may be added/removed from this Enum or even MineCraft itself! There is no guarantee the sounds will play.
  * There is no guarantee values will not be removed from this Enum. As such, you should not depend on the ordinal values of this class.
  */

--- a/src/main/java/org/bukkit/Statistic.java
+++ b/src/main/java/org/bukkit/Statistic.java
@@ -48,7 +48,7 @@ public enum Statistic {
 
     /**
      * Checks if this is a substatistic.
-     * <p />
+     * <p>
      * A substatistic exists in mass for each block or item, depending on {@link #isBlock()}
      *
      * @return true if this is a substatistic

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -163,7 +163,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Loads the {@link Chunk} at the specified coordinates
-     * <p />
+     * <p>
      * If the chunk does not exist, it will be generated.
      * This method is analogous to {@link #loadChunk(int, int, boolean)} where generate is true.
      *
@@ -184,7 +184,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Safely unloads and saves the {@link Chunk} at the specified coordinates
-     * <p />
+     * <p>
      * This method is analogous to {@link #unloadChunk(int, int, boolean, boolean)} where safe and saveis true
      *
      * @param chunk the chunk to unload
@@ -194,7 +194,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Safely unloads and saves the {@link Chunk} at the specified coordinates
-     * <p />
+     * <p>
      * This method is analogous to {@link #unloadChunk(int, int, boolean, boolean)} where safe and saveis true
      *
      * @param x X-coordinate of the chunk
@@ -205,7 +205,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Safely unloads and optionally saves the {@link Chunk} at the specified coordinates
-     * <p />
+     * <p>
      * This method is analogous to {@link #unloadChunk(int, int, boolean, boolean)} where save is true
      *
      * @param x X-coordinate of the chunk
@@ -228,7 +228,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Safely queues the {@link Chunk} at the specified coordinates for unloading
-     * <p />
+     * <p>
      * This method is analogous to {@link #unloadChunkRequest(int, int, boolean)} where safe is true
      *
      * @param x X-coordinate of the chunk
@@ -438,7 +438,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Gets the relative in-game time of this world.
-     * <p />
+     * <p>
      * The relative time is analogous to hours * 1000
      *
      * @return The current relative time
@@ -448,9 +448,9 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Sets the relative in-game time on the server.
-     * <p />
+     * <p>
      * The relative time is analogous to hours * 1000
-     * <p />
+     * <p>
      * Note that setting the relative time below the current relative time will
      * actually move the clock forward a day. If you require to rewind time, please
      * see setFullTime
@@ -470,7 +470,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Sets the in-game time on the server
-     * <p />
+     * <p>
      * Note that this sets the full time of the world, which may cause adverse
      * effects such as breaking redstone clocks and any scheduled events
      *
@@ -655,7 +655,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
     /**
      * Spawn a {@link FallingBlock} entity at the given {@link Location} of the specified {@link Material}.
      * The material dictates what is falling. When the FallingBlock hits the ground, it will place that block.
-     * <p />
+     * <p>
      * The Material must be a block type, check with {@link Material#isBlock() material.isBlock()}.
      * The Material may not be air.
      *
@@ -771,7 +771,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Gets the temperature for the given block coordinates.
-     * <p />
+     * <p>
      * It is safe to run this method when the block does not exist, it will not create the block.
      *
      * @param x X coordinate of the block
@@ -782,7 +782,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Gets the humidity for the given block coordinates.
-     * <p />
+     * <p>
      * It is safe to run this method when the block does not exist, it will not create the block.
      *
      * @param x X coordinate of the block
@@ -793,7 +793,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Gets the maximum height of this world.
-     * <p />
+     * <p>
      * If the max height is 100, there are only blocks from y=0 to y=99.
      *
      * @return Maximum height of the world
@@ -802,7 +802,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Gets the sea level for this world.
-     * <p />
+     * <p>
      * This is often half of {@link #getMaxHeight()}
      *
      * @return Sea level
@@ -874,19 +874,19 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Gets the world's ticks per animal spawns value
-     * <p />
+     * <p>
      * This value determines how many ticks there are between attempts to spawn animals.
-     * <p />
+     * <p>
      * <b>Example Usage:</b>
      * <ul>
      * <li>A value of 1 will mean the server will attempt to spawn animals in this world every tick.
      * <li>A value of 400 will mean the server will attempt to spawn animals in this world every 400th tick.
      * <li>A value below 0 will be reset back to Minecraft's default.
      * </ul>
-     * <p />
+     * <p>
      * <b>Note:</b>
      * If set to 0, animal spawning will be disabled for this world. We recommend using {@link #setSpawnFlags(boolean, boolean)} to control this instead.
-     * <p />
+     * <p>
      * Minecraft default: 400.
      *
      * @return The world's ticks per animal spawns value
@@ -895,19 +895,19 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Sets the world's ticks per animal spawns value
-     * <p />
+     * <p>
      * This value determines how many ticks there are between attempts to spawn animals.
-     * <p />
+     * <p>
      * <b>Example Usage:</b>
      * <ul>
      * <li>A value of 1 will mean the server will attempt to spawn animals in this world every tick.
      * <li>A value of 400 will mean the server will attempt to spawn animals in this world every 400th tick.
      * <li>A value below 0 will be reset back to Minecraft's default.
      * </ul>
-     * <p />
+     * <p>
      * <b>Note:</b>
      * If set to 0, animal spawning will be disabled for this world. We recommend using {@link #setSpawnFlags(boolean, boolean)} to control this instead.
-     * <p />
+     * <p>
      * Minecraft default: 400.
      *
      * @param ticksPerAnimalSpawns the ticks per animal spawns value you want to set the world to
@@ -916,19 +916,19 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Gets the world's ticks per monster spawns value
-     * <p />
+     * <p>
      * This value determines how many ticks there are between attempts to spawn monsters.
-     * <p />
+     * <p>
      * <b>Example Usage:</b>
      * <ul>
      * <li>A value of 1 will mean the server will attempt to spawn monsters in this world every tick.
      * <li>A value of 400 will mean the server will attempt to spawn monsters in this world every 400th tick.
      * <li>A value below 0 will be reset back to Minecraft's default.
      * </ul>
-     * <p />
+     * <p>
      * <b>Note:</b>
      * If set to 0, monsters spawning will be disabled for this world. We recommend using {@link #setSpawnFlags(boolean, boolean)} to control this instead.
-     * <p />
+     * <p>
      * Minecraft default: 1.
      *
      * @return The world's ticks per monster spawns value
@@ -937,19 +937,19 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Sets the world's ticks per monster spawns value
-     * <p />
+     * <p>
      * This value determines how many ticks there are between attempts to spawn monsters.
-     * <p />
+     * <p>
      * <b>Example Usage:</b>
      * <ul>
      * <li>A value of 1 will mean the server will attempt to spawn monsters in this world on every tick.
      * <li>A value of 400 will mean the server will attempt to spawn monsters in this world every 400th tick.
      * <li>A value below 0 will be reset back to Minecraft's default.
      * </ul>
-     * <p />
+     * <p>
      * <b>Note:</b>
      * If set to 0, monsters spawning will be disabled for this world. We recommend using {@link #setSpawnFlags(boolean, boolean)} to control this instead.
-     * <p />
+     * <p>
      * Minecraft default: 1.
      *
      * @param ticksPerMonsterSpawns the ticks per monster spawns value you want to set the world to
@@ -964,7 +964,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Sets the limit for number of monsters that can spawn in a chunk in this world
-     * <p />
+     * <p>
      * <b>Note:</b>
      * If set to a negative number the world will use the server-wide spawn limit instead.
      */
@@ -978,7 +978,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Sets the limit for number of animals that can spawn in a chunk in this world
-     * <p />
+     * <p>
      * <b>Note:</b>
      * If set to a negative number the world will use the server-wide spawn limit instead.
      */
@@ -992,7 +992,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Sets the limit for number of water animals that can spawn in a chunk in this world
-     * <p />
+     * <p>
      * <b>Note:</b>
      * If set to a negative number the world will use the server-wide spawn limit instead.
      */
@@ -1006,7 +1006,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Sets the limit for number of ambient mobs that can spawn in a chunk in this world
-     * <p />
+     * <p>
      * <b>Note:</b>
      * If set to a negative number the world will use the server-wide spawn limit instead.
      */
@@ -1014,7 +1014,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Play a Sound at the provided Location in the World
-     * <p />
+     * <p>
      * This function will fail silently if Location or Sound are null.
      *
      * @param location The location to play the sound
@@ -1033,7 +1033,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Gets the current state of the specified rule
-     * <p />
+     * <p>
      * Will return null if rule passed is null
      *
      * @param rule Rule to look up value of
@@ -1043,10 +1043,10 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Set the specified gamerule to specified value.
-     * <p />
+     * <p>
      * The rule may attempt to validate the value passed, will return true if
      * value was set.
-     * <p />
+     * <p>
      * If rule is null, the function will return false.
      *
      * @param rule Rule to set

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -1061,6 +1061,23 @@ public interface World extends PluginMessageRecipient, Metadatable {
      * @return True if rule exists
      */
     public boolean isGameRule(String rule);
+    
+    /**
+     * Broadcasts the specified message to every player in this world with the given permission
+     * 
+     * @param message the message 
+     * @param permission the permission
+     * @return the number of players who recieved the message
+     */
+    public int broadcast(String message, String permission);
+    
+    /**
+     * Broadcasts the specified message to every player in this world
+     * 
+     * @param message the message
+     * @return the number of players who recieved the message
+     */
+    public int broadcastMessage(String message);
 
     /**
      * Represents various map environment types that a world may be

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -1062,6 +1062,23 @@ public interface World extends PluginMessageRecipient, Metadatable {
      * @return True if rule exists
      */
     public boolean isGameRule(String rule);
+    
+    /**
+     * Broadcasts the specified message to every player in this world with the given permission
+     * 
+     * @param message the message 
+     * @param permission the permission
+     * @return the number of players who recieved the message
+     */
+    public int broadcast(String message, String permission);
+    
+    /**
+     * Broadcasts the specified message to every player in this world
+     * 
+     * @param message the message
+     * @return the number of players who recieved the message
+     */
+    public int broadcastMessage(String message);
 
     /**
      * Represents various map environment types that a world may be

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -1062,19 +1062,19 @@ public interface World extends PluginMessageRecipient, Metadatable {
      * @return True if rule exists
      */
     public boolean isGameRule(String rule);
-    
+
     /**
      * Broadcasts the specified message to every player in this world with the given permission
-     * 
+     *
      * @param message the message 
      * @param permission the permission
      * @return the number of players who recieved the message
      */
     public int broadcast(String message, String permission);
-    
+
     /**
      * Broadcasts the specified message to every player in this world
-     * 
+     *
      * @param message the message
      * @return the number of players who recieved the message
      */

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -1062,23 +1062,6 @@ public interface World extends PluginMessageRecipient, Metadatable {
      * @return True if rule exists
      */
     public boolean isGameRule(String rule);
-    
-    /**
-     * Broadcasts the specified message to every player in this world with the given permission
-     * 
-     * @param message the message 
-     * @param permission the permission
-     * @return the number of players who recieved the message
-     */
-    public int broadcast(String message, String permission);
-    
-    /**
-     * Broadcasts the specified message to every player in this world
-     * 
-     * @param message the message
-     * @return the number of players who recieved the message
-     */
-    public int broadcastMessage(String message);
 
     /**
      * Broadcasts the specified message to every player in this world with the given permission

--- a/src/main/java/org/bukkit/WorldCreator.java
+++ b/src/main/java/org/bukkit/WorldCreator.java
@@ -140,7 +140,7 @@ public class WorldCreator {
 
     /**
      * Gets the generator that will be used to create or load the world.
-     * <p />
+     * <p>
      * This may be null, in which case the "natural" generator for this environment
      * will be used.
      *
@@ -152,7 +152,7 @@ public class WorldCreator {
 
     /**
      * Sets the generator that will be used to create or load the world.
-     * <p />
+     * <p>
      * This may be null, in which case the "natural" generator for this environment
      * will be used.
      *
@@ -167,10 +167,10 @@ public class WorldCreator {
 
     /**
      * Sets the generator that will be used to create or load the world.
-     * <p />
+     * <p>
      * This may be null, in which case the "natural" generator for this environment
      * will be used.
-     * <p />
+     * <p>
      * If the generator cannot be found for the given name, the natural environment generator
      * will be used instead and a warning will be printed to the console.
      *
@@ -185,10 +185,10 @@ public class WorldCreator {
 
     /**
      * Sets the generator that will be used to create or load the world.
-     * <p />
+     * <p>
      * This may be null, in which case the "natural" generator for this environment
      * will be used.
-     * <p />
+     * <p>
      * If the generator cannot be found for the given name, the natural environment generator
      * will be used instead and a warning will be printed to the specified output
      *
@@ -225,7 +225,7 @@ public class WorldCreator {
 
     /**
      * Creates a world with the specified options.
-     * <p />
+     * <p>
      * If the world already exists, it will be loaded from disk and some options
      * may be ignored.
      *
@@ -247,10 +247,10 @@ public class WorldCreator {
 
     /**
      * Attempts to get the {@link ChunkGenerator} with the given name.
-     * <p />
+     * <p>
      * If the generator is not found, null will be returned and a message will be
      * printed to the specified {@link CommandSender} explaining why.
-     * <p />
+     * <p>
      * The name must be in the "plugin:id" notation, or optionally just "plugin",
      * where "plugin" is the safe-name of a plugin and "id" is an optional unique
      * identifier for the generator you wish to request from the plugin.

--- a/src/main/java/org/bukkit/block/Beacon.java
+++ b/src/main/java/org/bukkit/block/Beacon.java
@@ -1,0 +1,9 @@
+package org.bukkit.block;
+
+import org.bukkit.inventory.InventoryHolder;
+
+/**
+ * Represents a beacon.
+ */
+public interface Beacon extends BlockState, InventoryHolder {
+}

--- a/src/main/java/org/bukkit/block/Block.java
+++ b/src/main/java/org/bukkit/block/Block.java
@@ -36,7 +36,7 @@ public interface Block extends Metadatable {
 
     /**
      * Gets the block at the given face
-     * <p />
+     * <p>
      * This method is equal to getRelative(face, 1)
      *
      * @param face Face of this block to return
@@ -47,7 +47,7 @@ public interface Block extends Metadatable {
 
     /**
      * Gets the block at the given distance of the given face
-     * <p />
+     * <p>
      * For example, the following method places water at 100,102,100; two blocks
      * above 100,100,100.
      *
@@ -86,7 +86,7 @@ public interface Block extends Metadatable {
 
     /**
      * Get the amount of light at this block from the sky.
-     * <p />
+     * <p>
      * Any light given from other sources (such as blocks like torches) will be ignored.
      *
      * @return Sky light level
@@ -95,7 +95,7 @@ public interface Block extends Metadatable {
 
     /**
      * Get the amount of light at this block from nearby blocks.
-     * <p />
+     * <p>
      * Any light given from other sources (such as the sun) will be ignored.
      *
      * @return Block light level
@@ -203,7 +203,7 @@ public interface Block extends Metadatable {
 
     /**
      * Gets the face relation of this block compared to the given block
-     * <p />
+     * <p>
      * For example:
      * <pre>
      * Block current = world.getBlockAt(100, 100, 100);
@@ -222,7 +222,7 @@ public interface Block extends Metadatable {
     /**
      * Captures the current state of this block. You may then cast that state
      * into any accepted type, such as Furnace or Sign.
-     * <p />
+     * <p>
      * The returned object will never be updated, and you are not guaranteed that
      * (for example) a sign is still a sign after you capture its state.
      *
@@ -291,7 +291,7 @@ public interface Block extends Metadatable {
 
     /**
      * Checks if this block is empty.
-     * <p />
+     * <p>
      * A block is considered empty when {@link #getType()} returns {@link Material#AIR}.
      *
      * @return true if this block is empty
@@ -300,7 +300,7 @@ public interface Block extends Metadatable {
 
     /**
      * Checks if this block is liquid.
-     * <p />
+     * <p>
      * A block is considered liquid when {@link #getType()} returns {@link Material#WATER}, {@link Material#STATIONARY_WATER}, {@link Material#LAVA} or {@link Material#STATIONARY_LAVA}.
      *
      * @return true if this block is liquid

--- a/src/main/java/org/bukkit/block/BlockState.java
+++ b/src/main/java/org/bukkit/block/BlockState.java
@@ -142,17 +142,33 @@ public interface BlockState extends Metadatable {
      * Attempts to update the block represented by this state, setting it to the
      * new values as defined by this state.
      * <p />
+     * This has the same effect as calling update(force, true). That is to say,
+     * this will trigger a physics update to surrounding blocks.
+     *
+     * @param force true to forcefully set the state
+     * @return true if the update was successful, otherwise false
+     */
+    boolean update(boolean force);
+
+    /**
+     * Attempts to update the block represented by this state, setting it to the
+     * new values as defined by this state.
+     * <p />
      * Unless force is true, this will not modify the state of a block if it is
      * no longer the same type as it was when this state was taken. It will return
      * false in this eventuality.
      * <p />
      * If force is true, it will set the type of the block to match the new state,
      * set the state data and then return true.
+     * <p />
+     * If applyPhysics is true, it will trigger a physics update on surrounding
+     * blocks which could cause them to update or disappear.
      *
      * @param force true to forcefully set the state
+     * @param applyPhysics false to cancel updating physics on surrounding blocks
      * @return true if the update was successful, otherwise false
      */
-    boolean update(boolean force);
+    boolean update(boolean force, boolean applyPhysics);
 
     /**
      * @return The data as a raw byte.

--- a/src/main/java/org/bukkit/block/BlockState.java
+++ b/src/main/java/org/bukkit/block/BlockState.java
@@ -9,7 +9,7 @@ import org.bukkit.metadata.Metadatable;
 
 /**
  * Represents a captured state of a block, which will not change automatically.
- * <p />
+ * <p>
  * Unlike Block, which only one object can exist per coordinate, BlockState can
  * exist multiple times for any given Block. Note that another plugin may change
  * the state of the block and you will not know, or they may change the block to
@@ -127,7 +127,7 @@ public interface BlockState extends Metadatable {
     /**
      * Attempts to update the block represented by this state, setting it to the
      * new values as defined by this state.
-     * <p />
+     * <p>
      * This has the same effect as calling update(false). That is to say,
      * this will not modify the state of a block if it is no longer the same
      * type as it was when this state was taken. It will return false in this
@@ -141,7 +141,7 @@ public interface BlockState extends Metadatable {
     /**
      * Attempts to update the block represented by this state, setting it to the
      * new values as defined by this state.
-     * <p />
+     * <p>
      * This has the same effect as calling update(force, true). That is to say,
      * this will trigger a physics update to surrounding blocks.
      *
@@ -153,14 +153,14 @@ public interface BlockState extends Metadatable {
     /**
      * Attempts to update the block represented by this state, setting it to the
      * new values as defined by this state.
-     * <p />
+     * <p>
      * Unless force is true, this will not modify the state of a block if it is
      * no longer the same type as it was when this state was taken. It will return
      * false in this eventuality.
-     * <p />
+     * <p>
      * If force is true, it will set the type of the block to match the new state,
      * set the state data and then return true.
-     * <p />
+     * <p>
      * If applyPhysics is true, it will trigger a physics update on surrounding
      * blocks which could cause them to update or disappear.
      *

--- a/src/main/java/org/bukkit/block/CommandBlock.java
+++ b/src/main/java/org/bukkit/block/CommandBlock.java
@@ -1,0 +1,40 @@
+package org.bukkit.block;
+
+public interface CommandBlock extends BlockState {
+
+    /**
+     * Gets the command that this CommandBlock will run when powered.
+     * This will never return null.  If the CommandBlock does not have a
+     * command, an empty String will be returned instead.
+     *
+     * @return Command that this CommandBlock will run when powered.
+     */
+    public String getCommand();
+
+    /**
+     * Sets the command that this CommandBlock will run when powered.
+     * Setting the command to null is the same as setting it to an empty
+     * String.
+     *
+     * @param command Command that this CommandBlock will run when powered.
+     */
+    public void setCommand(String command);
+
+    /**
+     * Gets the name of this CommandBlock.  The name is used with commands
+     * that this CommandBlock executes.  This name will never be null, and
+     * by default is "@".
+     *
+     * @return Name of this CommandBlock.
+     */
+    public String getName();
+
+    /**
+     * Sets the name of this CommandBlock.  The name is used with commands
+     * that this CommandBlock executes.  Setting the name to null is the
+     * same as setting it to "@".
+     *
+     * @param name New name for this CommandBlock.
+     */
+    public void setName(String name);
+}

--- a/src/main/java/org/bukkit/block/Dispenser.java
+++ b/src/main/java/org/bukkit/block/Dispenser.java
@@ -7,7 +7,7 @@ public interface Dispenser extends BlockState, ContainerBlock {
 
     /**
      * Attempts to dispense the contents of this block
-     * <p />
+     * <p>
      * If the block is no longer a dispenser, this will return false
      *
      * @return true if successful, otherwise false

--- a/src/main/java/org/bukkit/block/Dropper.java
+++ b/src/main/java/org/bukkit/block/Dropper.java
@@ -1,0 +1,25 @@
+package org.bukkit.block;
+
+import org.bukkit.inventory.InventoryHolder;
+
+/**
+ * Represents a dropper.
+ */
+public interface Dropper extends BlockState, InventoryHolder {
+    /**
+     * Tries to drop a randomly selected item from the Dropper's inventory,
+     * following the normal behavior of a Dropper.
+     * <p />
+     * Normal behavior of a Dropper is as follows:
+     * <p />
+     * If the block that the Dropper is facing is an InventoryHolder or
+     * ContainerBlock the randomly selected ItemStack is placed within that 
+     * Inventory in the first slot that's available, starting with 0 and
+     * counting up.  If the inventory is full, nothing happens.
+     * <p />
+     * If the block that the Dropper is facing is not an InventoryHolder or
+     * ContainerBlock, the randomly selected ItemStack is dropped on
+     * the ground in the form of an {@link org.bukkit.entity.Item Item}.
+     */
+     public void drop();
+}

--- a/src/main/java/org/bukkit/block/Dropper.java
+++ b/src/main/java/org/bukkit/block/Dropper.java
@@ -9,14 +9,14 @@ public interface Dropper extends BlockState, InventoryHolder {
     /**
      * Tries to drop a randomly selected item from the Dropper's inventory,
      * following the normal behavior of a Dropper.
-     * <p />
+     * <p>
      * Normal behavior of a Dropper is as follows:
-     * <p />
+     * <p>
      * If the block that the Dropper is facing is an InventoryHolder or
      * ContainerBlock the randomly selected ItemStack is placed within that 
      * Inventory in the first slot that's available, starting with 0 and
      * counting up.  If the inventory is full, nothing happens.
-     * <p />
+     * <p>
      * If the block that the Dropper is facing is not an InventoryHolder or
      * ContainerBlock, the randomly selected ItemStack is dropped on
      * the ground in the form of an {@link org.bukkit.entity.Item Item}.

--- a/src/main/java/org/bukkit/block/NoteBlock.java
+++ b/src/main/java/org/bukkit/block/NoteBlock.java
@@ -38,7 +38,7 @@ public interface NoteBlock extends BlockState {
 
     /**
      * Attempts to play the note at block
-     * <p />
+     * <p>
      * If the block is no longer a note block, this will return false
      *
      * @return true if successful, otherwise false

--- a/src/main/java/org/bukkit/block/Sign.java
+++ b/src/main/java/org/bukkit/block/Sign.java
@@ -14,7 +14,7 @@ public interface Sign extends BlockState {
 
     /**
      * Gets the line of text at the specified index.
-     * <p />
+     * <p>
      * For example, getLine(0) will return the first line of text.
      *
      * @param index Line number to get the text from, starting at 0
@@ -25,7 +25,7 @@ public interface Sign extends BlockState {
 
     /**
      * Sets the line of text at the specified index.
-     * <p />
+     * <p>
      * For example, setLine(0, "Line One") will set the first line of text to
      * "Line One".
      *

--- a/src/main/java/org/bukkit/block/Skull.java
+++ b/src/main/java/org/bukkit/block/Skull.java
@@ -30,14 +30,14 @@ public interface Skull extends BlockState {
     public boolean setOwner(String name);
 
     /**
-     * Gets the rotation of the skull
+     * Gets the rotation of the skull in the world
      *
      * @return the rotation of the skull
      */
     public BlockFace getRotation();
 
     /**
-     * Sets the rotation of the skull
+     * Sets the rotation of the skull in the world
      *
      * @param rotation the rotation of the skull
      */

--- a/src/main/java/org/bukkit/block/Skull.java
+++ b/src/main/java/org/bukkit/block/Skull.java
@@ -17,7 +17,7 @@ public interface Skull extends BlockState {
     /**
      * Gets the owner of the skull
      *
-     * @return the owner if the skull
+     * @return the owner of the skull
      */
     public String getOwner();
 

--- a/src/main/java/org/bukkit/command/Command.java
+++ b/src/main/java/org/bukkit/command/Command.java
@@ -11,6 +11,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.Permissible;
+import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.util.StringUtil;
 
 import com.google.common.collect.ImmutableList;
@@ -279,10 +280,13 @@ public abstract class Command {
     }
 
     /**
-     * Sets the list of aliases to request on registration for this command
+     * Sets the list of aliases to request on registration for this command.
+     * This is not effective outside of defining aliases in the {@link
+     * PluginDescriptionFile#getCommands()} (under the
+     * `<code>aliases</code>' node) is equivalent to this method.
      *
-     * @param aliases Aliases to register to this command
-     * @return This command object, for linking
+     * @param aliases aliases to register to this command
+     * @return this command object, for chaining
      */
     public Command setAliases(List<String> aliases) {
         this.aliases = aliases;
@@ -293,10 +297,12 @@ public abstract class Command {
     }
 
     /**
-     * Sets a brief description of this command
+     * Sets a brief description of this command. Defining a description in the
+     * {@link PluginDescriptionFile#getCommands()} (under the
+     * `<code>description</code>' node) is equivalent to this method.
      *
-     * @param description New command description
-     * @return This command object, for linking
+     * @param description new command description
+     * @return this command object, for chaining
      */
     public Command setDescription(String description) {
         this.description = description;
@@ -306,8 +312,9 @@ public abstract class Command {
     /**
      * Sets the message sent when a permission check fails
      *
-     * @param permissionMessage New permission message, null to indicate default message, or an empty string to indicate no message
-     * @return This command object, for linking
+     * @param permissionMessage new permission message, null to indicate
+     *     default message, or an empty string to indicate no message
+     * @return this command object, for chaining
      */
     public Command setPermissionMessage(String permissionMessage) {
         this.permissionMessage = permissionMessage;
@@ -317,8 +324,8 @@ public abstract class Command {
     /**
      * Sets the example usage of this command
      *
-     * @param usage New example usage
-     * @return This command object, for linking
+     * @param usage new example usage
+     * @return this command object, for chaining
      */
     public Command setUsage(String usage) {
         this.usageMessage = usage;

--- a/src/main/java/org/bukkit/command/Command.java
+++ b/src/main/java/org/bukkit/command/Command.java
@@ -126,7 +126,7 @@ public abstract class Command {
 
     /**
      * Tests the given {@link CommandSender} to see if they can perform this command.
-     * <p />
+     * <p>
      * If they do not have permission, they will be informed that they cannot do this.
      *
      * @param target User to test
@@ -150,7 +150,7 @@ public abstract class Command {
 
     /**
      * Tests the given {@link CommandSender} to see if they can perform this command.
-     * <p />
+     * <p>
      * No error is sent to the sender.
      *
      * @param target User to test

--- a/src/main/java/org/bukkit/command/SimpleCommandMap.java
+++ b/src/main/java/org/bukkit/command/SimpleCommandMap.java
@@ -56,6 +56,7 @@ public class SimpleCommandMap implements CommandMap {
         fallbackCommands.add(new GameRuleCommand());
         fallbackCommands.add(new EnchantCommand());
         fallbackCommands.add(new TestForCommand());
+        fallbackCommands.add(new EffectCommand());
     }
 
     public SimpleCommandMap(final Server server) {

--- a/src/main/java/org/bukkit/command/SimpleCommandMap.java
+++ b/src/main/java/org/bukkit/command/SimpleCommandMap.java
@@ -57,6 +57,7 @@ public class SimpleCommandMap implements CommandMap {
         fallbackCommands.add(new EnchantCommand());
         fallbackCommands.add(new TestForCommand());
         fallbackCommands.add(new EffectCommand());
+        fallbackCommands.add(new ScoreboardCommand());
     }
 
     public SimpleCommandMap(final Server server) {

--- a/src/main/java/org/bukkit/command/defaults/EffectCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/EffectCommand.java
@@ -1,0 +1,111 @@
+package org.bukkit.command.defaults;
+
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.util.StringUtil;
+
+public class EffectCommand extends VanillaCommand {
+    private static final List<String> effects;
+
+    public EffectCommand() {
+        super("effect");
+        this.description = "Adds/Removes effects on players";
+        this.usageMessage = "/effect <player> <effect> [seconds] [amplifier]";
+        this.setPermission("bukkit.command.effect");
+    }
+
+    static {
+        ImmutableList.Builder<String> builder = ImmutableList.<String>builder();
+
+        for (PotionEffectType type : PotionEffectType.values()) {
+            if (type != null) {
+                builder.add(type.getName());
+            }
+        }
+
+        effects = builder.build();
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String commandLabel, String[] args) {
+        if (!testPermission(sender)) {
+            return true;
+        }
+
+        if (args.length < 2) {
+            sender.sendMessage(getUsage());
+            return true;
+        }
+
+        final Player player = sender.getServer().getPlayer(args[0]);
+
+        if (player == null) {
+            sender.sendMessage(ChatColor.RED + String.format("Player, %s, not found", args[0]));
+            return true;
+        }
+
+        PotionEffectType effect = PotionEffectType.getByName(args[1]);
+
+        if (effect == null) {
+            effect = PotionEffectType.getById(getInteger(sender, args[1], 0));
+        }
+
+        if (effect == null) {
+            sender.sendMessage(ChatColor.RED + String.format("Effect, %s, not found", args[1]));
+            return true;
+        }
+
+        int duration = 600;
+        int duration_temp = 30;
+        int amplification = 0;
+
+        if (args.length >= 3) {
+            duration_temp = getInteger(sender, args[2], 0, 1000000);
+            if (effect.isInstant()) {
+                duration = duration_temp;
+            } else {
+                duration = duration_temp * 20;
+            }
+        } else if (effect.isInstant()) {
+            duration = 1;
+        }
+
+        if (args.length >= 4) {
+            amplification = getInteger(sender, args[3], 0, 255);
+        }
+
+        if (duration_temp == 0) {
+            if (!player.hasPotionEffect(effect)) {
+                sender.sendMessage(String.format("Couldn't take %s from %s as they do not have the effect", effect.getName(), args[0]));
+                return true;
+            }
+
+            player.removePotionEffect(effect);
+            broadcastCommandMessage(sender, String.format("Took %s from %s", effect.getName(), args[0]));
+        } else {
+            final PotionEffect applyEffect = new PotionEffect(effect, duration, amplification);
+
+            player.addPotionEffect(applyEffect, true);
+            broadcastCommandMessage(sender, String.format("Given %s (ID %d) * %d to %s for %d seconds", effect.getName(), effect.getId(), amplification, args[0], duration));
+        }
+
+        return true;
+    }
+
+    @Override
+    public List<String> tabComplete(CommandSender sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return super.tabComplete(sender, commandLabel, args);
+        } else if (args.length == 2) {
+            return StringUtil.copyPartialMatches(args[1], effects, new ArrayList<String>(effects.size()));
+        }
+
+        return ImmutableList.of();
+    }
+}

--- a/src/main/java/org/bukkit/command/defaults/ScoreboardCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/ScoreboardCommand.java
@@ -385,13 +385,13 @@ public class ScoreboardCommand extends VanillaCommand {
                     sender.sendMessage("Added " + addedPlayers.size() + " player(s) to team " + team.getName() + ": " + stringCollectionToString(addedPlayers));
                 }
             } else if (args[1].equalsIgnoreCase("leave")) {
-                if ((sender instanceof Player) ? args.length < 2 : args.length < 3) {
+                if (!(sender instanceof Player) && args.length < 3) {
                     sender.sendMessage(ChatColor.RED + "/scoreboard teams leave [player...]");
                     return false;
                 }
                 Set<String> left = new HashSet<String>();
                 Set<String> noTeam = new HashSet<String>();
-                if ((sender instanceof Player) && args.length == 3) {
+                if ((sender instanceof Player) && args.length == 2) {
                     Team team = mainScoreboard.getPlayerTeam((Player) sender);
                     if (team != null) {
                         team.removePlayer((Player) sender);

--- a/src/main/java/org/bukkit/command/defaults/ScoreboardCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/ScoreboardCommand.java
@@ -309,7 +309,7 @@ public class ScoreboardCommand extends VanillaCommand {
                 } else {
                     String displayName = null;
                     if (args.length > 3) {
-                        displayName = StringUtils.join(ArrayUtils.subarray(args, 4, args.length), ' ');
+                        displayName = StringUtils.join(ArrayUtils.subarray(args, 3, args.length), ' ');
                         if (displayName.length() > 32) {
                             sender.sendMessage(ChatColor.RED + "The display name '" + displayName + "' is too long for a team, it can be at most 32 characters long");
                             return false;

--- a/src/main/java/org/bukkit/command/defaults/ScoreboardCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/ScoreboardCommand.java
@@ -1,0 +1,627 @@
+package org.bukkit.command.defaults;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.Validate;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.DisplaySlot;
+import org.bukkit.scoreboard.Objective;
+import org.bukkit.scoreboard.Score;
+import org.bukkit.scoreboard.Scoreboard;
+import org.bukkit.scoreboard.Team;
+import org.bukkit.util.StringUtil;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+public class ScoreboardCommand extends VanillaCommand {
+
+    private static final List<String> MAIN_CHOICES = ImmutableList.of("objectives", "players", "teams");
+    private static final List<String> OBJECTIVES_CHOICES = ImmutableList.of("list", "add", "remove", "setdisplay");
+    private static final List<String> OBJECTIVES_CRITERIA = ImmutableList.of("health", "playerKillCount", "totalKillCount", "deathCount", "dummy");
+    private static final List<String> PLAYERS_CHOICES = ImmutableList.of("set", "add", "remove", "reset", "list");
+    private static final List<String> TEAMS_CHOICES = ImmutableList.of("add", "remove", "join", "leave", "empty", "list", "option");
+    private static final List<String> TEAMS_OPTION_CHOICES = ImmutableList.of("color", "friendlyfire", "seeFriendlyInvisibles");
+    private static final Map<String, DisplaySlot> OBJECTIVES_DISPLAYSLOT = ImmutableMap.of("belowName", DisplaySlot.BELOW_NAME, "list", DisplaySlot.PLAYER_LIST, "sidebar", DisplaySlot.SIDEBAR);
+    private static final Map<String, ChatColor> TEAMS_OPTION_COLOR = ImmutableMap.<String, ChatColor>builder()
+            .put("aqua", ChatColor.AQUA)
+            .put("black", ChatColor.BLACK)
+            .put("blue", ChatColor.BLUE)
+            .put("bold", ChatColor.BOLD)
+            .put("dark_aqua", ChatColor.DARK_AQUA)
+            .put("dark_blue", ChatColor.DARK_BLUE)
+            .put("dark_gray",  ChatColor.DARK_GRAY)
+            .put("dark_green", ChatColor.DARK_GREEN)
+            .put("dark_purple", ChatColor.DARK_PURPLE)
+            .put("dark_red", ChatColor.DARK_RED)
+            .put("gold", ChatColor.GOLD)
+            .put("gray", ChatColor.GRAY)
+            .put("green", ChatColor.GREEN)
+            .put("italic", ChatColor.ITALIC)
+            .put("light_purple", ChatColor.LIGHT_PURPLE)
+            .put("obfuscated", ChatColor.MAGIC) // This is the important line
+            .put("red", ChatColor.RED)
+            .put("reset", ChatColor.RESET)
+            .put("strikethrough", ChatColor.STRIKETHROUGH)
+            .put("underline", ChatColor.UNDERLINE)
+            .put("white", ChatColor.WHITE)
+            .put("yellow", ChatColor.YELLOW)
+            .build();
+    private static final List<String> BOOLEAN = ImmutableList.of("true", "false");
+
+    public ScoreboardCommand() {
+        super("scoreboard");
+        this.description = "Scoreboard control";
+        this.usageMessage = "/scoreboard";
+        this.setPermission("bukkit.command.scoreboard");
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String currentAlias, String[] args) {
+        if (!testPermission(sender))
+            return true;
+        if (args.length < 1 || args[0].length() == 0) {
+            sender.sendMessage(ChatColor.RED + "Usage: /scoreboard <objectives|players|teams>");
+            return false;
+        }
+
+        final Scoreboard mainScoreboard = Bukkit.getScoreboardManager().getMainScoreboard();
+
+        if (args[0].equalsIgnoreCase("objectives")) {
+            if (args.length == 1) {
+                sender.sendMessage(ChatColor.RED + "Usage: /scoreboard objectives <list|add|remove|setdisplay>");
+                return false;
+            }
+            if (args[1].equalsIgnoreCase("list")) {
+                Set<Objective> objectives = mainScoreboard.getObjectives();
+                if (objectives.isEmpty()) {
+                    sender.sendMessage(ChatColor.RED + "There are no objectives on the scoreboard");
+                    return false;
+                }
+                sender.sendMessage(ChatColor.DARK_GREEN + "Showing " + objectives.size() + " objective(s) on scoreboard");
+                for (Objective objective : objectives) {
+                    sender.sendMessage("- " + objective.getName() + ": displays as '" + objective.getDisplayName() + "' and is type '" + objective.getCriteria() + "'");
+                }
+            } else if (args[1].equalsIgnoreCase("add")) {
+                if (args.length < 4) {
+                    sender.sendMessage(ChatColor.RED + "/scoreboard objectives add <name> <criteriaType> [display name ...]");
+                    return false;
+                }
+                String name = args[2];
+                String criteria = args[3];
+
+                if (criteria == null) {
+                    sender.sendMessage(ChatColor.RED + "Invalid objective criteria type. Valid types are: " + stringCollectionToString(OBJECTIVES_CRITERIA));
+                } else if (name.length() > 16) {
+                    sender.sendMessage(ChatColor.RED + "The name '" + name + "' is too long for an objective, it can be at most 16 characters long");
+                } else if (mainScoreboard.getObjective(name) != null) {
+                    sender.sendMessage(ChatColor.RED + "An objective with the name '" + name + "' already exists");
+                } else {
+                    String displayName = null;
+                    if (args.length > 4) {
+                        displayName = StringUtils.join(ArrayUtils.subarray(args, 4, args.length), ' ');
+                        if (displayName.length() > 32) {
+                            sender.sendMessage(ChatColor.RED + "The name '" + displayName + "' is too long for an objective, it can be at most 32 characters long");
+                            return false;
+                        }
+                    }
+                    Objective objective = mainScoreboard.registerNewObjective(name, criteria);
+                    if (displayName != null && displayName.length() > 0) {
+                        objective.setDisplayName(displayName);
+                    }
+                    sender.sendMessage("Added new objective '" + name + "' successfully");
+                }
+            } else if (args[1].equalsIgnoreCase("remove")) {
+                if (args.length != 3) {
+                    sender.sendMessage(ChatColor.RED + "/scoreboard objectives remove <name>");
+                    return false;
+                }
+                String name = args[2];
+                Objective objective = mainScoreboard.getObjective(name);
+                if (objective == null) {
+                    sender.sendMessage(ChatColor.RED + "No objective was found by the name '" + name + "'");
+                } else {
+                    objective.unregister();
+                    sender.sendMessage("Removed objective '" + name + "' successfully");
+                }
+            } else if (args[1].equalsIgnoreCase("setdisplay")) {
+                if (args.length != 3 && args.length != 4) {
+                    sender.sendMessage(ChatColor.RED + "/scoreboard objectives setdisplay <slot> [objective]");
+                    return false;
+                }
+                String slotName = args[2];
+                DisplaySlot slot = OBJECTIVES_DISPLAYSLOT.get(slotName);
+                if (slot == null) {
+                    sender.sendMessage(ChatColor.RED + "No such display slot '" + slotName + "'");
+                } else {
+                    if (args.length == 4) {
+                        String objectiveName = args[3];
+                        Objective objective = mainScoreboard.getObjective(objectiveName);
+                        if (objective == null) {
+                            sender.sendMessage(ChatColor.RED + "No objective was found by the name '" + objectiveName + "'");
+                            return false;
+                        }
+
+                        objective.setDisplaySlot(slot);
+                        sender.sendMessage("Set the display objective in slot '" + slotName + "' to '" + objective.getName() + "'");
+                    } else {
+                        Objective objective = mainScoreboard.getObjective(slot);
+                        if (objective != null) {
+                            objective.setDisplaySlot(null);
+                        }
+                        sender.sendMessage("Cleared objective display slot '" + slotName + "'");
+                    }
+                }
+            }
+        } else if (args[0].equalsIgnoreCase("players")) {
+            if (args.length == 1) {
+                sender.sendMessage(ChatColor.RED + "/scoreboard players <set|add|remove|reset|list>");
+                return false;
+            }
+            if (args[1].equalsIgnoreCase("set") || args[1].equalsIgnoreCase("add") || args[1].equalsIgnoreCase("remove")) {
+                if (args.length != 5) {
+                    if (args[1].equalsIgnoreCase("set")) {
+                        sender.sendMessage(ChatColor.RED + "/scoreboard players set <player> <objective> <score>");
+                    } else if (args[1].equalsIgnoreCase("add")) {
+                        sender.sendMessage(ChatColor.RED + "/scoreboard players add <player> <objective> <count>");
+                    } else {
+                        sender.sendMessage(ChatColor.RED + "/scoreboard players remove <player> <objective> <count>");
+                    }
+                    return false;
+                }
+                String objectiveName = args[3];
+                Objective objective = mainScoreboard.getObjective(objectiveName);
+                if (objective == null) {
+                    sender.sendMessage(ChatColor.RED + "No objective was found by the name '" + objectiveName + "'");
+                    return false;
+                } else if (!objective.isModifiable()) {
+                    sender.sendMessage(ChatColor.RED + "The objective '" + objectiveName + "' is read-only and cannot be set");
+                    return false;
+                }
+
+                String valueString = args[4];
+                int value;
+                try {
+                    value = Integer.parseInt(valueString);
+                } catch (NumberFormatException e) {
+                    sender.sendMessage(ChatColor.RED + "'" + valueString + "' is not a valid number");
+                    return false;
+                }
+                if (value < 1 && !args[1].equalsIgnoreCase("set")) {
+                    sender.sendMessage(ChatColor.RED + "The number you have entered (" + value + ") is too small, it must be at least 1");
+                    return false;
+                }
+
+                String playerName = args[2];
+                if (playerName.length() > 16) {
+                    sender.sendMessage(ChatColor.RED + "'" + playerName + "' is too long for a player name");
+                    return false;
+                }
+                Score score = objective.getScore(Bukkit.getOfflinePlayer(playerName));
+                int newScore;
+                if (args[1].equalsIgnoreCase("set")) {
+                    newScore = value;
+                } else if (args[1].equalsIgnoreCase("add")) {
+                    newScore = score.getScore() + value;
+                } else {
+                    newScore = score.getScore() - value;
+                }
+                score.setScore(newScore);
+                sender.sendMessage("Set score of " + objectiveName + " for player " + playerName + " to " + newScore);
+            } else if (args[1].equalsIgnoreCase("reset")) {
+                if (args.length != 3) {
+                    sender.sendMessage(ChatColor.RED + "/scoreboard players reset <player>");
+                    return false;
+                }
+                String playerName = args[2];
+                if (playerName.length() > 16) {
+                    sender.sendMessage(ChatColor.RED + "'" + playerName + "' is too long for a player name");
+                    return false;
+                }
+                mainScoreboard.resetScores(Bukkit.getOfflinePlayer(playerName));
+                sender.sendMessage("Reset all scores of player " + playerName);
+            } else if (args[1].equalsIgnoreCase("list")) {
+                if (args.length > 3) {
+                    sender.sendMessage(ChatColor.RED + "/scoreboard players list <player>");
+                    return false;
+                }
+                if (args.length == 2) {
+                    Set<OfflinePlayer> players = mainScoreboard.getPlayers();
+                    if (players.isEmpty()) {
+                        sender.sendMessage(ChatColor.RED + "There are no tracked players on the scoreboard");
+                    } else {
+                        sender.sendMessage(ChatColor.DARK_GREEN + "Showing " + players.size() + " tracked players on the scoreboard");
+                        sender.sendMessage(offlinePlayerSetToString(players));
+                    }
+                } else {
+                    String playerName = args[2];
+                    if (playerName.length() > 16) {
+                        sender.sendMessage(ChatColor.RED + "'" + playerName + "' is too long for a player name");
+                        return false;
+                    }
+                    Set<Score> scores = mainScoreboard.getScores(Bukkit.getOfflinePlayer(playerName));
+                    if (scores.isEmpty()) {
+                        sender.sendMessage(ChatColor.RED + "Player " + playerName + " has no scores recorded");
+                    } else {
+                        sender.sendMessage(ChatColor.DARK_GREEN + "Showing " + scores.size() + " tracked objective(s) for " + playerName);
+                        for (Score score : scores) {
+                            sender.sendMessage("- " + score.getObjective().getDisplayName() + ": " + score.getScore() + " (" + score.getObjective().getName() + ")");
+                        }
+                    }
+                }
+            }
+        } else if (args[0].equalsIgnoreCase("teams")) {
+            if (args.length == 1) {
+                sender.sendMessage(ChatColor.RED + "/scoreboard teams <list|add|remove|empty|join|leave|option>");
+                return false;
+            }
+            if (args[1].equalsIgnoreCase("list")) {
+                if (args.length == 2) {
+                    Set<Team> teams = mainScoreboard.getTeams();
+                    if (teams.isEmpty()) {
+                        sender.sendMessage(ChatColor.RED + "There are no teams registered on the scoreboard");
+                    } else {
+                        sender.sendMessage(ChatColor.DARK_GREEN + "Showing " + teams.size() + " teams on the scoreboard");
+                        for (Team team : teams) {
+                            sender.sendMessage("- " + team.getName() + ": '" + team.getDisplayName() + "' has " + team.getSize() + " players");
+                        }
+                    }
+                } else if (args.length == 3) {
+                    String teamName = args[2];
+                    Team team = mainScoreboard.getTeam(teamName);
+                    if (team == null) {
+                        sender.sendMessage(ChatColor.RED + "No team was found by the name '" + teamName + "'");
+                    } else {
+                        Set<OfflinePlayer> players = team.getPlayers();
+                        if (players.isEmpty()) {
+                            sender.sendMessage(ChatColor.RED + "Team " + team.getName() + " has no players");
+                        } else {
+                            sender.sendMessage(ChatColor.DARK_GREEN + "Showing " + players.size() + " player(s) in team " + team.getName());
+                            sender.sendMessage(offlinePlayerSetToString(players));
+                        }
+                    }
+                } else {
+                    sender.sendMessage(ChatColor.RED + "/scoreboard teams list [name]");
+                    return false;
+                }
+            } else if (args[1].equalsIgnoreCase("add")) {
+                if (args.length < 3) {
+                    sender.sendMessage(ChatColor.RED + "/scoreboard teams add <name> [display name ...]");
+                    return false;
+                }
+                String name = args[2];
+                if (name.length() > 16) {
+                    sender.sendMessage(ChatColor.RED + "The name '" + name + "' is too long for a team, it can be at most 16 characters long");
+                } else if (mainScoreboard.getTeam(name) != null) {
+                    sender.sendMessage(ChatColor.RED + "A team with the name '" + name + "' already exists");
+                } else {
+                    String displayName = null;
+                    if (args.length > 3) {
+                        displayName = StringUtils.join(ArrayUtils.subarray(args, 4, args.length), ' ');
+                        if (displayName.length() > 32) {
+                            sender.sendMessage(ChatColor.RED + "The display name '" + displayName + "' is too long for a team, it can be at most 32 characters long");
+                            return false;
+                        }
+                    }
+                    Team team = mainScoreboard.registerNewTeam(name);
+                    if (displayName != null && displayName.length() > 0) {
+                        team.setDisplayName(displayName);
+                    }
+                    sender.sendMessage("Added new team '" + team.getName() + "' successfully");
+                }
+            } else if (args[1].equalsIgnoreCase("remove")) {
+                if (args.length != 3) {
+                    sender.sendMessage(ChatColor.RED + "/scoreboard teams remove <name>");
+                    return false;
+                }
+                String name = args[2];
+                Team team = mainScoreboard.getTeam(name);
+                if (team == null) {
+                    sender.sendMessage(ChatColor.RED + "No team was found by the name '" + name + "'");
+                } else {
+                    team.unregister();
+                    sender.sendMessage("Removed team " + name);
+                }
+            } else if (args[1].equalsIgnoreCase("empty")) {
+                if (args.length != 3) {
+                    sender.sendMessage(ChatColor.RED + "/scoreboard teams clear <name>");
+                    return false;
+                }
+                String name = args[2];
+                Team team = mainScoreboard.getTeam(name);
+                if (team == null) {
+                    sender.sendMessage(ChatColor.RED + "No team was found by the name '" + name + "'");
+                } else {
+                    Set<OfflinePlayer> players = team.getPlayers();
+                    if (players.isEmpty()) {
+                        sender.sendMessage(ChatColor.RED + "Team " + team.getName() + " is already empty, cannot remove nonexistant players");
+                    } else {
+                        for (OfflinePlayer player : players) {
+                            team.removePlayer(player);
+                        }
+                        sender.sendMessage("Removed all " + players.size() + " player(s) from team " + team.getName());
+                    }
+                }
+            } else if (args[1].equalsIgnoreCase("join")) {
+                if ((sender instanceof Player) ? args.length < 3 : args.length < 4) {
+                    sender.sendMessage(ChatColor.RED + "/scoreboard teams join <team> [player...]");
+                    return false;
+                }
+                String teamName = args[2];
+                Team team = mainScoreboard.getTeam(teamName);
+                if (team == null) {
+                    sender.sendMessage(ChatColor.RED + "No team was found by the name '" + teamName + "'");
+                } else {
+                    Set<String> addedPlayers = new HashSet<String>();
+                    if ((sender instanceof Player) && args.length == 3) {
+                        team.addPlayer((Player) sender);
+                        addedPlayers.add(sender.getName());
+                    } else {
+                        for (int i = 3; i < args.length; i++) {
+                            String playerName = args[i];
+                            OfflinePlayer offlinePlayer;
+                            Player player = Bukkit.getPlayerExact(playerName);
+                            if (player != null) {
+                                offlinePlayer = player;
+                            } else {
+                                offlinePlayer = Bukkit.getOfflinePlayer(playerName);
+                            }
+                            team.addPlayer(offlinePlayer);
+                            addedPlayers.add(offlinePlayer.getName());
+                        }
+                    }
+                    String[] playerArray = addedPlayers.toArray(new String[0]);
+                    StringBuilder builder = new StringBuilder();
+                    for (int x = 0; x < playerArray.length; x++) {
+                        if (x == playerArray.length - 1) {
+                            builder.append(" and ");
+                        } else if (x > 0) {
+                            builder.append(", ");
+                        }
+                        builder.append(playerArray[x]);
+                    }
+                    sender.sendMessage("Added " + addedPlayers.size() + " player(s) to team " + team.getName() + ": " + builder.toString());
+                }
+            } else if (args[1].equalsIgnoreCase("leave")) {
+                if ((sender instanceof Player) ? args.length < 2 : args.length < 3) {
+                    sender.sendMessage(ChatColor.RED + "/scoreboard teams leave [player...]");
+                    return false;
+                }
+                Set<String> left = new HashSet<String>();
+                Set<String> noTeam = new HashSet<String>();
+                if ((sender instanceof Player) && args.length == 3) {
+                    Team team = mainScoreboard.getPlayerTeam((Player) sender);
+                    if (team != null) {
+                        team.removePlayer((Player) sender);
+                        left.add(sender.getName());
+                    } else {
+                        noTeam.add(sender.getName());
+                    }
+                } else {
+                    for (int i = 3; i < args.length; i++) {
+                        String playerName = args[i];
+                        OfflinePlayer offlinePlayer;
+                        Player player = Bukkit.getPlayerExact(playerName);
+                        if (player != null) {
+                            offlinePlayer = player;
+                        } else {
+                            offlinePlayer = Bukkit.getOfflinePlayer(playerName);
+                        }
+                        Team team = mainScoreboard.getPlayerTeam(offlinePlayer);
+                        if (team != null) {
+                            team.removePlayer(offlinePlayer);
+                            left.add(offlinePlayer.getName());
+                        } else {
+                            noTeam.add(offlinePlayer.getName());
+                        }
+                    }
+                }
+                if (!left.isEmpty()) {
+                    sender.sendMessage("Removed " + left.size() + " player(s) from their teams: " + stringCollectionToString(left));
+                }
+                if (!noTeam.isEmpty()) {
+                    sender.sendMessage("Could not remove " + noTeam.size() + " player(s) from their teams: " + stringCollectionToString(noTeam));
+                }
+            } else if (args[1].equalsIgnoreCase("option")) {
+                if (args.length != 4 && args.length != 5) {
+                    sender.sendMessage(ChatColor.RED + "/scoreboard teams option <team> <friendlyfire|color|seefriendlyinvisibles> <value>");
+                    return false;
+                }
+                String teamName = args[2];
+                Team team = mainScoreboard.getTeam(teamName);
+                if (team == null) {
+                    sender.sendMessage(ChatColor.RED + "No team was found by the name '" + teamName + "'");
+                    return false;
+                }
+                String option = args[3].toLowerCase();
+                if (!option.equals("friendlyfire") && !option.equals("color") && !option.equals("seefriendlyinvisibles")) {
+                    sender.sendMessage(ChatColor.RED + "/scoreboard teams option <team> <friendlyfire|color|seefriendlyinvisibles> <value>");
+                    return false;
+                }
+                if (args.length == 4) {
+                    if (option.equals("color")) {
+                        sender.sendMessage(ChatColor.RED + "Valid values for option color are: " + stringCollectionToString(TEAMS_OPTION_COLOR.keySet()));
+                    } else {
+                        sender.sendMessage(ChatColor.RED + "Valid values for option " + option + " are: true and false");
+                    }
+                } else {
+                    String value = args[4].toLowerCase();
+                    if (option.equals("color")) {
+                        ChatColor color = TEAMS_OPTION_COLOR.get(value);
+                        if (color == null) {
+                            sender.sendMessage(ChatColor.RED + "Valid values for option color are: " + stringCollectionToString(TEAMS_OPTION_COLOR.keySet()));
+                            return false;
+                        }
+                        team.setPrefix(color.toString());
+                        team.setSuffix(ChatColor.RESET.toString());
+                    } else {
+                        if (!value.equals("true") && !value.equals("false")) {
+                            sender.sendMessage(ChatColor.RED + "Valid values for option " + option + " are: true and false");
+                            return false;
+                        }
+                        if (option.equals("friendlyfire")) {
+                            team.setAllowFriendlyFire(value.equals("true"));
+                        } else {
+                            team.setCanSeeFriendlyInvisibles(value.equals("true"));
+                        }
+                    }
+                    sender.sendMessage("Set option " + option + " for team " + team.getName() + " to " + value);
+                }
+            }
+        } else {
+            sender.sendMessage(ChatColor.RED + "Usage: /scoreboard <objectives|players|teams>");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public List<String> tabComplete(CommandSender sender, String alias, String[] args) throws IllegalArgumentException {
+        Validate.notNull(sender, "Sender cannot be null");
+        Validate.notNull(args, "Arguments cannot be null");
+        Validate.notNull(alias, "Alias cannot be null");
+
+        if (args.length == 1) {
+            return StringUtil.copyPartialMatches(args[0], MAIN_CHOICES, new ArrayList<String>());
+        }
+        if (args.length > 1) {
+            if (args[0].equalsIgnoreCase("objectives")) {
+                if (args.length == 2) {
+                    return StringUtil.copyPartialMatches(args[1], OBJECTIVES_CHOICES, new ArrayList<String>());
+                }
+                if (args[1].equalsIgnoreCase("add")) {
+                    if (args.length == 4) {
+                        return StringUtil.copyPartialMatches(args[3], OBJECTIVES_CRITERIA, new ArrayList<String>());
+                    }
+                } else if (args[1].equalsIgnoreCase("remove")) {
+                    if (args.length == 3) {
+                        return StringUtil.copyPartialMatches(args[2], this.getCurrentObjectives(), new ArrayList<String>());
+                    }
+                } else if (args[1].equalsIgnoreCase("setdisplay")) {
+                    if (args.length == 3) {
+                        return StringUtil.copyPartialMatches(args[2], OBJECTIVES_DISPLAYSLOT.keySet(), new ArrayList<String>());
+                    }
+                    if (args.length == 4) {
+                        return StringUtil.copyPartialMatches(args[3], this.getCurrentObjectives(), new ArrayList<String>());
+                    }
+                }
+            } else if (args[0].equalsIgnoreCase("players")) {
+                if (args.length == 2) {
+                    return StringUtil.copyPartialMatches(args[1], PLAYERS_CHOICES, new ArrayList<String>());
+                }
+                if (args[1].equalsIgnoreCase("set") || args[1].equalsIgnoreCase("add") || args[1].equalsIgnoreCase("remove")) {
+                    if (args.length == 3) {
+                        return super.tabComplete(sender, alias, args);
+                    }
+                    if (args.length == 4) {
+                        return StringUtil.copyPartialMatches(args[3], this.getCurrentObjectives(), new ArrayList<String>());
+                    }
+                } else {
+                    if (args.length == 3) {
+                        return StringUtil.copyPartialMatches(args[2], this.getCurrentPlayers(), new ArrayList<String>());
+                    }
+                }
+            } else if (args[0].equalsIgnoreCase("teams")) {
+                if (args.length == 2) {
+                    return StringUtil.copyPartialMatches(args[1], TEAMS_CHOICES, new ArrayList<String>());
+                }
+                if (args[1].equalsIgnoreCase("join")) {
+                    if (args.length == 3) {
+                        return StringUtil.copyPartialMatches(args[2], this.getCurrentTeams(), new ArrayList<String>());
+                    }
+                    if (args.length >= 4) {
+                        return super.tabComplete(sender, alias, args);
+                    }
+                } else if (args[1].equalsIgnoreCase("leave")) {
+                    return super.tabComplete(sender, alias, args);
+                } else if (args[1].equalsIgnoreCase("option")) {
+                    if (args.length == 3) {
+                        return StringUtil.copyPartialMatches(args[2], this.getCurrentTeams(), new ArrayList<String>());
+                    }
+                    if (args.length == 4) {
+                        return StringUtil.copyPartialMatches(args[3], TEAMS_OPTION_CHOICES, new ArrayList<String>());
+                    }
+                    if (args.length == 5) {
+                        if (args[3].equalsIgnoreCase("color")) {
+                            return StringUtil.copyPartialMatches(args[4], TEAMS_OPTION_COLOR.keySet(), new ArrayList<String>());
+                        } else {
+                            return StringUtil.copyPartialMatches(args[4], BOOLEAN, new ArrayList<String>());
+                        }
+                    }
+                } else {
+                    if (args.length == 3) {
+                        return StringUtil.copyPartialMatches(args[2], this.getCurrentTeams(), new ArrayList<String>());
+                    }
+                }
+            }
+        }
+
+        return ImmutableList.of();
+    }
+
+    private static String offlinePlayerSetToString(Set<OfflinePlayer> set) {
+        StringBuilder string = new StringBuilder();
+        String lastValue = null;
+        for (OfflinePlayer value : set) {
+            string.append(lastValue = value.getName()).append(", ");
+        }
+        string.delete(string.length() - 2, Integer.MAX_VALUE);
+        if (string.length() != lastValue.length()) {
+            string.insert(string.length() - lastValue.length(), "and ");
+        }
+        return string.toString();
+
+    }
+
+    private static String stringCollectionToString(Collection<String> set) {
+        StringBuilder string = new StringBuilder();
+        String lastValue = null;
+        for (String value : set) {
+            string.append(lastValue = value).append(", ");
+        }
+        string.delete(string.length() - 2, Integer.MAX_VALUE);
+        if (string.length() != lastValue.length()) {
+            string.insert(string.length() - lastValue.length(), "and ");
+        }
+        return string.toString();
+    }
+
+    private List<String> getCurrentObjectives() {
+        List<String> list = new ArrayList<String>();
+        for (Objective objective : Bukkit.getScoreboardManager().getMainScoreboard().getObjectives()) {
+            list.add(objective.getName());
+        }
+        Collections.sort(list, String.CASE_INSENSITIVE_ORDER);
+        return list;
+    }
+
+    private List<String> getCurrentPlayers() {
+        List<String> list = new ArrayList<String>();
+        for (OfflinePlayer player : Bukkit.getScoreboardManager().getMainScoreboard().getPlayers()) {
+            list.add(player.getName());
+        }
+        Collections.sort(list, String.CASE_INSENSITIVE_ORDER);
+        return list;
+    }
+
+    private List<String> getCurrentTeams() {
+        List<String> list = new ArrayList<String>();
+        for (Team team : Bukkit.getScoreboardManager().getMainScoreboard().getTeams()) {
+            list.add(team.getName());
+        }
+        Collections.sort(list, String.CASE_INSENSITIVE_ORDER);
+        return list;
+    }
+}

--- a/src/main/java/org/bukkit/command/defaults/ScoreboardCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/ScoreboardCommand.java
@@ -400,7 +400,7 @@ public class ScoreboardCommand extends VanillaCommand {
                         noTeam.add(sender.getName());
                     }
                 } else {
-                    for (int i = 3; i < args.length; i++) {
+                    for (int i = 2; i < args.length; i++) {
                         String playerName = args[i];
                         OfflinePlayer offlinePlayer;
                         Player player = Bukkit.getPlayerExact(playerName);

--- a/src/main/java/org/bukkit/command/defaults/ScoreboardCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/ScoreboardCommand.java
@@ -382,17 +382,7 @@ public class ScoreboardCommand extends VanillaCommand {
                             addedPlayers.add(offlinePlayer.getName());
                         }
                     }
-                    String[] playerArray = addedPlayers.toArray(new String[0]);
-                    StringBuilder builder = new StringBuilder();
-                    for (int x = 0; x < playerArray.length; x++) {
-                        if (x == playerArray.length - 1) {
-                            builder.append(" and ");
-                        } else if (x > 0) {
-                            builder.append(", ");
-                        }
-                        builder.append(playerArray[x]);
-                    }
-                    sender.sendMessage("Added " + addedPlayers.size() + " player(s) to team " + team.getName() + ": " + builder.toString());
+                    sender.sendMessage("Added " + addedPlayers.size() + " player(s) to team " + team.getName() + ": " + stringCollectionToString(addedPlayers));
                 }
             } else if (args[1].equalsIgnoreCase("leave")) {
                 if ((sender instanceof Player) ? args.length < 2 : args.length < 3) {

--- a/src/main/java/org/bukkit/configuration/Configuration.java
+++ b/src/main/java/org/bukkit/configuration/Configuration.java
@@ -8,11 +8,11 @@ import java.util.Map;
 public interface Configuration extends ConfigurationSection {
     /**
      * Sets the default value of the given path as provided.
-     * <p />
+     * <p>
      * If no source {@link Configuration} was provided as a default collection,
      * then a new {@link MemoryConfiguration} will be created to hold the new default
      * value.
-     * <p />
+     * <p>
      * If value is null, the value will be removed from the default Configuration source.
      *
      * @param path Path of the value to set.
@@ -23,7 +23,7 @@ public interface Configuration extends ConfigurationSection {
 
     /**
      * Sets the default values of the given paths as provided.
-     * <p />
+     * <p>
      * If no source {@link Configuration} was provided as a default collection,
      * then a new {@link MemoryConfiguration} will be created to hold the new default
      * values.
@@ -35,11 +35,11 @@ public interface Configuration extends ConfigurationSection {
 
     /**
      * Sets the default values of the given paths as provided.
-     * <p />
+     * <p>
      * If no source {@link Configuration} was provided as a default collection,
      * then a new {@link MemoryConfiguration} will be created to hold the new default
      * value.
-     * <p />
+     * <p>
      * This method will not hold a reference to the specified Configuration, nor will it
      * automatically update if that Configuration ever changes. If you require this,
      * you should set the default source with {@link #setDefaults(org.bukkit.configuration.Configuration)}.
@@ -51,7 +51,7 @@ public interface Configuration extends ConfigurationSection {
 
     /**
      * Sets the source of all default values for this {@link Configuration}.
-     * <p />
+     * <p>
      * If a previous source was set, or previous default values were defined, then they will
      * not be copied to the new source.
      *
@@ -62,7 +62,7 @@ public interface Configuration extends ConfigurationSection {
 
     /**
      * Gets the source {@link Configuration} for this configuration.
-     * <p />
+     * <p>
      * If no configuration source was set, but default values were added, then a
      * {@link MemoryConfiguration} will be returned. If no source was set and no
      * defaults were set, then this method will return null.
@@ -73,7 +73,7 @@ public interface Configuration extends ConfigurationSection {
 
     /**
      * Gets the {@link ConfigurationOptions} for this {@link Configuration}.
-     * <p />
+     * <p>
      * All setters through this method are chainable.
      *
      * @return Options for this configuration

--- a/src/main/java/org/bukkit/configuration/ConfigurationOptions.java
+++ b/src/main/java/org/bukkit/configuration/ConfigurationOptions.java
@@ -23,7 +23,7 @@ public class ConfigurationOptions {
 
     /**
      * Gets the char that will be used to separate {@link ConfigurationSection}s
-     * <p />
+     * <p>
      * This value does not affect how the {@link Configuration} is stored, only in
      * how you access the data. The default value is '.'.
      *
@@ -35,7 +35,7 @@ public class ConfigurationOptions {
 
     /**
      * Sets the char that will be used to separate {@link ConfigurationSection}s
-     * <p />
+     * <p>
      * This value does not affect how the {@link Configuration} is stored, only in
      * how you access the data. The default value is '.'.
      *
@@ -49,7 +49,7 @@ public class ConfigurationOptions {
 
     /**
      * Checks if the {@link Configuration} should copy values from its default {@link Configuration} directly.
-     * <p />
+     * <p>
      * If this is true, all values in the default Configuration will be directly copied,
      * making it impossible to distinguish between values that were set and values that
      * are provided by default. As a result, {@link ConfigurationSection#contains(java.lang.String)} will always
@@ -64,7 +64,7 @@ public class ConfigurationOptions {
 
     /**
      * Sets if the {@link Configuration} should copy values from its default {@link Configuration} directly.
-     * <p />
+     * <p>
      * If this is true, all values in the default Configuration will be directly copied,
      * making it impossible to distinguish between values that were set and values that
      * are provided by default. As a result, {@link ConfigurationSection#contains(java.lang.String)} will always

--- a/src/main/java/org/bukkit/configuration/ConfigurationSection.java
+++ b/src/main/java/org/bukkit/configuration/ConfigurationSection.java
@@ -15,11 +15,11 @@ import org.bukkit.inventory.ItemStack;
 public interface ConfigurationSection {
     /**
      * Gets a set containing all keys in this section.
-     * <p />
+     * <p>
      * If deep is set to true, then this will contain all the keys within any child
      * {@link ConfigurationSection}s (and their children, etc). These will be in a
      * valid path notation for you to use.
-     * <p />
+     * <p>
      * If deep is set to false, then this will contain only the keys of any direct children,
      * and not their own children.
      *
@@ -30,11 +30,11 @@ public interface ConfigurationSection {
 
     /**
      * Gets a Map containing all keys and their values for this section.
-     * <p />
+     * <p>
      * If deep is set to true, then this will contain all the keys and values within
      * any child {@link ConfigurationSection}s (and their children, etc). These
      * keys will be in a valid path notation for you to use.
-     * <p />
+     * <p>
      * If deep is set to false, then this will contain only the keys and values of any
      * direct children, and not their own children.
      *
@@ -45,7 +45,7 @@ public interface ConfigurationSection {
 
     /**
      * Checks if this {@link ConfigurationSection} contains the given path.
-     * <p />
+     * <p>
      * If the value for the requested path does not exist but a default value has
      * been specified, this will return true.
      *
@@ -57,7 +57,7 @@ public interface ConfigurationSection {
 
     /**
      * Checks if this {@link ConfigurationSection} has a value set for the given path.
-     * <p />
+     * <p>
      * If the value for the requested path does not exist but a default value has
      * been specified, this will still return false.
      *
@@ -69,12 +69,12 @@ public interface ConfigurationSection {
 
     /**
      * Gets the path of this {@link ConfigurationSection} from its root {@link Configuration}
-     * <p />
+     * <p>
      * For any {@link Configuration} themselves, this will return an empty string.
-     * <p />
+     * <p>
      * If the section is no longer contained within its root for any reason, such as
      * being replaced with a different value, this may return null.
-     * <p />
+     * <p>
      * To retrieve the single name of this section, that is, the final part of the path
      * returned by this method, you may use {@link #getName()}.
      *
@@ -84,7 +84,7 @@ public interface ConfigurationSection {
 
     /**
      * Gets the name of this individual {@link ConfigurationSection}, in the path.
-     * <p />
+     * <p>
      * This will always be the final part of {@link #getCurrentPath()}, unless the
      * section is orphaned.
      *
@@ -94,9 +94,9 @@ public interface ConfigurationSection {
 
     /**
      * Gets the root {@link Configuration} that contains this {@link ConfigurationSection}
-     * <p />
+     * <p>
      * For any {@link Configuration} themselves, this will return its own object.
-     * <p />
+     * <p>
      * If the section is no longer contained within its root for any reason, such as
      * being replaced with a different value, this may return null.
      *
@@ -107,9 +107,9 @@ public interface ConfigurationSection {
     /**
      * Gets the parent {@link ConfigurationSection} that directly contains this
      * {@link ConfigurationSection}.
-     * <p />
+     * <p>
      * For any {@link Configuration} themselves, this will return null.
-     * <p />
+     * <p>
      * If the section is no longer contained within its parent for any reason, such as
      * being replaced with a different value, this may return null.
      *
@@ -119,7 +119,7 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested Object by path.
-     * <p />
+     * <p>
      * If the Object does not exist but a default value has been specified, this
      * will return the default value. If the Object does not exist and no default
      * value was specified, this will return null.
@@ -131,7 +131,7 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested Object by path, returning a default value if not found.
-     * <p />
+     * <p>
      * If the Object does not exist then the specified default value will returned
      * regardless of if a default has been identified in the root {@link Configuration}.
      *
@@ -143,10 +143,10 @@ public interface ConfigurationSection {
 
     /**
      * Sets the specified path to the given value.
-     * <p />
+     * <p>
      * If value is null, the entry will be removed. Any existing entry will be
      * replaced, regardless of what the new value is.
-     * <p />
+     * <p>
      * Some implementations may have limitations on what you may store. See their
      * individual javadocs for details. No implementations should allow you to store
      * {@link Configuration}s or {@link ConfigurationSection}s, please use
@@ -159,7 +159,7 @@ public interface ConfigurationSection {
 
     /**
      * Creates an empty {@link ConfigurationSection} at the specified path.
-     * <p />
+     * <p>
      * Any value that was previously set at this path will be overwritten. If the
      * previous value was itself a {@link ConfigurationSection}, it will be orphaned.
      *
@@ -170,7 +170,7 @@ public interface ConfigurationSection {
 
     /**
      * Creates a {@link ConfigurationSection} at the specified path, with specified values.
-     * <p />
+     * <p>
      * Any value that was previously set at this path will be overwritten. If the
      * previous value was itself a {@link ConfigurationSection}, it will be orphaned.
      *
@@ -183,7 +183,7 @@ public interface ConfigurationSection {
     // Primitives
     /**
      * Gets the requested String by path.
-     * <p />
+     * <p>
      * If the String does not exist but a default value has been specified, this
      * will return the default value. If the String does not exist and no default
      * value was specified, this will return null.
@@ -195,7 +195,7 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested String by path, returning a default value if not found.
-     * <p />
+     * <p>
      * If the String does not exist then the specified default value will returned
      * regardless of if a default has been identified in the root {@link Configuration}.
      *
@@ -207,7 +207,7 @@ public interface ConfigurationSection {
 
     /**
      * Checks if the specified path is a String.
-     * <p />
+     * <p>
      * If the path exists but is not a String, this will return false. If the path does not
      * exist, this will return false. If the path does not exist but a default value
      * has been specified, this will check if that default value is a String and return
@@ -220,7 +220,7 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested int by path.
-     * <p />
+     * <p>
      * If the int does not exist but a default value has been specified, this
      * will return the default value. If the int does not exist and no default
      * value was specified, this will return 0.
@@ -232,7 +232,7 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested int by path, returning a default value if not found.
-     * <p />
+     * <p>
      * If the int does not exist then the specified default value will returned
      * regardless of if a default has been identified in the root {@link Configuration}.
      *
@@ -244,7 +244,7 @@ public interface ConfigurationSection {
 
     /**
      * Checks if the specified path is an int.
-     * <p />
+     * <p>
      * If the path exists but is not a int, this will return false. If the path does not
      * exist, this will return false. If the path does not exist but a default value
      * has been specified, this will check if that default value is a int and return
@@ -257,7 +257,7 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested boolean by path.
-     * <p />
+     * <p>
      * If the boolean does not exist but a default value has been specified, this
      * will return the default value. If the boolean does not exist and no default
      * value was specified, this will return false.
@@ -269,7 +269,7 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested boolean by path, returning a default value if not found.
-     * <p />
+     * <p>
      * If the boolean does not exist then the specified default value will returned
      * regardless of if a default has been identified in the root {@link Configuration}.
      *
@@ -281,7 +281,7 @@ public interface ConfigurationSection {
 
     /**
      * Checks if the specified path is a boolean.
-     * <p />
+     * <p>
      * If the path exists but is not a boolean, this will return false. If the path does not
      * exist, this will return false. If the path does not exist but a default value
      * has been specified, this will check if that default value is a boolean and return
@@ -294,7 +294,7 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested double by path.
-     * <p />
+     * <p>
      * If the double does not exist but a default value has been specified, this
      * will return the default value. If the double does not exist and no default
      * value was specified, this will return 0.
@@ -306,7 +306,7 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested double by path, returning a default value if not found.
-     * <p />
+     * <p>
      * If the double does not exist then the specified default value will returned
      * regardless of if a default has been identified in the root {@link Configuration}.
      *
@@ -318,7 +318,7 @@ public interface ConfigurationSection {
 
     /**
      * Checks if the specified path is a double.
-     * <p />
+     * <p>
      * If the path exists but is not a double, this will return false. If the path does not
      * exist, this will return false. If the path does not exist but a default value
      * has been specified, this will check if that default value is a double and return
@@ -331,7 +331,7 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested long by path.
-     * <p />
+     * <p>
      * If the long does not exist but a default value has been specified, this
      * will return the default value. If the long does not exist and no default
      * value was specified, this will return 0.
@@ -343,7 +343,7 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested long by path, returning a default value if not found.
-     * <p />
+     * <p>
      * If the long does not exist then the specified default value will returned
      * regardless of if a default has been identified in the root {@link Configuration}.
      *
@@ -355,7 +355,7 @@ public interface ConfigurationSection {
 
     /**
      * Checks if the specified path is a long.
-     * <p />
+     * <p>
      * If the path exists but is not a long, this will return false. If the path does not
      * exist, this will return false. If the path does not exist but a default value
      * has been specified, this will check if that default value is a long and return
@@ -369,7 +369,7 @@ public interface ConfigurationSection {
     // Java
     /**
      * Gets the requested List by path.
-     * <p />
+     * <p>
      * If the List does not exist but a default value has been specified, this
      * will return the default value. If the List does not exist and no default
      * value was specified, this will return null.
@@ -381,7 +381,7 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested List by path, returning a default value if not found.
-     * <p />
+     * <p>
      * If the List does not exist then the specified default value will returned
      * regardless of if a default has been identified in the root {@link Configuration}.
      *
@@ -393,7 +393,7 @@ public interface ConfigurationSection {
 
     /**
      * Checks if the specified path is a List.
-     * <p />
+     * <p>
      * If the path exists but is not a List, this will return false. If the path does not
      * exist, this will return false. If the path does not exist but a default value
      * has been specified, this will check if that default value is a List and return
@@ -406,11 +406,11 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested List of String by path.
-     * <p />
+     * <p>
      * If the List does not exist but a default value has been specified, this
      * will return the default value. If the List does not exist and no default
      * value was specified, this will return an empty List.
-     * <p />
+     * <p>
      * This method will attempt to cast any values into a String if possible, but may
      * miss any values out if they are not compatible.
      *
@@ -421,11 +421,11 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested List of Integer by path.
-     * <p />
+     * <p>
      * If the List does not exist but a default value has been specified, this
      * will return the default value. If the List does not exist and no default
      * value was specified, this will return an empty List.
-     * <p />
+     * <p>
      * This method will attempt to cast any values into a Integer if possible, but may
      * miss any values out if they are not compatible.
      *
@@ -436,11 +436,11 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested List of Boolean by path.
-     * <p />
+     * <p>
      * If the List does not exist but a default value has been specified, this
      * will return the default value. If the List does not exist and no default
      * value was specified, this will return an empty List.
-     * <p />
+     * <p>
      * This method will attempt to cast any values into a Boolean if possible, but may
      * miss any values out if they are not compatible.
      *
@@ -451,11 +451,11 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested List of Double by path.
-     * <p />
+     * <p>
      * If the List does not exist but a default value has been specified, this
      * will return the default value. If the List does not exist and no default
      * value was specified, this will return an empty List.
-     * <p />
+     * <p>
      * This method will attempt to cast any values into a Double if possible, but may
      * miss any values out if they are not compatible.
      *
@@ -466,11 +466,11 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested List of Float by path.
-     * <p />
+     * <p>
      * If the List does not exist but a default value has been specified, this
      * will return the default value. If the List does not exist and no default
      * value was specified, this will return an empty List.
-     * <p />
+     * <p>
      * This method will attempt to cast any values into a Float if possible, but may
      * miss any values out if they are not compatible.
      *
@@ -481,11 +481,11 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested List of Long by path.
-     * <p />
+     * <p>
      * If the List does not exist but a default value has been specified, this
      * will return the default value. If the List does not exist and no default
      * value was specified, this will return an empty List.
-     * <p />
+     * <p>
      * This method will attempt to cast any values into a Long if possible, but may
      * miss any values out if they are not compatible.
      *
@@ -496,11 +496,11 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested List of Byte by path.
-     * <p />
+     * <p>
      * If the List does not exist but a default value has been specified, this
      * will return the default value. If the List does not exist and no default
      * value was specified, this will return an empty List.
-     * <p />
+     * <p>
      * This method will attempt to cast any values into a Byte if possible, but may
      * miss any values out if they are not compatible.
      *
@@ -511,11 +511,11 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested List of Character by path.
-     * <p />
+     * <p>
      * If the List does not exist but a default value has been specified, this
      * will return the default value. If the List does not exist and no default
      * value was specified, this will return an empty List.
-     * <p />
+     * <p>
      * This method will attempt to cast any values into a Character if possible, but may
      * miss any values out if they are not compatible.
      *
@@ -526,11 +526,11 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested List of Short by path.
-     * <p />
+     * <p>
      * If the List does not exist but a default value has been specified, this
      * will return the default value. If the List does not exist and no default
      * value was specified, this will return an empty List.
-     * <p />
+     * <p>
      * This method will attempt to cast any values into a Short if possible, but may
      * miss any values out if they are not compatible.
      *
@@ -541,11 +541,11 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested List of Maps by path.
-     * <p />
+     * <p>
      * If the List does not exist but a default value has been specified, this
      * will return the default value. If the List does not exist and no default
      * value was specified, this will return an empty List.
-     * <p />
+     * <p>
      * This method will attempt to cast any values into a Map if possible, but may
      * miss any values out if they are not compatible.
      *
@@ -557,7 +557,7 @@ public interface ConfigurationSection {
     // Bukkit
     /**
      * Gets the requested Vector by path.
-     * <p />
+     * <p>
      * If the Vector does not exist but a default value has been specified, this
      * will return the default value. If the Vector does not exist and no default
      * value was specified, this will return null.
@@ -569,7 +569,7 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested {@link Vector} by path, returning a default value if not found.
-     * <p />
+     * <p>
      * If the Vector does not exist then the specified default value will returned
      * regardless of if a default has been identified in the root {@link Configuration}.
      *
@@ -581,7 +581,7 @@ public interface ConfigurationSection {
 
     /**
      * Checks if the specified path is a Vector.
-     * <p />
+     * <p>
      * If the path exists but is not a Vector, this will return false. If the path does not
      * exist, this will return false. If the path does not exist but a default value
      * has been specified, this will check if that default value is a Vector and return
@@ -594,7 +594,7 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested OfflinePlayer by path.
-     * <p />
+     * <p>
      * If the OfflinePlayer does not exist but a default value has been specified, this
      * will return the default value. If the OfflinePlayer does not exist and no default
      * value was specified, this will return null.
@@ -606,7 +606,7 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested {@link OfflinePlayer} by path, returning a default value if not found.
-     * <p />
+     * <p>
      * If the OfflinePlayer does not exist then the specified default value will returned
      * regardless of if a default has been identified in the root {@link Configuration}.
      *
@@ -618,7 +618,7 @@ public interface ConfigurationSection {
 
     /**
      * Checks if the specified path is an OfflinePlayer.
-     * <p />
+     * <p>
      * If the path exists but is not a OfflinePlayer, this will return false. If the path does not
      * exist, this will return false. If the path does not exist but a default value
      * has been specified, this will check if that default value is a OfflinePlayer and return
@@ -631,7 +631,7 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested ItemStack by path.
-     * <p />
+     * <p>
      * If the ItemStack does not exist but a default value has been specified, this
      * will return the default value. If the ItemStack does not exist and no default
      * value was specified, this will return null.
@@ -643,7 +643,7 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested {@link ItemStack} by path, returning a default value if not found.
-     * <p />
+     * <p>
      * If the ItemStack does not exist then the specified default value will returned
      * regardless of if a default has been identified in the root {@link Configuration}.
      *
@@ -655,7 +655,7 @@ public interface ConfigurationSection {
 
     /**
      * Checks if the specified path is an ItemStack.
-     * <p />
+     * <p>
      * If the path exists but is not a ItemStack, this will return false. If the path does not
      * exist, this will return false. If the path does not exist but a default value
      * has been specified, this will check if that default value is a ItemStack and return
@@ -668,7 +668,7 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested Color by path.
-     * <p />
+     * <p>
      * If the Color does not exist but a default value has been specified, this
      * will return the default value. If the Color does not exist and no default
      * value was specified, this will return null.
@@ -680,7 +680,7 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested {@link Color} by path, returning a default value if not found.
-     * <p />
+     * <p>
      * If the Color does not exist then the specified default value will returned
      * regardless of if a default has been identified in the root {@link Configuration}.
      *
@@ -692,7 +692,7 @@ public interface ConfigurationSection {
 
     /**
      * Checks if the specified path is a Color.
-     * <p />
+     * <p>
      * If the path exists but is not a Color, this will return false. If the path does not
      * exist, this will return false. If the path does not exist but a default value
      * has been specified, this will check if that default value is a Color and return
@@ -705,7 +705,7 @@ public interface ConfigurationSection {
 
     /**
      * Gets the requested ConfigurationSection by path.
-     * <p />
+     * <p>
      * If the ConfigurationSection does not exist but a default value has been specified, this
      * will return the default value. If the ConfigurationSection does not exist and no default
      * value was specified, this will return null.
@@ -717,7 +717,7 @@ public interface ConfigurationSection {
 
     /**
      * Checks if the specified path is a ConfigurationSection.
-     * <p />
+     * <p>
      * If the path exists but is not a ConfigurationSection, this will return false. If the path does not
      * exist, this will return false. If the path does not exist but a default value
      * has been specified, this will check if that default value is a ConfigurationSection and return
@@ -730,7 +730,7 @@ public interface ConfigurationSection {
 
     /**
      * Gets the equivalent {@link ConfigurationSection} from the default {@link Configuration} defined in {@link #getRoot()}.
-     * <p />
+     * <p>
      * If the root contains no defaults, or the defaults doesn't contain a value
      * for this path, or the value at this path is not a {@link ConfigurationSection} then
      * this will return null.
@@ -741,13 +741,13 @@ public interface ConfigurationSection {
 
     /**
      * Sets the default value in the root at the given path as provided.
-     * <p />
+     * <p>
      * If no source {@link Configuration} was provided as a default collection,
      * then a new {@link MemoryConfiguration} will be created to hold the new default
      * value.
-     * <p />
+     * <p>
      * If value is null, the value will be removed from the default Configuration source.
-     * <p />
+     * <p>
      * If the value as returned by {@link #getDefaultSection()} is null,
      * then this will create a new section at the path, replacing anything that
      * may have existed there previously.

--- a/src/main/java/org/bukkit/configuration/MemorySection.java
+++ b/src/main/java/org/bukkit/configuration/MemorySection.java
@@ -27,7 +27,7 @@ public class MemorySection implements ConfigurationSection {
 
     /**
      * Creates an empty MemorySection for use as a root {@link Configuration} section.
-     * <p />
+     * <p>
      * Note that calling this without being yourself a {@link Configuration} will throw an
      * exception!
      *
@@ -746,7 +746,7 @@ public class MemorySection implements ConfigurationSection {
 
     /**
      * Creates a full path to the given {@link ConfigurationSection} from its root {@link Configuration}.
-     * <p />
+     * <p>
      * You may use this method for any given {@link ConfigurationSection}, not only {@link MemorySection}.
      *
      * @param section Section to create a path for.
@@ -759,7 +759,7 @@ public class MemorySection implements ConfigurationSection {
 
     /**
      * Creates a relative path to the given {@link ConfigurationSection} from the given relative section.
-     * <p />
+     * <p>
      * You may use this method for any given {@link ConfigurationSection}, not only {@link MemorySection}.
      *
      * @param section Section to create a path for.

--- a/src/main/java/org/bukkit/configuration/file/FileConfiguration.java
+++ b/src/main/java/org/bukkit/configuration/file/FileConfiguration.java
@@ -38,7 +38,7 @@ public abstract class FileConfiguration extends MemoryConfiguration {
 
     /**
      * Saves this {@link FileConfiguration} to the specified location.
-     * <p />
+     * <p>
      * If the file does not exist, it will be created. If already exists, it will
      * be overwritten. If it cannot be overwritten or created, an exception will be thrown.
      *
@@ -64,7 +64,7 @@ public abstract class FileConfiguration extends MemoryConfiguration {
 
     /**
      * Saves this {@link FileConfiguration} to the specified location.
-     * <p />
+     * <p>
      * If the file does not exist, it will be created. If already exists, it will
      * be overwritten. If it cannot be overwritten or created, an exception will be thrown.
      *
@@ -87,10 +87,10 @@ public abstract class FileConfiguration extends MemoryConfiguration {
 
     /**
      * Loads this {@link FileConfiguration} from the specified location.
-     * <p />
+     * <p>
      * All the values contained within this configuration will be removed, leaving
      * only settings and defaults, and the new values will be loaded from the given file.
-     * <p />
+     * <p>
      * If the file cannot be loaded for any reason, an exception will be thrown.
      *
      * @param file File to load from.
@@ -107,7 +107,7 @@ public abstract class FileConfiguration extends MemoryConfiguration {
 
     /**
      * Loads this {@link FileConfiguration} from the specified stream.
-     * <p />
+     * <p>
      * All the values contained within this configuration will be removed, leaving
      * only settings and defaults, and the new values will be loaded from the given stream.
      *
@@ -140,10 +140,10 @@ public abstract class FileConfiguration extends MemoryConfiguration {
 
     /**
      * Loads this {@link FileConfiguration} from the specified location.
-     * <p />
+     * <p>
      * All the values contained within this configuration will be removed, leaving
      * only settings and defaults, and the new values will be loaded from the given file.
-     * <p />
+     * <p>
      * If the file cannot be loaded for any reason, an exception will be thrown.
      *
      * @param file File to load from.
@@ -160,10 +160,10 @@ public abstract class FileConfiguration extends MemoryConfiguration {
 
     /**
      * Loads this {@link FileConfiguration} from the specified string, as opposed to from file.
-     * <p />
+     * <p>
      * All the values contained within this configuration will be removed, leaving
      * only settings and defaults, and the new values will be loaded from the given string.
-     * <p />
+     * <p>
      * If the string is invalid in any way, an exception will be thrown.
      *
      * @param contents Contents of a Configuration to load.
@@ -174,7 +174,7 @@ public abstract class FileConfiguration extends MemoryConfiguration {
 
     /**
      * Compiles the header for this {@link FileConfiguration} and returns the result.
-     * <p />
+     * <p>
      * This will use the header from {@link #options()} -> {@link FileConfigurationOptions#header()},
      * respecting the rules of {@link FileConfigurationOptions#copyHeader()} if set.
      *

--- a/src/main/java/org/bukkit/configuration/file/FileConfigurationOptions.java
+++ b/src/main/java/org/bukkit/configuration/file/FileConfigurationOptions.java
@@ -32,12 +32,12 @@ public class FileConfigurationOptions extends MemoryConfigurationOptions {
 
     /**
      * Gets the header that will be applied to the top of the saved output.
-     * <p />
+     * <p>
      * This header will be commented out and applied directly at the top of the
      * generated output of the {@link FileConfiguration}. It is not required to
      * include a newline at the end of the header as it will automatically be applied,
      * but you may include one if you wish for extra spacing.
-     * <p />
+     * <p>
      * Null is a valid value which will indicate that no header is to be applied.
      * The default value is null.
      *
@@ -49,12 +49,12 @@ public class FileConfigurationOptions extends MemoryConfigurationOptions {
 
     /**
      * Sets the header that will be applied to the top of the saved output.
-     * <p />
+     * <p>
      * This header will be commented out and applied directly at the top of the
      * generated output of the {@link FileConfiguration}. It is not required to
      * include a newline at the end of the header as it will automatically be applied,
      * but you may include one if you wish for extra spacing.
-     * <p />
+     * <p>
      * Null is a valid value which will indicate that no header is to be applied.
      *
      * @param value New header
@@ -67,15 +67,15 @@ public class FileConfigurationOptions extends MemoryConfigurationOptions {
 
     /**
      * Gets whether or not the header should be copied from a default source.
-     * <p />
+     * <p>
      * If this is true, if a default {@link FileConfiguration} is passed to
      * {@link FileConfiguration#setDefaults(org.bukkit.configuration.Configuration)}
      * then upon saving it will use the header from that config, instead of the one provided here.
-     * <p />
+     * <p>
      * If no default is set on the configuration, or the default is not of type FileConfiguration,
      * or that config has no header ({@link #header()} returns null) then the header
      * specified in this configuration will be used.
-     * <p />
+     * <p>
      * Defaults to true.
      *
      * @return Whether or not to copy the header
@@ -86,15 +86,15 @@ public class FileConfigurationOptions extends MemoryConfigurationOptions {
 
     /**
      * Sets whether or not the header should be copied from a default source.
-     * <p />
+     * <p>
      * If this is true, if a default {@link FileConfiguration} is passed to
      * {@link FileConfiguration#setDefaults(org.bukkit.configuration.Configuration)}
      * then upon saving it will use the header from that config, instead of the one provided here.
-     * <p />
+     * <p>
      * If no default is set on the configuration, or the default is not of type FileConfiguration,
      * or that config has no header ({@link #header()} returns null) then the header
      * specified in this configuration will be used.
-     * <p />
+     * <p>
      * Defaults to true.
      *
      * @param value Whether or not to copy the header

--- a/src/main/java/org/bukkit/configuration/file/YamlConfiguration.java
+++ b/src/main/java/org/bukkit/configuration/file/YamlConfiguration.java
@@ -158,7 +158,7 @@ public class YamlConfiguration extends FileConfiguration {
 
     /**
      * Creates a new {@link YamlConfiguration}, loading from the given file.
-     * <p />
+     * <p>
      * Any errors loading the Configuration will be logged and then ignored.
      * If the specified input is not a valid config, a blank config will be returned.
      *
@@ -185,7 +185,7 @@ public class YamlConfiguration extends FileConfiguration {
 
     /**
      * Creates a new {@link YamlConfiguration}, loading from the given stream.
-     * <p />
+     * <p>
      * Any errors loading the Configuration will be logged and then ignored.
      * If the specified input is not a valid config, a blank config will be returned.
      *

--- a/src/main/java/org/bukkit/configuration/file/YamlConfigurationOptions.java
+++ b/src/main/java/org/bukkit/configuration/file/YamlConfigurationOptions.java
@@ -43,7 +43,7 @@ public class YamlConfigurationOptions extends FileConfigurationOptions {
 
     /**
      * Gets how much spaces should be used to indent each line.
-     * <p />
+     * <p>
      * The minimum value this may be is 2, and the maximum is 9.
      *
      * @return How much to indent by
@@ -54,7 +54,7 @@ public class YamlConfigurationOptions extends FileConfigurationOptions {
 
     /**
      * Sets how much spaces should be used to indent each line.
-     * <p />
+     * <p>
      * The minimum value this may be is 2, and the maximum is 9.
      *
      * @param value New indent

--- a/src/main/java/org/bukkit/configuration/serialization/ConfigurationSerializable.java
+++ b/src/main/java/org/bukkit/configuration/serialization/ConfigurationSerializable.java
@@ -4,7 +4,7 @@ import java.util.Map;
 
 /**
  * Represents an object that may be serialized.
- * <p />
+ * <p>
  * These objects MUST implement one of the following, in addition to the methods
  * as defined by this interface:
  * <ul>
@@ -22,7 +22,7 @@ import java.util.Map;
 public interface ConfigurationSerializable {
     /**
      * Creates a Map representation of this class.
-     * <p />
+     * <p>
      * This class must provide a method to restore this class, as defined in the
      * {@link ConfigurationSerializable} interface javadocs.
      *

--- a/src/main/java/org/bukkit/configuration/serialization/ConfigurationSerialization.java
+++ b/src/main/java/org/bukkit/configuration/serialization/ConfigurationSerialization.java
@@ -135,10 +135,10 @@ public class ConfigurationSerialization {
 
     /**
      * Attempts to deserialize the given arguments into a new instance of the given class.
-     * <p />
+     * <p>
      * The class must implement {@link ConfigurationSerializable}, including the extra methods
      * as specified in the javadoc of ConfigurationSerializable.
-     * <p />
+     * <p>
      * If a new instance could not be made, an example being the class not fully implementing
      * the interface, null will be returned.
      *
@@ -152,10 +152,10 @@ public class ConfigurationSerialization {
 
     /**
      * Attempts to deserialize the given arguments into a new instance of the given class.
-     * <p />
+     * <p>
      * The class must implement {@link ConfigurationSerializable}, including the extra methods
      * as specified in the javadoc of ConfigurationSerializable.
-     * <p />
+     * <p>
      * If a new instance could not be made, an example being the class not fully implementing
      * the interface, null will be returned.
      *

--- a/src/main/java/org/bukkit/configuration/serialization/SerializableAs.java
+++ b/src/main/java/org/bukkit/configuration/serialization/SerializableAs.java
@@ -9,10 +9,10 @@ import java.lang.annotation.Target;
  * Represents an "alias" that a {@link ConfigurationSerializable} may be stored as.
  * If this is not present on a {@link ConfigurationSerializable} class, it will use the
  * fully qualified name of the class.
- * <p />
+ * <p>
  * This value will be stored in the configuration so that the configuration deserialization
  * can determine what type it is.
- * <p />
+ * <p>
  * Using this annotation on any other class than a {@link ConfigurationSerializable} will
  * have no effect.
  * @see ConfigurationSerialization#registerClass(Class, String)
@@ -22,7 +22,7 @@ import java.lang.annotation.Target;
 public @interface SerializableAs {
     /**
      * This is the name your class will be stored and retrieved as.
-     * <p />
+     * <p>
      * This name MUST be unique. We recommend using names such as "MyPluginThing" instead of
      * "Thing".
      *

--- a/src/main/java/org/bukkit/enchantments/Enchantment.java
+++ b/src/main/java/org/bukkit/enchantments/Enchantment.java
@@ -176,7 +176,7 @@ public abstract class Enchantment {
 
     /**
      * Checks if this Enchantment may be applied to the given {@link ItemStack}.
-     * This does not check if it conflicts with any enchantmentds already applied to the item.
+     * This does not check if it conflicts with any enchantments already applied to the item.
      *
      * @param item Item to test
      * @return True if the enchantment may be applied, otherwise False

--- a/src/main/java/org/bukkit/enchantments/Enchantment.java
+++ b/src/main/java/org/bukkit/enchantments/Enchantment.java
@@ -210,7 +210,7 @@ public abstract class Enchantment {
 
     /**
      * Registers an enchantment with the given ID and object.
-     * <p />
+     * <p>
      * Generally not to be used from within a plugin.
      *
      * @param enchantment Enchantment to register

--- a/src/main/java/org/bukkit/entity/Damageable.java
+++ b/src/main/java/org/bukkit/entity/Damageable.java
@@ -43,9 +43,9 @@ public interface Damageable extends Entity {
 
     /**
      * Sets the maximum health this entity can have.
-     * <p />
+     * <p>
      * If the health of the entity is above the value provided it will be set to that value.
-     * <p />
+     * <p>
      * Note: An entity with a health bar ({@link Player}, {@link EnderDragon}, {@link Wither}, etc...} will have their bar scaled accordingly.
      *
      * @param health amount of health to set the maximum to

--- a/src/main/java/org/bukkit/entity/Entity.java
+++ b/src/main/java/org/bukkit/entity/Entity.java
@@ -226,7 +226,7 @@ public interface Entity extends Metadatable {
 
     /**
      * Gets the amount of ticks this entity has lived for.
-     * <p />
+     * <p>
      * This is the equivalent to "age" in entities.
      *
      * @return Age of entity
@@ -235,7 +235,7 @@ public interface Entity extends Metadatable {
 
     /**
      * Sets the amount of ticks this entity has lived for.
-     * <p />
+     * <p>
      * This is the equivalent to "age" in entities. May not be less than one tick.
      *
      * @param value Age of entity
@@ -244,7 +244,7 @@ public interface Entity extends Metadatable {
 
     /**
      * Performs the specified {@link EntityEffect} for this entity.
-     * <p />
+     * <p>
      * This will be viewable to all players near the entity.
      *
      * @param type Effect to play.

--- a/src/main/java/org/bukkit/entity/Fish.java
+++ b/src/main/java/org/bukkit/entity/Fish.java
@@ -3,4 +3,26 @@ package org.bukkit.entity;
 /**
  * Represents a fishing hook.
  */
-public interface Fish extends Projectile {}
+public interface Fish extends Projectile {
+
+    /**
+     * Gets the chance of a fish biting.
+     * <p>
+     * 0.0 = No Chance.<br>
+     * 1.0 = Instant catch.
+     *
+     * @return chance the bite chance
+     */
+    public double getBiteChance();
+
+    /**
+     * Sets the chance of a fish biting.
+     * <p>
+     * 0.0 = No Chance.<br>
+     * 1.0 = Instant catch.
+     *
+     * @param chance the bite chance
+     * @throws IllegalArgumentException if the bite chance is not between 0 and 1
+     */
+    public void setBiteChance(double chance) throws IllegalArgumentException;
+}

--- a/src/main/java/org/bukkit/entity/LivingEntity.java
+++ b/src/main/java/org/bukkit/entity/LivingEntity.java
@@ -15,278 +15,309 @@ import org.bukkit.potion.PotionEffectType;
  */
 public interface LivingEntity extends Entity, Damageable {
     /**
-     * Gets the height of the entity's head above its Location
+     * Gets the height of the living entity's eyes above its Location.
      *
-     * @return Height of the entity's eyes above its Location
+     * @return height of the living entity's eyes above its location
      */
     public double getEyeHeight();
 
     /**
-     * Gets the height of the entity's head above its Location
+     * Gets the height of the living entity's eyes above its Location.
      *
-     * @param ignoreSneaking If set to true, the effects of sneaking will be ignored
-     * @return Height of the entity's eyes above its Location
+     * @param ignoreSneaking if set to true, the effects of sneaking
+     *     will be ignored
+     * @return height of the living entity's eyes above its location
      */
     public double getEyeHeight(boolean ignoreSneaking);
 
     /**
-     * Get a Location detailing the current eye position of the LivingEntity.
+     * Get a Location detailing the current eye position of the living
+     * entity.
      *
-     * @return a Location at the eyes of the LivingEntity.
+     * @return a location at the eyes of the living entity
      */
     public Location getEyeLocation();
 
     /**
-     * Gets all blocks along the player's line of sight
-     * List iterates from player's position to target inclusive
+     * Gets all blocks along the living entity's line of sight.
+     * <p>
+     * This list contains all blocks from the living entity's eye position
+     * to target inclusive.
      *
-     * @param transparent HashSet containing all transparent block IDs. If set to null only air is considered transparent.
-     * @param maxDistance This is the maximum distance to scan. This may be further limited by the server, but never to less than 100 blocks.
-     * @return List containing all blocks along the player's line of sight
+     * @param transparent HashSet containing all transparent block IDs
+     *     (set to null for only air)
+     * @param maxDistance this is the maximum distance to scan (may be
+     *     limited by server by at least 100 blocks, no less)
+     * @return list containing all blocks along the living entity's line
+     *     of sight
      */
     public List<Block> getLineOfSight(HashSet<Byte> transparent, int maxDistance);
 
     /**
-     * Gets the block that the player has targeted
+     * Gets the block that the living entity has targeted.
      *
-     * @param transparent HashSet containing all transparent block IDs. If set to null only air is considered transparent.
-     * @param maxDistance This is the maximum distance to scan. This may be further limited by the server, but never to less than 100 blocks.
-     * @return Block that the player has targeted
+     * @param transparent HashSet containing all transparent block IDs
+     *     (set to null for only air)
+     * @param maxDistance this is the maximum distance to scan
+     *     (may be limited by server by at least 100 blocks, no less)
+     * @return block that the living entity has targeted
      */
     public Block getTargetBlock(HashSet<Byte> transparent, int maxDistance);
 
     /**
-     * Gets the last two blocks along the player's line of sight.
+     * Gets the last two blocks along the living entity's line of sight.
+     * <p>
      * The target block will be the last block in the list.
      *
-     * @param transparent HashSet containing all transparent block IDs. If set to null only air is considered transparent.
-     * @param maxDistance This is the maximum distance to scan. This may be further limited by the server, but never to less than 100 blocks
-     * @return List containing the last 2 blocks along the player's line of sight
+     * @param transparent HashSet containing all transparent block IDs
+     *     (set to null for only air)
+     * @param maxDistance this is the maximum distance to scan. This may be
+     *     further limited by the server, but never to less than 100 blocks
+     * @return list containing the last 2 blocks along the living entity's
+     *     line of sight
      */
     public List<Block> getLastTwoTargetBlocks(HashSet<Byte> transparent, int maxDistance);
 
     /**
-     * Throws an egg from the entity.
+     * Throws an egg from the living entity.
      *
-     * @deprecated Use launchProjectile(Egg.class) instead
-     * @return The egg thrown.
+     * @deprecated use launchProjectile(Egg.class) instead
+     * @return the egg thrown
      */
     @Deprecated
     public Egg throwEgg();
 
     /**
-     * Throws a snowball from the entity.
+     * Throws a snowball from the living entity.
      *
-     * @deprecated Use launchProjectile(Snowball.class) instead
-     * @return The snowball thrown.
+     * @deprecated use launchProjectile(Snowball.class) instead
+     * @return the snowball thrown
      */
     @Deprecated
     public Snowball throwSnowball();
 
     /**
-     * Shoots an arrow from the entity.
+     * Shoots an arrow from the living entity.
      *
-     * @deprecated Use launchProjectile(Arrow.class) instead
-     * @return The arrow shot.
+     * @deprecated use launchProjectile(Arrow.class) instead
+     * @return the arrow shot
      */
     @Deprecated
     public Arrow shootArrow();
 
     /**
-     * Launches a {@link Projectile} from the entity.
+     * Launches a {@link Projectile} from the living entity.
      *
-     * @param projectile Class of the projectile to launch
-     *
-     * @return The launched projectile.
+     * @param projectile class of the projectile to launch
+     * @return the launched projectile
      */
     public <T extends Projectile> T launchProjectile(Class<? extends T> projectile);
 
     /**
-     * Returns the amount of air that this entity has remaining, in ticks
+     * Returns the amount of air that the living entity has remaining, in
+     * ticks.
      *
-     * @return Amount of air remaining
+     * @return amount of air remaining
      */
     public int getRemainingAir();
 
     /**
-     * Sets the amount of air that this entity has remaining, in ticks
+     * Sets the amount of air that the living entity has remaining, in
+     * ticks.
      *
-     * @param ticks Amount of air remaining
+     * @param ticks amount of air remaining
      */
     public void setRemainingAir(int ticks);
 
     /**
-     * Returns the maximum amount of air this entity can have, in ticks
+     * Returns the maximum amount of air the living entity can
+     * have, in ticks.
      *
-     * @return Maximum amount of air
+     * @return maximum amount of air
      */
     public int getMaximumAir();
 
     /**
-     * Sets the maximum amount of air this entity can have, in ticks
+     * Sets the maximum amount of air the living entity can have, in ticks.
      *
-     * @param ticks Maximum amount of air
+     * @param ticks maximum amount of air
      */
     public void setMaximumAir(int ticks);
 
     /**
-     * Returns the entities current maximum noDamageTicks
-     * This is the time in ticks the entity will become unable to take
-     * equal or less damage than the lastDamage
+     * Returns the living entity's current maximum no damage ticks.
+     * <p>
+     * This is the maximum duration in which the living entity will not
+     * take damage.
      *
-     * @return noDamageTicks
+     * @return maximum no damage ticks
      */
     public int getMaximumNoDamageTicks();
 
     /**
-     * Sets the entities current maximum noDamageTicks
+     * Sets the living entity's current maximum no damage ticks.
      *
-     * @param ticks maximumNoDamageTicks
+     * @param ticks maximum amount of no damage ticks
      */
     public void setMaximumNoDamageTicks(int ticks);
 
     /**
-     * Returns the entities lastDamage taken in the current noDamageTicks time.
-     * Only damage higher than this amount will further damage the entity.
+     * Returns the living entity's last damage taken in the current no
+     * damage ticks time.
+     * <p>
+     * Only damage higher than this amount will further damage the living
+     * entity.
      *
-     * @return lastDamage
+     * @return damage taken since the last no damage ticks time period
      */
     public int getLastDamage();
 
     /**
-     * Sets the entities current maximum noDamageTicks
+     * Sets the damage dealt within the current no damage ticks time period.
      *
-     * @param damage last damage
+     * @param damage amount of damage
      */
     public void setLastDamage(int damage);
 
     /**
-     * Returns the entities current noDamageTicks
+     * Returns the living entity's current no damage ticks.
      *
-     * @return noDamageTicks
+     * @return amount of no damage ticks
      */
     public int getNoDamageTicks();
 
     /**
-     * Sets the entities current noDamageTicks
+     * Sets the living entity's current no damage ticks.
      *
-     * @param ticks NoDamageTicks
+     * @param ticks amount of no damage ticks
      */
     public void setNoDamageTicks(int ticks);
 
     /**
-     * Gets the player identified as the killer of this entity.
-     * <p />
+     * Gets the player identified as the killer of the living entity.
+     * <p>
      * May be null.
      *
-     * @return Killer player, or null if none found.
+     * @return killer player, or null if none found
      */
     public Player getKiller();
 
     /**
-     * Adds the given {@link PotionEffect} to this entity.
-     * Only one potion effect can be present for a given {@link PotionEffectType}.
+     * Adds the given {@link PotionEffect} to the living entity.
+     * <p>
+     * Only one potion effect can be present for a given
+     * {@link PotionEffectType}.
      *
      * @param effect PotionEffect to be added
-     * @return Whether the effect could be added
+     * @return whether the effect could be added
      */
     public boolean addPotionEffect(PotionEffect effect);
 
     /**
-     * Adds the given {@link PotionEffect} to this entity.
-     * Only one potion effect can be present for a given {@link PotionEffectType}.
+     * Adds the given {@link PotionEffect} to the living entity.
+     * <p>
+     * Only one potion effect can be present for a given
+     * {@link PotionEffectType}.
      *
      * @param effect PotionEffect to be added
-     * @param force Whether conflicting effects should be removed
-     * @return Whether the effect could be added
+     * @param force whether conflicting effects should be removed
+     * @return whether the effect could be added
      */
     public boolean addPotionEffect(PotionEffect effect, boolean force);
 
     /**
-     * Attempts to add all of the given {@link PotionEffect} to this entity.
+     * Attempts to add all of the given {@link PotionEffect} to the living
+     * entity.
      *
-     * @param effects The effects to add
-     * @return Whether all of the effects could be added
+     * @param effects the effects to add
+     * @return whether all of the effects could be added
      */
     public boolean addPotionEffects(Collection<PotionEffect> effects);
 
     /**
-     * Returns whether the entity already has an existing
-     * effect of the given {@link PotionEffectType} applied to it.
+     * Returns whether the living entity already has an existing effect of
+     * the given {@link PotionEffectType} applied to it.
      *
-     * @param type The potion type to check
-     * @return Whether the player has this potion effect active on them.
+     * @param type the potion type to check
+     * @return whether the living entity has this potion effect active
+     *     on them
      */
     public boolean hasPotionEffect(PotionEffectType type);
 
     /**
      * Removes any effects present of the given {@link PotionEffectType}.
      *
-     * @param type The potion type to remove
+     * @param type the potion type to remove
      */
     public void removePotionEffect(PotionEffectType type);
 
     /**
-     * Returns all currently active {@link PotionEffect}s on this entity.
+     * Returns all currently active {@link PotionEffect}s on the
+     * living entity.
      *
-     * @return A collection of {@link PotionEffect}s
+     * @return a collection of {@link PotionEffect}s
      */
     public Collection<PotionEffect> getActivePotionEffects();
 
     /**
-     * Checks whether the entity has block line of sight to another.<br />
-     * This uses the same algorithm that hostile mobs use to find the closest player.
+     * Checks whether the living entity has block line of sight to another.
+     * <p>
+     * This uses the same algorithm that hostile mobs use to find the
+     * closest player.
      *
-     * @param other The entity to determine line of sight to.
-     * @return true if there is a line of sight, false if not.
+     * @param other the entity to determine line of sight to
+     * @return true if there is a line of sight, false if not
      */
     public boolean hasLineOfSight(Entity other);
 
     /**
-     * Returns if the entity despawns when away from players or not.<br />
-     * By default animals are not removed while other mobs are.
+     * Returns if the living entity despawns when away from players or not.
+     * <p>
+     * By default, animals are not removed while other mobs are.
      *
-     * @return true if the entity is removed when away from players
+     * @return true if the living entity is removed when away from players
      */
     public boolean getRemoveWhenFarAway();
 
     /**
-     * Sets whether or not the entity despawns when away from players or not.
+     * Sets whether or not the living entity despawns when away from
+     * players or not.
      *
-     * @param remove The remove status
+     * @param remove the removal status
      */
     public void setRemoveWhenFarAway(boolean remove);
 
     /**
-     *  Gets the inventory with the equipment worn by this entity.
+     *  Gets the inventory with the equipment worn by the living entity.
      *
-     *  @return the entities inventory.
+     * @return the living entity's inventory
      */
     public EntityEquipment getEquipment();
 
     /**
-     * Sets whether or not the entity can pick up items
+     * Sets whether or not the living entity can pick up items.
      *
-     * @param pickup Whether or not the entity can pick up items
+     * @param pickup whether or not the living entity can pick up items
      */
     public void setCanPickupItems(boolean pickup);
 
     /**
-     * Gets if the entity can pick up items
+     * Gets if the living entity can pick up items.
      *
-     * @return whether or not the entity can pick up items
+     * @return whether or not the living entity can pick up items
      */
     public boolean getCanPickupItems();
 
     /**
-     * Sets a custom name on a mob. This name will be used in death messages
-     * and can be sent to the client as a nameplate over the mob.
+     * Sets a custom name on a mob. This name will be used in death
+     * messages and can be sent to the client as a nameplate over the mob.
      * <p>
      * Setting the name to null or an empty string will clear it.
      * <p>
      * This value has no effect on players, they will always use their real
      * name.
-     * @param name name to set
+     * 
+     * @param name the name to set
      */
     public void setCustomName(String name);
 
@@ -296,6 +327,7 @@ public interface LivingEntity extends Entity, Damageable {
      * <p>
      * This value has no effect on players, they will always use their real
      * name.
+     * 
      * @return name of the mob or null
      */
     public String getCustomName();
@@ -306,7 +338,8 @@ public interface LivingEntity extends Entity, Damageable {
      * <p>
      * This value has no effect on players, they will always display their
      * name.
-     * @param flag show custom name
+     * 
+     * @param flag custom name or not
      */
     public void setCustomNameVisible(boolean flag);
 
@@ -315,6 +348,7 @@ public interface LivingEntity extends Entity, Damageable {
      * <p>
      * This value has no effect on players, they will always display their
      * name.
+     * 
      * @return if the custom name is displayed
      */
     public boolean isCustomNameVisible();

--- a/src/main/java/org/bukkit/entity/Minecart.java
+++ b/src/main/java/org/bukkit/entity/Minecart.java
@@ -67,7 +67,7 @@ public interface Minecart extends Vehicle {
 
     /**
      * Gets the derailed velocity modifier. Used for minecarts that are on the ground, but not on rails.
-     * <p />
+     * <p>
      * A derailed minecart's velocity is multiplied by this factor each tick.
      *
      * @return derailed visible speed

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -560,7 +560,7 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      * not be reliable, as it is a state provided by the client, and may therefore not be accurate.
      *
      * @return True if the player standing on a solid block, else false.
-     * @deprecated Inconsistent with {@link org.bukkit.craftbukkit.entity.Entity#isOnGround()}
+     * @deprecated Inconsistent with {@link org.bukkit.entity.Entity#isOnGround()}
      */
     @Deprecated
     public boolean isOnGround();

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -636,10 +636,14 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
     public Scoreboard getScoreboard();
 
     /**
-     * Sets the player's visible Scoreboard
-     * Scoreboard must be currently registered or an IllegalArgumentException is thrown
+     * Sets the player's visible Scoreboard.
      *
      * @param scoreboard New Scoreboard for the player
+     * @throws IllegalArgumentException if scoreboard is null
+     * @throws IllegalArgumentException if scoreboard was not created by the
+     *     {@link org.bukkit.scoreboard.ScoreboardManager scoreboard manager}
+     * @throws IllegalStateException if this is a player that is not logged
+     *     yet or has logged out
      */
-    public void setScoreboard(Scoreboard scoreboard);
+    public void setScoreboard(Scoreboard scoreboard) throws IllegalArgumentException, IllegalStateException;
 }

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -17,6 +17,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.conversations.Conversable;
 import org.bukkit.map.MapView;
 import org.bukkit.plugin.messaging.PluginMessageRecipient;
+import org.bukkit.scoreboard.Scoreboard;
 
 /**
  * Represents a player, connected or not
@@ -626,4 +627,19 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      * @throws IllegalArgumentException Thrown if the URL is too long.
      */
     public void setTexturePack(String url);
+
+    /**
+     * Gets the Scoreboard displayed to this player
+     *
+     * @return The current scoreboard seen by this player
+     */
+    public Scoreboard getScoreboard();
+
+    /**
+     * Sets the player's visible Scoreboard
+     * Scoreboard must be currently registered or an IllegalArgumentException is thrown
+     *
+     * @param scoreboard New Scoreboard for the player
+     */
+    public void setScoreboard(Scoreboard scoreboard);
 }

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -24,7 +24,7 @@ import org.bukkit.plugin.messaging.PluginMessageRecipient;
 public interface Player extends HumanEntity, Conversable, CommandSender, OfflinePlayer, PluginMessageRecipient {
     /**
      * Gets the "friendly" name to display of this player. This may include color.
-     * <p />
+     * <p>
      * Note that this name will not be displayed in game, only in chat and places
      * defined by plugins
      *
@@ -34,7 +34,7 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
 
     /**
      * Sets the "friendly" name to display of this player. This may include color.
-     * <p />
+     * <p>
      * Note that this name will not be displayed in game, only in chat and places
      * defined by plugins
      *
@@ -51,11 +51,11 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
 
     /**
      * Sets the name that is shown on the in-game player list.
-     * <p />
+     * <p>
      * The name cannot be longer than 16 characters, but {@link ChatColor} is supported.
-     * <p />
+     * <p>
      * If the value is null, the name will be identical to {@link #getName()}.
-     * <p />
+     * <p>
      * This name is case sensitive and unique, two names with different casing will
      * appear as two different people. If a player joins afterwards with
      * a name that conflicts with a player's custom list name, the
@@ -155,7 +155,7 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
 
     /**
      * Loads the players current location, health, inventory, motion, and other information from the username.dat file, in the world/player folder
-     * <p />
+     * <p>
      * Note: This will overwrite the players current inventory, health, motion, etc, with the state from the saved dat file.
      */
     public void loadData();
@@ -202,7 +202,7 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
 
     /**
      * Play a sound for a player at the location.
-     * <p />
+     * <p>
      * This function will fail silently if Location or Sound are null.
      *
      * @param location The location to play the sound
@@ -244,7 +244,7 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      * Send a chunk change. This fakes a chunk change packet for a user at
      * a certain location. The updated cuboid must be entirely within a single
      * chunk. This will not actually change the world in any way.
-     * <p />
+     * <p>
      * At least one of the dimensions of the cuboid must be even. The size of the
      * data buffer must be 2.5*sx*sy*sz and formatted in accordance with the Packet51
      * format.
@@ -270,7 +270,7 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
 
     /**
      * Render a map and send it to the player in its entirety. This may be used
-     * when streaming the map in the normal manner is not desirbale.
+     * when streaming the map in the normal manner is not desirable.
      *
      * @param map The map to be sent
      */
@@ -326,7 +326,7 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
     /**
      * Sets the current time on the player's client. When relative is true the player's time
      * will be kept synchronized to its world time with the specified offset.
-     * <p />
+     * <p>
      * When using non relative time the player's time will stay fixed at the specified time parameter. It's up to
      * the caller to continue updating the player's time. To restore player time to normal use resetPlayerTime().
      *
@@ -403,7 +403,7 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
 
     /**
      * Gets the players current experience points towards the next level.
-     * <p />
+     * <p>
      * This is a percentage value. 0 is "no progress" and 1 is "next level".
      *
      * @return Current experience points
@@ -412,7 +412,7 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
 
     /**
      * Sets the players current experience points towards the next level
-     * <p />
+     * <p>
      * This is a percentage value. 0 is "no progress" and 1 is "next level".
      *
      * @param exp New experience points
@@ -449,7 +449,7 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
 
     /**
      * Gets the players current exhaustion level.
-     * <p />
+     * <p>
      * Exhaustion controls how fast the food level drops. While you have a certain
      * amount of exhaustion, your saturation will drop to zero, and then your food
      * will drop to zero.
@@ -467,7 +467,7 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
 
     /**
      * Gets the players current saturation level.
-     * <p />
+     * <p>
      * Saturation is a buffer for food level. Your food level will not drop if you
      * are saturated > 0.
      *
@@ -606,14 +606,14 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
 
     /**
      * Request that the player's client download and switch texture packs.
-     * <p />
+     * <p>
      * The player's client will download the new texture pack asynchronously in the background, and
      * will automatically switch to it once the download is complete. If the client has downloaded
      * and cached the same texture pack in the past, it will perform a quick timestamp check over
      * the network to determine if the texture pack has changed and needs to be downloaded again.
      * When this request is sent for the very first time from a given server, the client will first
      * display a confirmation GUI to the player before proceeding with the download.
-     * <p />
+     * <p>
      * Notes:
      *   <ul>
      *     <li>Players can disable server textures on their client, in which case this method will have no affect on them.</li>

--- a/src/main/java/org/bukkit/entity/Projectile.java
+++ b/src/main/java/org/bukkit/entity/Projectile.java
@@ -24,7 +24,7 @@ public interface Projectile extends Entity {
 
     /**
      * Determine if this projectile should bounce or not when it hits.
-     * <p />
+     * <p>
      * If a small fireball does not bounce it will set the target on fire.
      *
      * @return true if it should bounce.

--- a/src/main/java/org/bukkit/entity/TNTPrimed.java
+++ b/src/main/java/org/bukkit/entity/TNTPrimed.java
@@ -12,9 +12,27 @@ public interface TNTPrimed extends Explosive {
     public void setFuseTicks(int fuseTicks);
 
     /**
-     * Retrieve the number of ticks until the explosion of this TNTPrimed entity
+     * Retrieve the number of ticks until the explosion of this TNTPrimed
+     * entity
      *
      * @return the number of ticks until this TNTPrimed explodes
      */
     public int getFuseTicks();
+
+    /**
+     * Gets the source of this primed TNT. The source is the entity
+     * responsible for the creation of this primed TNT.
+     * (I.E. player ignites TNT with flint and steel.) Take note
+     * that this can be null if there is no suitable source.
+     * (created by the {@link org.bukkit.World#spawn(Location, Class)}
+     * method, for example.)
+     *
+     * The source will become null if the chunk this primed TNT is in
+     * is unloaded then reloaded. If the source Entity becomes invalidated
+     * for any reason, such being removed from the world, the returned value
+     * will be null.
+     *
+     * @return the source of this primed TNT
+     */
+    public Entity getSource();
 }

--- a/src/main/java/org/bukkit/entity/Tameable.java
+++ b/src/main/java/org/bukkit/entity/Tameable.java
@@ -4,7 +4,7 @@ public interface Tameable {
 
     /**
      * Check if this is tamed
-     * <p />
+     * <p>
      * If something is tamed then a player can not tame it through normal methods, even if it does not belong to anyone in particular.
      *
      * @return true if this has been tamed
@@ -13,7 +13,7 @@ public interface Tameable {
 
     /**
      * Sets if this has been tamed. Not necessary if the method setOwner has been used, as it tames automatically.
-     * <p />
+     * <p>
      * If something is tamed then a player can not tame it through normal methods, even if it does not belong to anyone in particular.
      *
      * @param tame true if tame

--- a/src/main/java/org/bukkit/entity/ThrownPotion.java
+++ b/src/main/java/org/bukkit/entity/ThrownPotion.java
@@ -2,6 +2,7 @@ package org.bukkit.entity;
 
 import java.util.Collection;
 
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 
 /**
@@ -13,4 +14,24 @@ public interface ThrownPotion extends Projectile {
      * @return The potion effects
      */
     public Collection<PotionEffect> getEffects();
+
+    /**
+     * Returns a copy of the ItemStack for this thrown potion.
+     * <p>
+     * Altering this copy will not alter the thrown potion directly.
+     * If you want to alter the thrown potion, you must use the
+     * {@link #setItemStack(ItemStack) setItemStack} method.
+     *
+     * @return A copy of the ItemStack for this thrown potion.
+     */
+    public ItemStack getItem();
+
+    /**
+     * Set the ItemStack for this thrown potion.
+     * <p>
+     * The ItemStack must be a potion, otherwise an exception is thrown.
+     *
+     * @param item New ItemStack
+     */
+    public void setItem(ItemStack item);
 }

--- a/src/main/java/org/bukkit/entity/ThrownPotion.java
+++ b/src/main/java/org/bukkit/entity/ThrownPotion.java
@@ -9,8 +9,10 @@ import org.bukkit.potion.PotionEffect;
  * Represents a thrown potion bottle
  */
 public interface ThrownPotion extends Projectile {
+
     /**
      * Returns the effects that are applied by this potion.
+     *
      * @return The potion effects
      */
     public Collection<PotionEffect> getEffects();
@@ -18,9 +20,9 @@ public interface ThrownPotion extends Projectile {
     /**
      * Returns a copy of the ItemStack for this thrown potion.
      * <p>
-     * Altering this copy will not alter the thrown potion directly.
-     * If you want to alter the thrown potion, you must use the
-     * {@link #setItemStack(ItemStack) setItemStack} method.
+     * Altering this copy will not alter the thrown potion directly. If you
+     * want to alter the thrown potion, you must use the {@link
+     * #setItem(ItemStack) setItemStack} method.
      *
      * @return A copy of the ItemStack for this thrown potion.
      */

--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -1,31 +1,42 @@
 package org.bukkit.event;
 
+import org.bukkit.plugin.PluginManager;
+
 /**
- * Represents an event
+ * Represents an event.
+ *
+ * @see PluginManager#callEvent(Event)
+ * @see PluginManager#registerEvents(Listener,Plugin)
  */
 public abstract class Event {
     private String name;
     private final boolean async;
 
     /**
-     * The default constructor is defined for cleaner code.
-     * This constructor assumes the event is synchronous.
+     * The default constructor is defined for cleaner code. This constructor
+     * assumes the event is synchronous.
      */
     public Event() {
         this(false);
     }
 
     /**
-     * This constructor is used to explicitly declare an event as synchronous or asynchronous.
+     * This constructor is used to explicitly declare an event as synchronous
+     * or asynchronous.
      *
-     * @param isAsync true indicates the event will fire asynchronously. false by default
+     * @param isAsync true indicates the event will fire asynchronously, false
+     *     by default from default constructor
      */
     public Event(boolean isAsync) {
         this.async = isAsync;
     }
 
     /**
-     * @return Name of this event
+     * Convenience method for providing a user-friendly identifier. By
+     * default, it is the event's class's {@linkplain Class#getSimpleName()
+     * simple name}.
+     *
+     * @return name of this event
      */
     public String getEventName() {
         if (name == null) {
@@ -37,17 +48,24 @@ public abstract class Event {
     public abstract HandlerList getHandlers();
 
     /**
-     * Any custom event that should not by synchronized with other events must use the specific constructor.
-     * These are the caveats of using an asynchronous event:
-     * <li>The event is never fired from inside code triggered by a synchronous event.
-     *          Attempting to do so results in an {@link java.lang.IllegalStateException}.</li>
-     * <li>However, asynchronous event handlers may fire synchronous or asynchronous events</li>
-     * <li>The event may be fired multiple times simultaneously and in any order.</li>
-     * <li>Any newly registered or unregistered handler is ignored after an event starts execution.</li>
-     * <li>The handlers for this event may block for any length of time.</li>
-     * <li>Some implementations may selectively declare a specific event use as asynchronous.
-     *          This behavior should be clearly defined.</li>
-     * <li>Asynchronous calls are not calculated in the plugin timing system.</li>
+     * Any custom event that should not by synchronized with other events must
+     * use the specific constructor. These are the caveats of using an
+     * asynchronous event:
+     * <ul>
+     * <li>The event is never fired from inside code triggered by a
+     *     synchronous event. Attempting to do so results in an {@link
+     *     java.lang.IllegalStateException}.
+     * <li>However, asynchronous event handlers may fire synchronous or
+     *     asynchronous events
+     * <li>The event may be fired multiple times simultaneously and in any
+     *     order.
+     * <li>Any newly registered or unregistered handler is ignored after an
+     *     event starts execution.
+     * <li>The handlers for this event may block for any length of time.
+     * <li>Some implementations may selectively declare a specific event use
+     *     as asynchronous. This behavior should be clearly defined.
+     * <li>Asynchronous calls are not calculated in the plugin timing system.
+     * </ul>
      *
      * @return false by default, true if the event fires asynchronously
      */
@@ -58,20 +76,20 @@ public abstract class Event {
     public enum Result {
 
         /**
-         * Deny the event.
-         * Depending on the event, the action indicated by the event will either not take place or will be reverted.
-         * Some actions may not be denied.
+         * Deny the event. Depending on the event, the action indicated by the
+         * event will either not take place or will be reverted. Some actions
+         * may not be denied.
          */
         DENY,
         /**
-         * Neither deny nor allow the event.
-         * The server will proceed with its normal handling.
+         * Neither deny nor allow the event. The server will proceed with its
+         * normal handling.
          */
         DEFAULT,
         /**
-         * Allow / Force the event.
-         * The action indicated by the event will take place if possible, even if the server would not normally allow the action.
-         * Some actions may not be allowed.
+         * Allow / Force the event. The action indicated by the event will
+         * take place if possible, even if the server would not normally allow
+         * the action. Some actions may not be allowed.
          */
         ALLOW;
     }

--- a/src/main/java/org/bukkit/event/EventHandler.java
+++ b/src/main/java/org/bukkit/event/EventHandler.java
@@ -11,7 +11,27 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface EventHandler {
+
+    /**
+     * Define the priority of the event.
+     * <p />
+     * First priority to the last priority executed:
+     * <ol>
+     * <li>LOWEST</li>
+     * <li>LOW</li>
+     * <li>NORMAL</li>
+     * <li>HIGH</li>
+     * <li>HIGHEST</li>
+     * <li>MONITOR</li>
+     * </ol>
+     */
     EventPriority priority() default EventPriority.NORMAL;
 
+    /**
+     * Define if the handler ignores a cancelled event.
+     * <p />
+     * If ignoreCancelled is true and the event is cancelled, the method is
+     * not called. Otherwise, the method is always called.
+     */
     boolean ignoreCancelled() default false;
 }

--- a/src/main/java/org/bukkit/event/EventHandler.java
+++ b/src/main/java/org/bukkit/event/EventHandler.java
@@ -14,7 +14,7 @@ public @interface EventHandler {
 
     /**
      * Define the priority of the event.
-     * <p />
+     * <p>
      * First priority to the last priority executed:
      * <ol>
      * <li>LOWEST</li>
@@ -29,7 +29,7 @@ public @interface EventHandler {
 
     /**
      * Define if the handler ignores a cancelled event.
-     * <p />
+     * <p>
      * If ignoreCancelled is true and the event is cancelled, the method is
      * not called. Otherwise, the method is always called.
      */

--- a/src/main/java/org/bukkit/event/block/BlockBreakEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockBreakEvent.java
@@ -7,7 +7,7 @@ import org.bukkit.event.HandlerList;
 
 /**
  * Called when a block is broken by a player.
- * <p />
+ * <p>
  * If you wish to have the block drop experience, you must set the experience value above 0.
  * By default, experience will be set in the event if:
  * <ol>
@@ -16,11 +16,11 @@ import org.bukkit.event.HandlerList;
  * <li />The player does not have silk touch
  * <li />The block drops experience in vanilla MineCraft
  * </ol>
- * <p />
+ * <p>
  * Note:
  * Plugins wanting to simulate a traditional block drop should set the block to air and utilize their own methods for determining
  *   what the default drop for the block being broken is and what to do about it, if anything.
- * <p />
+ * <p>
  * If a Block Break event is cancelled, the block will not break and experience will not drop.
  */
 public class BlockBreakEvent extends BlockExpEvent implements Cancellable {

--- a/src/main/java/org/bukkit/event/block/BlockBurnEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockBurnEvent.java
@@ -6,7 +6,7 @@ import org.bukkit.event.HandlerList;
 
 /**
  * Called when a block is destroyed as a result of being burnt by fire.
- * <p />
+ * <p>
  * If a Block Burn event is cancelled, the block will not be destroyed as a result of being burnt by fire.
  */
 public class BlockBurnEvent extends BlockEvent implements Cancellable {

--- a/src/main/java/org/bukkit/event/block/BlockCanBuildEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockCanBuildEvent.java
@@ -6,7 +6,7 @@ import org.bukkit.event.HandlerList;
 
 /**
  * Called when we try to place a block, to see if we can build it here or not.
- * <p />
+ * <p>
  * Note:
  * <ul>
  * <li>The Block returned by getBlock() is the block we are trying to place on, not the block we are trying to place.</li>

--- a/src/main/java/org/bukkit/event/block/BlockDamageEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockDamageEvent.java
@@ -8,7 +8,7 @@ import org.bukkit.inventory.ItemStack;
 
 /**
  * Called when a block is damaged by a player.
- * <p />
+ * <p>
  * If a Block Damage event is cancelled, the block will not be damaged.
  */
 public class BlockDamageEvent extends BlockEvent implements Cancellable {

--- a/src/main/java/org/bukkit/event/block/BlockDispenseEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockDispenseEvent.java
@@ -8,7 +8,7 @@ import org.bukkit.util.Vector;
 
 /**
  * Called when an item is dispensed from a block.
- * <p />
+ * <p>
  * If a Block Dispense event is cancelled, the block will not dispense the item.
  */
 public class BlockDispenseEvent extends BlockEvent implements Cancellable {
@@ -44,7 +44,7 @@ public class BlockDispenseEvent extends BlockEvent implements Cancellable {
 
     /**
      * Gets the velocity.
-     * <p />
+     * <p>
      * Note: Modifying the returned Vector will not change the velocity, you must use {@link #setVelocity(org.bukkit.util.Vector)} instead.
      *
      * @return A Vector for the dispensed item's velocity

--- a/src/main/java/org/bukkit/event/block/BlockFadeEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockFadeEvent.java
@@ -7,13 +7,13 @@ import org.bukkit.event.HandlerList;
 
 /**
  * Called when a block fades, melts or disappears based on world conditions
- * <p />
+ * <p>
  * Examples:
  * <ul>
  * <li>Snow melting due to being near a light source.</li>
  * <li>Ice melting due to being near a light source.</li>
  * </ul>
- * <p />
+ * <p>
  * If a Block Fade event is cancelled, the block will not fade, melt or disappear.
  */
 public class BlockFadeEvent extends BlockEvent implements Cancellable {

--- a/src/main/java/org/bukkit/event/block/BlockFormEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockFormEvent.java
@@ -8,13 +8,13 @@ import org.bukkit.event.HandlerList;
 /**
  * Called when a block is formed or spreads based on world conditions.
  * Use {@link BlockSpreadEvent} to catch blocks that actually spread and don't just "randomly" form.
- * <p />
+ * <p>
  * Examples:
  * <ul>
  * <li>Snow forming due to a snow storm.</li>
  * <li>Ice forming in a snowy Biome like Taiga or Tundra.</li>
  * </ul>
- * <p />
+ * <p>
  * If a Block Form event is cancelled, the block will not be formed.
  *
  * @see BlockSpreadEvent

--- a/src/main/java/org/bukkit/event/block/BlockFromToEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockFromToEvent.java
@@ -8,7 +8,7 @@ import org.bukkit.event.HandlerList;
 /**
  * Represents events with a source block and a destination block, currently only applies to liquid (lava and water)
  * and teleporting dragon eggs.
- * <p />
+ * <p>
  * If a Block From To event is cancelled, the block will not move (the liquid will not flow).
  */
 public class BlockFromToEvent extends BlockEvent implements Cancellable {

--- a/src/main/java/org/bukkit/event/block/BlockGrowEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockGrowEvent.java
@@ -7,7 +7,7 @@ import org.bukkit.event.HandlerList;
 
 /**
  * Called when a block grows naturally in the world.
- * <p />
+ * <p>
  * Examples:
  * <ul>
  * <li>Wheat</li>
@@ -16,7 +16,7 @@ import org.bukkit.event.HandlerList;
  * <li>Watermelon</li>
  * <li>Pumpkin</li>
  * </ul>
- * <p />
+ * <p>
  * If a Block Grow event is cancelled, the block will not grow.
  */
 public class BlockGrowEvent extends BlockEvent implements Cancellable {

--- a/src/main/java/org/bukkit/event/block/BlockIgniteEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockIgniteEvent.java
@@ -8,7 +8,7 @@ import org.bukkit.event.HandlerList;
 
 /**
  * Called when a block is ignited. If you want to catch when a Player places fire, you need to use {@link BlockPlaceEvent}.
- * <p />
+ * <p>
  * If a Block Ignite event is cancelled, the block will not be ignited.
  */
 public class BlockIgniteEvent extends BlockEvent implements Cancellable {

--- a/src/main/java/org/bukkit/event/block/BlockPlaceEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockPlaceEvent.java
@@ -9,7 +9,7 @@ import org.bukkit.inventory.ItemStack;
 
 /**
  * Called when a block is placed by a player.
- * <p />
+ * <p>
  * If a Block Place event is cancelled, the block will not be placed.
  */
 public class BlockPlaceEvent extends BlockEvent implements Cancellable {

--- a/src/main/java/org/bukkit/event/block/BlockSpreadEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockSpreadEvent.java
@@ -7,13 +7,13 @@ import org.bukkit.event.HandlerList;
 /**
  * Called when a block spreads based on world conditions.
  * Use {@link BlockFormEvent} to catch blocks that "randomly" form instead of actually spread.
- * <p />
+ * <p>
  * Examples:
  * <ul>
  * <li>Mushrooms spreading.</li>
  * <li>Fire spreading.</li>
  * </ul>
- * <p />
+ * <p>
  * If a Block Spread event is cancelled, the block will not spread.
  *
  * @see BlockFormEvent

--- a/src/main/java/org/bukkit/event/block/EntityBlockFormEvent.java
+++ b/src/main/java/org/bukkit/event/block/EntityBlockFormEvent.java
@@ -6,7 +6,7 @@ import org.bukkit.entity.Entity;
 
 /**
  * Called when a block is formed by entities.
- * <p />
+ * <p>
  * Examples:
  * <ul>
  * <li>Snow formed by a {@link org.bukkit.entity.Snowman}.</li>

--- a/src/main/java/org/bukkit/event/block/LeavesDecayEvent.java
+++ b/src/main/java/org/bukkit/event/block/LeavesDecayEvent.java
@@ -6,7 +6,7 @@ import org.bukkit.event.HandlerList;
 
 /**
  * Called when leaves are decaying naturally.
- * <p />
+ * <p>
  * If a Leaves Decay event is cancelled, the leaves will not decay.
  */
 public class LeavesDecayEvent extends BlockEvent implements Cancellable {

--- a/src/main/java/org/bukkit/event/block/SignChangeEvent.java
+++ b/src/main/java/org/bukkit/event/block/SignChangeEvent.java
@@ -7,7 +7,7 @@ import org.bukkit.event.HandlerList;
 
 /**
  * Called when a sign is changed by a player.
- * <p />
+ * <p>
  * If a Sign Change event is cancelled, the sign will not be changed.
  */
 public class SignChangeEvent extends BlockEvent implements Cancellable {

--- a/src/main/java/org/bukkit/event/enchantment/EnchantItemEvent.java
+++ b/src/main/java/org/bukkit/event/enchantment/EnchantItemEvent.java
@@ -65,6 +65,7 @@ public class EnchantItemEvent extends InventoryEvent implements Cancellable {
 
     /**
      * Get cost in exp levels of the enchantment
+     *
      * @return experience level cost
      */
     public int getExpLevelCost() {
@@ -73,6 +74,7 @@ public class EnchantItemEvent extends InventoryEvent implements Cancellable {
 
     /**
      * Set cost in exp levels of the enchantment
+     *
      * @param level - cost in levels
      */
     public void setExpLevelCost(int level) {
@@ -91,6 +93,7 @@ public class EnchantItemEvent extends InventoryEvent implements Cancellable {
 
     /**
      * Which button was pressed to initiate the enchanting.
+     *
      * @return The button index (0, 1, or 2).
      */
     public int whichButton() {

--- a/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java
+++ b/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java
@@ -59,6 +59,7 @@ public class PrepareItemEnchantEvent extends InventoryEvent implements Cancellab
 
     /**
      * Get list of offered exp level costs of the enchantment (modify values to change offer)
+     *
      * @return experience level costs offered
      */
     public int[] getExpLevelCostsOffered() {
@@ -67,6 +68,7 @@ public class PrepareItemEnchantEvent extends InventoryEvent implements Cancellab
 
     /**
      * Get enchantment bonus in effect - corresponds to number of bookshelves
+     *
      * @return enchantment bonus
      */
     public int getEnchantmentBonus() {

--- a/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
+++ b/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
@@ -9,7 +9,7 @@ import org.bukkit.event.HandlerList;
 
 /**
  * Called when a creature is spawned into a world.
- * <p />
+ * <p>
  * If a Creature Spawn event is cancelled, the creature will not spawn.
  */
 public class CreatureSpawnEvent extends EntityEvent implements Cancellable {

--- a/src/main/java/org/bukkit/event/entity/CreeperPowerEvent.java
+++ b/src/main/java/org/bukkit/event/entity/CreeperPowerEvent.java
@@ -7,7 +7,7 @@ import org.bukkit.event.HandlerList;
 
 /**
  * Called when a Creeper is struck by lightning.
- * <p />
+ * <p>
  * If a Creeper Power event is cancelled, the Creeper will not be powered.
  */
 public class CreeperPowerEvent extends EntityEvent implements Cancellable {

--- a/src/main/java/org/bukkit/event/entity/EntityBreakDoorEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityBreakDoorEvent.java
@@ -7,7 +7,7 @@ import org.bukkit.entity.LivingEntity;
 
 /**
  * Called when an {@link Entity} breaks a door
- * <p />
+ * <p>
  * Canceling the event will cause the event to be delayed
  */
 public class EntityBreakDoorEvent extends EntityChangeBlockEvent {

--- a/src/main/java/org/bukkit/event/entity/EntityCombustByBlockEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityCombustByBlockEvent.java
@@ -13,7 +13,7 @@ public class EntityCombustByBlockEvent extends EntityCombustEvent {
 
     /**
      * The combuster can be lava or a block that is on fire.
-     * <p />
+     * <p>
      * WARNING: block may be null.
      *
      * @return the Block that set the combustee alight.

--- a/src/main/java/org/bukkit/event/entity/EntityCombustByEntityEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityCombustByEntityEvent.java
@@ -11,7 +11,7 @@ public class EntityCombustByEntityEvent extends EntityCombustEvent {
     }
 
     /**
-     * The combuster can be a WeatherStorm a Blaze, or an Entity holding a FIRE_ASPECT enchanted item.
+     * Get the entity that caused the combustion event.
      *
      * @return the Entity that set the combustee alight.
      */

--- a/src/main/java/org/bukkit/event/entity/EntityCombustEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityCombustEvent.java
@@ -6,7 +6,7 @@ import org.bukkit.event.HandlerList;
 
 /**
  * Called when an entity combusts.
- * <p />
+ * <p>
  * If an Entity Combust event is cancelled, the entity will not combust.
  */
 public class EntityCombustEvent extends EntityEvent implements Cancellable {
@@ -37,7 +37,7 @@ public class EntityCombustEvent extends EntityEvent implements Cancellable {
 
     /**
      * The number of seconds the combustee should be alight for.
-     * <p />
+     * <p>
      * This value will only ever increase the combustion time, not decrease existing combustion times.
      *
      * @param duration the time in seconds to be alight for.

--- a/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
@@ -189,6 +189,12 @@ public class EntityDamageEvent extends EntityEvent implements Cancellable {
          */
         FALLING_BLOCK,
         /**
+         * Damage caused in retaliation to another attack by the Thorns enchantment.
+         * <p />
+         * Damage: 1-4 (Thorns)
+         */
+        THORNS,
+        /**
          * Custom damage.
          * <p />
          * Damage: variable

--- a/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
@@ -28,18 +28,18 @@ public class EntityDamageEvent extends EntityEvent implements Cancellable {
     }
 
     /**
-     * Gets the amount of damage caused by the Block
+     * Gets the amount of damage caused by the event
      *
-     * @return The amount of damage caused by the Block
+     * @return The amount of damage caused by the event
      */
     public int getDamage() {
         return damage;
     }
 
     /**
-     * Sets the amount of damage caused by the Block
+     * Sets the amount of damage caused by the event
      *
-     * @param damage The amount of damage caused by the Block
+     * @param damage The amount of damage caused by the event
      */
     public void setDamage(int damage) {
         this.damage = damage;

--- a/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
@@ -177,7 +177,7 @@ public class EntityDamageEvent extends EntityEvent implements Cancellable {
          */
         MAGIC,
         /**
-         *
+         * Damage caused by Wither potion effect
          */
         WITHER,
         /**

--- a/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
@@ -70,109 +70,109 @@ public class EntityDamageEvent extends EntityEvent implements Cancellable {
 
         /**
          * Damage caused when an entity contacts a block such as a Cactus.
-         * <p />
+         * <p>
          * Damage: 1 (Cactus)
          */
         CONTACT,
         /**
          * Damage caused when an entity attacks another entity.
-         * <p />
+         * <p>
          * Damage: variable
          */
         ENTITY_ATTACK,
         /**
          * Damage caused when attacked by a projectile.
-         * <p />
+         * <p>
          * Damage: variable
          */
         PROJECTILE,
         /**
          * Damage caused by being put in a block
-         * <p />
+         * <p>
          * Damage: 1
          */
         SUFFOCATION,
         /**
          * Damage caused when an entity falls a distance greater than 3 blocks
-         * <p />
+         * <p>
          * Damage: fall height - 3.0
          */
         FALL,
         /**
          * Damage caused by direct exposure to fire
-         * <p />
+         * <p>
          * Damage: 1
          */
         FIRE,
         /**
          * Damage caused due to burns caused by fire
-         * <p />
+         * <p>
          * Damage: 1
          */
         FIRE_TICK,
         /**
          * Damage caused due to a snowman melting
-         * <p />
+         * <p>
          * Damage: 1
          */
         MELTING,
         /**
          * Damage caused by direct exposure to lava
-         * <p />
+         * <p>
          * Damage: 4
          */
         LAVA,
         /**
          * Damage caused by running out of air while in water
-         * <p />
+         * <p>
          * Damage: 2
          */
         DROWNING,
         /**
          * Damage caused by being in the area when a block explodes.
-         * <p />
+         * <p>
          * Damage: variable
          */
         BLOCK_EXPLOSION,
         /**
          * Damage caused by being in the area when an entity, such as a Creeper, explodes.
-         * <p />
+         * <p>
          * Damage: variable
          */
         ENTITY_EXPLOSION,
         /**
          * Damage caused by falling into the void
-         * <p />
+         * <p>
          * Damage: 4 for players
          */
         VOID,
         /**
          * Damage caused by being struck by lightning
-         * <p />
+         * <p>
          * Damage: 5
          */
         LIGHTNING,
         /**
          * Damage caused by committing suicide using the command "/kill"
-         * <p />
+         * <p>
          * Damage: 1000
          */
         SUICIDE,
         /**
          * Damage caused by starving due to having an empty hunger bar
-         * <p />
+         * <p>
          * Damage: 1
          */
         STARVATION,
         /**
          * Damage caused due to an ongoing poison effect
-         * <p />
+         * <p>
          * Damage: 1
          */
         POISON,
         /**
          * Damage caused by being hit by a damage potion or spell
-         * <p />
+         * <p>
          * Damage: variable
          */
         MAGIC,
@@ -182,21 +182,21 @@ public class EntityDamageEvent extends EntityEvent implements Cancellable {
         WITHER,
         /**
          * Damage caused by being hit by a falling block which deals damage
-         * <p />
+         * <p>
          * <b>Note:</b> Not every block deals damage
-         * <p />
+         * <p>
          * Damage: variable
          */
         FALLING_BLOCK,
         /**
          * Damage caused in retaliation to another attack by the Thorns enchantment.
-         * <p />
+         * <p>
          * Damage: 1-4 (Thorns)
          */
         THORNS,
         /**
          * Custom damage.
-         * <p />
+         * <p>
          * Damage: variable
          */
         CUSTOM

--- a/src/main/java/org/bukkit/event/entity/EntityDeathEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDeathEvent.java
@@ -30,7 +30,7 @@ public class EntityDeathEvent extends EntityEvent {
 
     /**
      * Gets how much EXP should be dropped from this death.
-     * <p />
+     * <p>
      * This does not indicate how much EXP should be taken from the entity in question,
      * merely how much should be created after its death.
      *
@@ -42,7 +42,7 @@ public class EntityDeathEvent extends EntityEvent {
 
     /**
      * Sets how much EXP should be dropped from this death.
-     * <p />
+     * <p>
      * This does not indicate how much EXP should be taken from the entity in question,
      * merely how much should be created after its death.
      *

--- a/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java
@@ -7,7 +7,7 @@ import org.bukkit.event.HandlerList;
 
 /**
  * Called when a non-player entity is about to teleport because it is in contact with a portal
- * <p />
+ * <p>
  * For players see {@link org.bukkit.event.player.PlayerPortalEvent PlayerPortalEvent}
  */
 public class EntityPortalEvent extends EntityTeleportEvent {

--- a/src/main/java/org/bukkit/event/entity/EntityPortalExitEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityPortalExitEvent.java
@@ -7,7 +7,7 @@ import org.bukkit.util.Vector;
 
 /**
  * Called before an entity exits a portal.
- * <p />
+ * <p>
  * This event allows you to modify the velocity of the entity after they
  * have successfully exeted the portal.
  */

--- a/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java
@@ -51,7 +51,7 @@ public class EntityTargetEvent extends EntityEvent implements Cancellable {
      * Set the entity that you want the mob to target instead.
      * It is possible to be null, null will cause the entity to be
      * target-less.
-     * <p />
+     * <p>
      * This is different from cancelling the event. Cancelling the event
      * will cause the entity to keep an original target, while setting to be
      * null will cause the entity to be reset

--- a/src/main/java/org/bukkit/event/entity/EntityTargetLivingEntityEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityTargetLivingEntityEvent.java
@@ -19,7 +19,7 @@ public class EntityTargetLivingEntityEvent extends EntityTargetEvent{
      * Set the Entity that you want the mob to target.
      * It is possible to be null, null will cause the entity to be
      * target-less.
-     * <p />
+     * <p>
      * Must be a LivingEntity, or null
      *
      * @param target The entity to target

--- a/src/main/java/org/bukkit/event/entity/FoodLevelChangeEvent.java
+++ b/src/main/java/org/bukkit/event/entity/FoodLevelChangeEvent.java
@@ -24,7 +24,7 @@ public class FoodLevelChangeEvent extends EntityEvent implements Cancellable {
 
     /**
      * Gets the resultant food level that the entity involved in this event should be set to.
-     * <p />
+     * <p>
      * Where 20 is a full food bar and 0 is an empty one.
      *
      * @return The resultant food level

--- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
+++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
@@ -56,7 +56,7 @@ public class PlayerDeathEvent extends EntityDeathEvent {
 
     /**
      * Gets how much EXP the Player should have at respawn.
-     * <p />
+     * <p>
      * This does not indicate how much EXP should be dropped, please see
      * {@link #getDroppedExp()} for that.
      *
@@ -68,7 +68,7 @@ public class PlayerDeathEvent extends EntityDeathEvent {
 
     /**
      * Sets how much EXP the Player should have at respawn.
-     * <p />
+     * <p>
      * This does not indicate how much EXP should be dropped, please see
      * {@link #setDroppedExp(int)} for that.
      *
@@ -116,7 +116,7 @@ public class PlayerDeathEvent extends EntityDeathEvent {
 
     /**
      * Gets if the Player should keep all EXP at respawn.
-     * <p />
+     * <p>
      * This flag overrides other EXP settings
      *
      * @return True if Player should keep all pre-death exp
@@ -127,7 +127,7 @@ public class PlayerDeathEvent extends EntityDeathEvent {
 
     /**
      * Sets if the Player should keep all EXP at respawn.
-     * <p />
+     * <p>
      * This overrides all other EXP settings
      *
      * @param keepLevel True to keep all current value levels

--- a/src/main/java/org/bukkit/event/inventory/ClickType.java
+++ b/src/main/java/org/bukkit/event/inventory/ClickType.java
@@ -1,0 +1,115 @@
+package org.bukkit.event.inventory;
+
+/**
+ * What the client did to trigger this action (not the result).
+ */
+public enum ClickType {
+    /**
+     * The left (or primary) mouse button.
+     */
+    LEFT,
+    /**
+     * Holding shift while pressing the left mouse button.
+     */
+    SHIFT_LEFT,
+    /**
+     * The right mouse button.
+     */
+    RIGHT,
+    /**
+     * Holding shift while pressing the right mouse button.
+     */
+    SHIFT_RIGHT,
+    /**
+     * Clicking the left mouse button on the grey area around the
+     * inventory.
+     */
+    WINDOW_BORDER_LEFT,
+    /**
+     * Clicking the right mouse button on the grey area around the
+     * inventory.
+     */
+    WINDOW_BORDER_RIGHT,
+    /**
+     * The middle mouse button, or a "scrollwheel click".
+     */
+    MIDDLE,
+    /**
+     * One of the number keys 1-9, correspond to slots on the hotbar.
+     */
+    NUMBER_KEY,
+    /**
+     * Pressing the left mouse button twice in quick succession.
+     */
+    DOUBLE_CLICK,
+    /**
+     * The "Drop" key (defaults to Q).
+     */
+    DROP,
+    /**
+     * Holding Ctrl while pressing the "Drop" key (defaults to Q).
+     */
+    CONTROL_DROP,
+    /**
+     * Any action done with the Creative inventory open.
+     */
+    CREATIVE,
+    /**
+     * A type of inventory manipulation not yet recognized by Bukkit.
+     * This is only for transitional purposes on a new Minecraft update,
+     * and should never be relied upon.
+     * <p>
+     * Any ClickType.UNKNOWN is called on a best-effort basis.
+     */
+    UNKNOWN,
+    ;
+
+    /**
+     * Gets whether this ClickType represents the pressing of a key on a
+     * keyboard.
+     *
+     * @return true if this ClickType represents the pressing of a key
+     */
+    public boolean isKeyboardClick() {
+        return (this == ClickType.NUMBER_KEY) || (this == ClickType.DROP) || (this == ClickType.CONTROL_DROP);
+    }
+
+    /**
+     * Gets whether this ClickType represents an action that can only be
+     * performed by a Player in creative mode.
+     *
+     * @return true if this action requires Creative mode
+     */
+    public boolean isCreativeAction() {
+        // Why use middle click?
+        return (this == ClickType.MIDDLE) || (this == ClickType.CREATIVE);
+    }
+
+    /**
+     * Gets whether this ClickType represents a right click.
+     *
+     * @return true if this ClickType represents a right click
+     */
+    public boolean isRightClick() {
+        return (this == ClickType.RIGHT) || (this == ClickType.SHIFT_RIGHT);
+    }
+
+    /**
+     * Gets whether this ClickType represents a left click.
+     *
+     * @return true if this ClickType represents a left click
+     */
+    public boolean isLeftClick() {
+        return (this == ClickType.LEFT) || (this == ClickType.SHIFT_LEFT) || (this == ClickType.DOUBLE_CLICK) || (this == ClickType.CREATIVE);
+    }
+
+    /**
+     * Gets whether this ClickType indicates that the shift key was pressed
+     * down when the click was made.
+     *
+     * @return true if the action uses Shift.
+     */
+    public boolean isShiftClick() {
+        return (this == ClickType.SHIFT_LEFT) || (this == ClickType.SHIFT_RIGHT) || (this == ClickType.CONTROL_DROP);
+    }
+}

--- a/src/main/java/org/bukkit/event/inventory/CraftItemEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/CraftItemEvent.java
@@ -8,8 +8,18 @@ import org.bukkit.inventory.Recipe;
 public class CraftItemEvent extends InventoryClickEvent {
     private Recipe recipe;
 
+    @Deprecated
     public CraftItemEvent(Recipe recipe, InventoryView what, SlotType type, int slot, boolean right, boolean shift) {
-        super(what, type, slot, right, shift);
+        this(recipe, what, type, slot, right ? (shift ? ClickType.SHIFT_RIGHT : ClickType.RIGHT) : (shift ? ClickType.SHIFT_LEFT : ClickType.LEFT), InventoryAction.PICKUP_ALL);
+    }
+
+    public CraftItemEvent(Recipe recipe, InventoryView what, SlotType type, int slot, ClickType click, InventoryAction action) {
+        super(what, type, slot, click, action);
+        this.recipe = recipe;
+    }
+
+    public CraftItemEvent(Recipe recipe, InventoryView what, SlotType type, int slot, ClickType click, InventoryAction action, int key) {
+        super(what, type, slot, click, action, key);
         this.recipe = recipe;
     }
 

--- a/src/main/java/org/bukkit/event/inventory/DragType.java
+++ b/src/main/java/org/bukkit/event/inventory/DragType.java
@@ -1,0 +1,18 @@
+package org.bukkit.event.inventory;
+
+/**
+ * Represents the effect of a drag that will be applied to an Inventory in an
+ * InventoryDragEvent.
+ */
+public enum DragType {
+    /**
+     * One item from the cursor is placed in each selected slot.
+     */
+    SINGLE,
+    /**
+     * The cursor is split evenly across all selected slots, not to
+     * exceed the Material's max stack size, with the remainder going to
+     * the cursor.
+     */
+    EVEN,
+}

--- a/src/main/java/org/bukkit/event/inventory/InventoryAction.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryAction.java
@@ -1,0 +1,90 @@
+package org.bukkit.event.inventory;
+
+/**
+ * An estimation of what the result will be.
+ */
+public enum InventoryAction {
+    /**
+     * Nothing will happen from the click.
+     * There may be cases where nothing will happen and this is value is
+     * not provided, but it is guaranteed that this value is accurate
+     * when given.
+     */
+    NOTHING,
+    /**
+     * All of the items on the clicked slot are moved to the cursor.
+     */
+    PICKUP_ALL,
+    /**
+     * Some of the items on the clicked slot are moved to the cursor.
+     */
+    PICKUP_SOME,
+    /**
+     * Half of the items on the clicked slot are moved to the cursor.
+     */
+    PICKUP_HALF,
+    /**
+     * One of the items on the clicked slot are moved to the cursor.
+     */
+    PICKUP_ONE,
+    /**
+     * All of the items on the cursor are moved to the clicked slot.
+     */
+    PLACE_ALL,
+    /**
+     * Some of the items from the cursor are moved to the clicked slot
+     * (usually up to the max stack size).
+     */
+    PLACE_SOME,
+    /**
+     * A single item from the cursor is moved to the clicked slot.
+     */
+    PLACE_ONE,
+    /**
+     * The clicked item and the cursor are exchanged.
+     */
+    SWAP_WITH_CURSOR,
+    /**
+     * The entire cursor item is dropped.
+     */
+    DROP_ALL_CURSOR,
+    /**
+     * One item is dropped from the cursor.
+     */
+    DROP_ONE_CURSOR,
+    /**
+     * The entire clicked slot is dropped.
+     */
+    DROP_ALL_SLOT,
+    /**
+     * One item is dropped from the clicked slot.
+     */
+    DROP_ONE_SLOT,
+    /**
+     * The item is moved to the opposite inventory if a space is found.
+     */
+    MOVE_TO_OTHER_INVENTORY,
+    /**
+     * The clicked item is moved to the hotbar, and the item currently
+     * there is re-added to the player's inventory.
+     */
+    HOTBAR_MOVE_AND_READD,
+    /**
+     * The clicked slot and the picked hotbar slot are swapped.
+     */
+    HOTBAR_SWAP,
+    /**
+     * A max-size stack of the clicked item is put on the cursor.
+     */
+    CLONE_STACK,
+    /**
+     * The inventory is searched for the same material, and they are put
+     * on the cursor up to {@link org.bukkit.Material#getMaxStackSize()}.
+     */
+    COLLECT_TO_CURSOR,
+    /**
+     * An unrecognized ClickType.
+     */
+    UNKNOWN,
+    ;
+}

--- a/src/main/java/org/bukkit/event/inventory/InventoryClickEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryClickEvent.java
@@ -3,121 +3,170 @@ package org.bukkit.event.inventory;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.entity.HumanEntity;
-import org.bukkit.event.Cancellable;
+import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.inventory.InventoryType.SlotType;
+import org.bukkit.Location;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.bukkit.plugin.Plugin;
 
-public class InventoryClickEvent extends InventoryEvent implements Cancellable {
+/**
+ * This event is called when a player clicks a slot in an inventory.
+ * <p>
+ * Because InventoryClickEvent occurs within a modification of the Inventory,
+ * not all Inventory related methods are safe to use.
+ * <p>
+ * The following should never be invoked by an EventHandler for
+ * InventoryClickEvent using the HumanEntity or InventoryView associated with
+ * this event:
+ * <ul>
+ * <li>{@link HumanEntity#closeInventory()}
+ * <li>{@link HumanEntity#openInventory(Inventory)}
+ * <li>{@link HumanEntity#openWorkbench(Location, boolean)}
+ * <li>{@link HumanEntity#openEnchanting(Location, boolean)}
+ * <li>{@link InventoryView#close()}
+ * </ul>
+ * To invoke one of these methods, schedule a task using 
+ * {@link BukkitScheduler#runTask(Plugin, Runnable)}, which will run the task
+ * on the next tick. Also be aware that this is not an exhaustive list, and
+ * other methods could potentially create issues as well.
+ * <p>
+ * Assuming the EntityHuman associated with this event is an instance of a
+ * Player, manipulating the MaxStackSize or contents of an Inventory will
+ * require an Invocation of {@link Player#updateInventory()}.
+ * <p>
+ * Modifications to slots that are modified by the results of this
+ * InventoryClickEvent can be overwritten. To change these slots, this event
+ * should be cancelled and all desired changes to the inventory applied.
+ * Alternatively, scheduling a task using {@link BukkitScheduler#runTask(
+ * Plugin, Runnable)}, which would execute the task on the next tick, would
+ * work as well.
+ */
+public class InventoryClickEvent extends InventoryInteractEvent {
     private static final HandlerList handlers = new HandlerList();
+    private final ClickType click;
+    private final InventoryAction action;
     private SlotType slot_type;
-    private boolean rightClick, shiftClick;
-    private Result result;
     private int whichSlot;
     private int rawSlot;
     private ItemStack current = null;
+    private int hotbarKey = -1;
 
-    public InventoryClickEvent(InventoryView what, SlotType type, int slot, boolean right, boolean shift) {
-        super(what);
+    @Deprecated
+    public InventoryClickEvent(InventoryView view, SlotType type, int slot, boolean right, boolean shift) {
+        this(view, type, slot, right ? (shift ? ClickType.SHIFT_RIGHT : ClickType.RIGHT) : (shift ? ClickType.SHIFT_LEFT : ClickType.LEFT), InventoryAction.SWAP_WITH_CURSOR);
+    }
+
+    public InventoryClickEvent(InventoryView view, SlotType type, int slot, ClickType click, InventoryAction action) {
+        super(view);
         this.slot_type = type;
-        this.rightClick = right;
-        this.shiftClick = shift;
-        this.result = Result.DEFAULT;
         this.rawSlot = slot;
-        this.whichSlot = what.convertSlot(slot);
+        this.whichSlot = view.convertSlot(slot);
+        this.click = click;
+        this.action = action;
+    }
+
+    public InventoryClickEvent(InventoryView view, SlotType type, int slot, ClickType click, InventoryAction action, int key) {
+        this(view, type, slot, click, action);
+        this.hotbarKey = key;
     }
 
     /**
-     * Get the type of slot that was clicked.
-     * @return The slot type.
+     * Gets the type of slot that was clicked.
+     *
+     * @return the slot type
      */
     public SlotType getSlotType() {
         return slot_type;
     }
 
     /**
-     * Get the current item on the cursor.
-     * @return The cursor item
+     * Gets the current ItemStack on the cursor.
+     *
+     * @return the cursor ItemStack
      */
     public ItemStack getCursor() {
         return getView().getCursor();
     }
 
     /**
-     * Get the current item in the clicked slot.
-     * @return The slot item.
+     * Gets the ItemStack currently in the clicked slot.
+     *
+     * @return the item in the clicked
      */
     public ItemStack getCurrentItem() {
-        if(slot_type == SlotType.OUTSIDE) return current;
+        if (slot_type == SlotType.OUTSIDE) {
+            return current;
+        }
         return getView().getItem(rawSlot);
     }
 
     /**
-     * @return True if the click is a right-click.
+     * Gets whether or not the ClickType for this event represents a right
+     * click.
+     *
+     * @return true if the ClickType uses the right mouse button.
+     * @see ClickType#isRightClick()
      */
     public boolean isRightClick() {
-        return rightClick;
+        return click.isRightClick();
     }
 
     /**
-     * @return True if the click is a left-click.
+     * Gets whether or not the ClickType for this event represents a left
+     * click.
+     *
+     * @return true if the ClickType uses the left mouse button.
+     * @see ClickType#isLeftClick()
      */
     public boolean isLeftClick() {
-        return !rightClick;
+        return click.isLeftClick();
     }
 
     /**
-     * Shift can be combined with right-click or left-click as a modifier.
-     * @return True if the click is a shift-click.
+     * Gets whether the ClickType for this event indicates that the key was
+     * pressed down when the click was made.
+     *
+     * @return true if the ClickType uses Shift or Ctrl.
+     * @see ClickType#isShiftClick()
      */
     public boolean isShiftClick() {
-        return shiftClick;
-    }
-
-    public void setResult(Result newResult) {
-        result = newResult;
-    }
-
-    public Result getResult() {
-        return result;
+        return click.isShiftClick();
     }
 
     /**
-     * Get the player who performed the click.
-     * @return The clicking player.
+     * Sets the item on the cursor.
+     *
+     * @param stack the new cursor item
+     * @deprecated This changes the ItemStack in their hand before any
+     *     calculations are applied to the Inventory, which has a tendency to
+     *     create inconsistencies between the Player and the server, and to
+     *     make unexpected changes in the behavior of the clicked Inventory.
      */
-    public HumanEntity getWhoClicked() {
-        return getView().getPlayer();
+    @Deprecated
+    public void setCursor(ItemStack stack) {
+        getView().setCursor(stack);
     }
 
     /**
-     * Set the item on the cursor.
-     * @param what The new cursor item.
+     * Sets the ItemStack currently in the clicked slot.
+     *
+     * @param stack the item to be placed in the current slot
      */
-    public void setCursor(ItemStack what) {
-        getView().setCursor(what);
+    public void setCurrentItem(ItemStack stack) {
+        if (slot_type == SlotType.OUTSIDE) {
+            current = stack;
+        } else {
+            getView().setItem(rawSlot, stack);
+        }
     }
 
     /**
-     * Set the current item in the slot.
-     * @param what The new slot item.
-     */
-    public void setCurrentItem(ItemStack what) {
-        if(slot_type == SlotType.OUTSIDE) current = what;
-        else getView().setItem(rawSlot, what);
-    }
-
-    public boolean isCancelled() {
-        return result == Result.DENY;
-    }
-
-    public void setCancelled(boolean toCancel) {
-        result = toCancel ? Result.DENY : Result.ALLOW;
-    }
-
-    /**
-     * The slot number that was clicked, ready for passing to {@link Inventory#getItem(int)}. Note
-     * that there may be two slots with the same slot number, since a view links two different inventories.
+     * The slot number that was clicked, ready for passing to
+     * {@link Inventory#getItem(int)}. Note that there may be two slots with
+     * the same slot number, since a view links two different inventories.
+     *
      * @return The slot number.
      */
     public int getSlot() {
@@ -125,11 +174,48 @@ public class InventoryClickEvent extends InventoryEvent implements Cancellable {
     }
 
     /**
-     * The raw slot number, which is unique for the view.
-     * @return The slot number.
+     * The raw slot number clicked, ready for passing to {@link InventoryView
+     * #getItem(int)} This slot number is unique for the view.
+     *
+     * @return the slot number
      */
     public int getRawSlot() {
         return rawSlot;
+    }
+
+    /**
+     * If the ClickType is NUMBER_KEY, this method will return the index of
+     * the pressed key (0-8).
+     *
+     * @return the number on the key minus 1 (range 0-8); or -1 if not
+     *     a NUMBER_KEY action
+     */
+    public int getHotbarButton() {
+        return hotbarKey;
+    }
+
+    /**
+     * Gets the InventoryAction that triggered this event.
+     * <p>
+     * This action cannot be changed, and represents what the normal outcome
+     * of the event will be. To change the behavior of this
+     * InventoryClickEvent, changes must be manually applied.
+     *
+     * @return the InventoryAction that triggered this event.
+     */
+    public InventoryAction getAction() {
+        return action;
+    }
+
+    /**
+     * Gets the ClickType for this event.
+     * <p>
+     * This is insulated against changes to the inventory by other plugins.
+     *
+     * @return the type of inventory click
+     */
+    public ClickType getClick() {
+        return click;
     }
 
     @Override

--- a/src/main/java/org/bukkit/event/inventory/InventoryCreativeEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryCreativeEvent.java
@@ -1,0 +1,27 @@
+package org.bukkit.event.inventory;
+
+import org.bukkit.event.inventory.InventoryType.SlotType;
+import org.bukkit.inventory.InventoryView;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * This event is called when a player in creative mode puts down or picks up
+ * an item in their inventory / hotbar and when they drop items from their
+ * Inventory while in creative mode.
+ */
+public class InventoryCreativeEvent extends InventoryClickEvent {
+    private ItemStack item;
+
+    public InventoryCreativeEvent(InventoryView what, SlotType type, int slot, ItemStack newItem) {
+        super(what, type, slot, ClickType.CREATIVE, InventoryAction.PLACE_ALL);
+        this.item = newItem;
+    }
+
+    public ItemStack getCursor() {
+        return item;
+    }
+
+    public void setCursor(ItemStack item) {
+        this.item = item;
+    }
+}

--- a/src/main/java/org/bukkit/event/inventory/InventoryDragEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryDragEvent.java
@@ -1,0 +1,164 @@
+package org.bukkit.event.inventory;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang.Validate;
+import org.bukkit.Location;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryView;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitScheduler;
+
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * This event is called when the player drags an item in their cursor across
+ * the inventory. The ItemStack is distributed across the slots the
+ * HumanEntity dragged over. The method of distribution is described by the 
+ * DragType returned by {@link #getType()}.
+ * <p>
+ * Canceling this event will result in none of the changes described in
+ * {@link #getNewItems()} being applied to the Inventory.
+ * <p>
+ * Because InventoryDragEvent occurs within a modification of the Inventory,
+ * not all Inventory related methods are safe to use.
+ * <p>
+ * The following should never be invoked by an EventHandler for
+ * InventoryDragEvent using the HumanEntity or InventoryView associated with
+ * this event.
+ * <ul>
+ * <li>{@link HumanEntity#closeInventory()}
+ * <li>{@link HumanEntity#openInventory(Inventory)}
+ * <li>{@link HumanEntity#openWorkbench(Location, boolean)}
+ * <li>{@link HumanEntity#openEnchanting(Location, boolean)}
+ * <li>{@link InventoryView#close()}
+ * </ul>
+ * To invoke one of these methods, schedule a task using 
+ * {@link BukkitScheduler#runTask(Plugin, Runnable)}, which will run the task
+ * on the next tick.  Also be aware that this is not an exhaustive list, and
+ * other methods could potentially create issues as well.
+ * <p>
+ * Assuming the EntityHuman associated with this event is an instance of a
+ * Player, manipulating the MaxStackSize or contents of an Inventory will
+ * require an Invocation of {@link Player#updateInventory()}.
+ * <p>
+ * Any modifications to slots that are modified by the results of this
+ * InventoryDragEvent will be overwritten. To change these slots, this event
+ * should be cancelled and the changes applied. Alternatively, scheduling a
+ * task using {@link BukkitScheduler#runTask(Plugin, Runnable)}, which would
+ * execute the task on the next tick, would work as well.
+ */
+public class InventoryDragEvent extends InventoryInteractEvent {
+    private static final HandlerList handlers = new HandlerList();
+    private final DragType type;
+    private final Map<Integer, ItemStack> addedItems;
+    private final Set<Integer> containerSlots;
+    private final ItemStack oldCursor;
+    private ItemStack newCursor;
+
+    public InventoryDragEvent(InventoryView what, ItemStack newCursor, ItemStack oldCursor, boolean right, Map<Integer, ItemStack> slots) {
+        super(what);
+
+        Validate.notNull(oldCursor);
+        Validate.notNull(slots);
+
+        type = right ? DragType.SINGLE : DragType.EVEN;
+        this.newCursor = newCursor;
+        this.oldCursor = oldCursor;
+        this.addedItems = slots;
+        ImmutableSet.Builder<Integer> b = ImmutableSet.builder();
+        for (Integer slot : slots.keySet()) {
+            b.add(what.convertSlot(slot));
+        }
+        this.containerSlots = b.build();
+    }
+
+    /**
+     * Gets all items to be added to the inventory in this drag.
+     *
+     * @return map from raw slot id to new ItemStack
+     */
+    public Map<Integer, ItemStack> getNewItems() {
+        return Collections.unmodifiableMap(addedItems);
+    }
+
+    /**
+     * Gets the raw slot ids to be changed in this drag.
+     *
+     * @return list of raw slot ids, suitable for getView().getItem(int)
+     */
+    public Set<Integer> getRawSlots() {
+        return addedItems.keySet();
+    }
+
+    /**
+     * Gets the slots to be changed in this drag.
+     *
+     * @return list of converted slot ids, suitable for {@link
+     *     org.bukkit.inventory.Inventory#getItem(int)}.
+     */
+    public Set<Integer> getInventorySlots() {
+        return containerSlots;
+    }
+
+    /**
+     * Gets the result cursor after the drag is done. The returned value is
+     * mutable.
+     *
+     * @return the result cursor
+     */
+    public ItemStack getCursor() {
+        return newCursor;
+    }
+
+    /**
+     * Sets the result cursor after the drag is done.
+     * <p>
+     * Changing this item stack changes the cursor item. Note that changing
+     * the affected "dragged" slots does not change this ItemStack, nor does
+     * changing this ItemStack affect the "dragged" slots.
+     *
+     * @param newCursor the new cursor ItemStack
+     */
+    public void setCursor(ItemStack newCursor) {
+        this.newCursor = newCursor;
+    }
+
+    /**
+     * Gets an ItemStack representing the cursor prior to any modifications
+     * as a result of this drag.
+     *
+     * @return the original cursor
+     */
+    public ItemStack getOldCursor() {
+        return oldCursor.clone();
+    }
+
+    /**
+     * Gets the DragType that describes the behavior of ItemStacks placed
+     * after this InventoryDragEvent.
+     * <p>
+     * The ItemStacks and the raw slots that they're being applied to can be
+     * found using {@link #getNewItems()}.
+     *
+     * @return the DragType of this InventoryDragEvent
+     */
+    public DragType getType() {
+        return type;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/org/bukkit/event/inventory/InventoryInteractEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryInteractEvent.java
@@ -1,0 +1,78 @@
+package org.bukkit.event.inventory;
+
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event.Result;
+import org.bukkit.inventory.InventoryView;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * An abstract base class for events that describe an interaction between a
+ * HumanEntity and the contents of an Inventory.
+ */
+public abstract class InventoryInteractEvent extends InventoryEvent implements Cancellable {
+    private Result result = Result.DEFAULT;
+
+    public InventoryInteractEvent(InventoryView transaction) {
+        super(transaction);
+    }
+
+    /**
+     * Gets the player who performed the click.
+     *
+     * @return The clicking player.
+     */
+    public HumanEntity getWhoClicked() {
+        return getView().getPlayer();
+    }
+
+    /**
+     * Sets the result of this event. This will change whether or not this
+     * event is considered cancelled.
+     *
+     * @see #isCancelled()
+     * @param newResult the new {@link Result} for this event
+     */
+    public void setResult(Result newResult) {
+        result = newResult;
+    }
+
+    /**
+     * Gets the {@link Result} of this event. The Result describes the
+     * behavior that will be applied to the inventory in relation to this
+     * event.
+     *
+     * @return the Result of this event.
+     */
+    public Result getResult() {
+        return result;
+    }
+
+    /**
+     * Gets whether or not this event is cancelled. This is based off of the
+     * Result value returned by {@link #getResult()}.  Result.ALLOW and
+     * Result.DEFAULT will result in a returned value of false, but
+     * Result.DENY will result in a returned value of true.
+     * <p>
+     * {@inheritDoc}
+     *
+     * @return whether the event is cancelled
+     */
+    public boolean isCancelled() {
+        return getResult() == Result.DENY;
+    }
+
+    /**
+     * Proxy method to {@link #setResult(Event.Result)} for the Cancellable
+     * interface. {@link #setResult(Event.Result)} is preferred, as it allows
+     * you to specify the Result beyond Result.DENY and Result.ALLOW.
+     * <p>
+     * {@inheritDoc}
+     *
+     * @param toCancel result becomes DENY if true, ALLOW if false
+     */
+    public void setCancelled(boolean toCancel) {
+        setResult(toCancel ? Result.DENY : Result.ALLOW);
+    }
+
+}

--- a/src/main/java/org/bukkit/event/inventory/InventoryMoveItemEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryMoveItemEvent.java
@@ -1,0 +1,109 @@
+package org.bukkit.event.inventory;
+
+import org.apache.commons.lang.Validate;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Called when some entity or block (e.g. hopper) tries to move items
+ * directly from one inventory to another.
+ *
+ * When this event is called, the initiator may already have removed the item
+ * from the source inventory and is ready to move it into the destination
+ * inventory.
+ *
+ * If this event is cancelled, the items will be returned to the source
+ * inventory, if needed.
+ *
+ * If this event is not cancelled, the initiator will try to put the
+ * ItemStack into the destination inventory. If this is not possible and the
+ * ItemStack has not been modified, the source inventory slot will be
+ * restored to its former state. Otherwise any additional items will be
+ * discarded.
+ */
+public class InventoryMoveItemEvent extends Event implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancelled;
+    private final Inventory sourceInventory;
+    private final Inventory destinationInventory;
+    private ItemStack itemStack;
+    private final boolean didSourceInitiate;
+
+    public InventoryMoveItemEvent(final Inventory sourceInventory, final ItemStack itemStack, final Inventory destinationInventory, final boolean didSourceInitiate) {
+        Validate.notNull(itemStack, "ItemStack cannot be null");
+        this.sourceInventory = sourceInventory;
+        this.itemStack = itemStack;
+        this.destinationInventory = destinationInventory;
+        this.didSourceInitiate = didSourceInitiate;
+    }
+
+    /**
+     * Gets the Inventory that the ItemStack is being taken from
+     *
+     * @return Inventory that the ItemStack is being taken from
+     */
+    public Inventory getSource() {
+        return sourceInventory;
+    }
+
+    /**
+     * Gets the ItemStack being moved; if modified, the original item will
+     * not be removed from the source inventory.
+     *
+     * @return ItemStack
+     */
+    public ItemStack getItem() {
+        return itemStack.clone();
+    }
+
+    /**
+     * Sets the ItemStack being moved; if this is different from the original
+     * ItemStack, the original item will not be removed from the source
+     * inventory.
+     *
+     * @param itemStack The ItemStack
+     */
+    public void setItem(ItemStack itemStack) {
+        Validate.notNull(itemStack, "ItemStack cannot be null.  Cancel the event if you want nothing to be transferred.");
+        this.itemStack = itemStack.clone();
+    }
+
+    /**
+     * Gets the Inventory that the ItemStack is being put into
+     *
+     * @return Inventory that the ItemStack is being put into
+     */
+    public Inventory getDestination() {
+        return destinationInventory;
+    }
+
+    /**
+     * Gets the Inventory that initiated the transfer.  This will always
+     * be either the destination or source Inventory.
+     *
+     * @return Inventory that initiated the transfer
+     */
+    public Inventory getInitiator() {
+        return didSourceInitiate ? sourceInventory : destinationInventory;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/org/bukkit/event/inventory/InventoryType.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryType.java
@@ -10,6 +10,10 @@ public enum InventoryType {
      */
     DISPENSER(9,"Dispenser"),
     /**
+     * A dropper inventory, with 9 slots of type CONTAINER.
+     */
+    DROPPER(9, "Dropper"),
+    /**
      * A furnace inventory, with a RESULT slot, a CRAFTING slot, and a FUEL slot.
      */
     FURNACE(3,"Furnace"),

--- a/src/main/java/org/bukkit/event/player/PlayerEggThrowEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerEggThrowEvent.java
@@ -102,7 +102,7 @@ public class PlayerEggThrowEvent extends PlayerEvent {
     /**
      * Get the number of mob hatches from the egg. By default the number
      * will be he number the server would've done
-     * <p />
+     * <p>
      * 7/8 chance of being 0
      * 31/256 ~= 1/8 chance to be 1
      * 1/256 chance to be 4
@@ -115,7 +115,7 @@ public class PlayerEggThrowEvent extends PlayerEvent {
 
     /**
      * Change the number of mobs coming out of the hatched egg
-     * <p />
+     * <p>
      * The boolean hatching will override this number.
      * Ie. If hatching = false, this number will not matter
      *

--- a/src/main/java/org/bukkit/event/player/PlayerFishEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerFishEvent.java
@@ -63,7 +63,7 @@ public class PlayerFishEvent extends PlayerEvent implements Cancellable {
 
     /**
      * Gets the amount of experience received when fishing.
-     * <p />
+     * <p>
      * Note: This value has no default effect unless the event state is {@link State#CAUGHT_FISH}.
      *
      * @return the amount of experience to drop
@@ -74,7 +74,7 @@ public class PlayerFishEvent extends PlayerEvent implements Cancellable {
 
     /**
      * Sets the amount of experience received when fishing.
-     * <p />
+     * <p>
      * Note: This value has no default effect unless the event state is {@link State#CAUGHT_FISH}.
      *
      * @param amount the amount of experience to drop

--- a/src/main/java/org/bukkit/event/player/PlayerFishEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerFishEvent.java
@@ -1,5 +1,6 @@
 package org.bukkit.event.player;
 
+import org.bukkit.entity.Fish;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.entity.Entity;
@@ -14,10 +15,24 @@ public class PlayerFishEvent extends PlayerEvent implements Cancellable {
     private boolean cancel = false;
     private int exp;
     private final State state;
+    private final Fish hookEntity;
 
+    /**
+     * @deprecated replaced by {@link #PlayerFishEvent(Player, Entity, Fish,
+     * State)} to include the {@link Fish} hook entity.
+     * @param player
+     * @param entity
+     * @param state
+     */
+    @Deprecated
     public PlayerFishEvent(final Player player, final Entity entity, final State state) {
+        this(player, entity, null, state);
+    }
+
+    public PlayerFishEvent(final Player player, final Entity entity, final Fish hookEntity, final State state) {
         super(player);
         this.entity = entity;
+        this.hookEntity = hookEntity;
         this.state = state;
     }
 
@@ -28,6 +43,14 @@ public class PlayerFishEvent extends PlayerEvent implements Cancellable {
      */
     public Entity getCaught() {
         return entity;
+    }
+
+    /**
+     * Gets the fishing hook.
+     * @return Fish the entity representing the fishing hook/bobber.
+     */
+    public Fish getHook() {
+        return hookEntity;
     }
 
     public boolean isCancelled() {

--- a/src/main/java/org/bukkit/event/player/PlayerInteractEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerInteractEvent.java
@@ -54,7 +54,7 @@ public class PlayerInteractEvent extends PlayerEvent implements Cancellable {
     /**
      * Sets the cancellation state of this event. A canceled event will not
      * be executed in the server, but will still pass to other plugins
-     * <p />
+     * <p>
      * Canceling this event will prevent use of food (player won't lose the
      * food item), prevent bows/snowballs/eggs from firing, etc. (player won't
      * lose the ammo)

--- a/src/main/java/org/bukkit/event/player/PlayerItemHeldEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerItemHeldEvent.java
@@ -1,13 +1,15 @@
 package org.bukkit.event.player;
 
 import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
 /**
  * Fired when a player changes their currently held item
  */
-public class PlayerItemHeldEvent extends PlayerEvent {
+public class PlayerItemHeldEvent extends PlayerEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
+    private boolean cancel = false;
     private final int previous;
     private final int current;
 
@@ -33,6 +35,14 @@ public class PlayerItemHeldEvent extends PlayerEvent {
      */
     public int getNewSlot() {
         return current;
+    }
+
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
     }
 
     @Override

--- a/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
@@ -23,7 +23,7 @@ public class PlayerMoveEvent extends PlayerEvent implements Cancellable {
     /**
      * Gets the cancellation state of this event. A cancelled event will not
      * be executed in the server, but will still pass to other plugins
-     * <p />
+     * <p>
      * If a move or teleport event is cancelled, the player will be moved or
      * teleported back to the Location as defined by getFrom(). This will not
      * fire an event
@@ -37,7 +37,7 @@ public class PlayerMoveEvent extends PlayerEvent implements Cancellable {
     /**
      * Sets the cancellation state of this event. A cancelled event will not
      * be executed in the server, but will still pass to other plugins
-     * <p />
+     * <p>
      * If a move or teleport event is cancelled, the player will be moved or
      * teleported back to the Location as defined by getFrom(). This will not
      * fire an event

--- a/src/main/java/org/bukkit/event/player/PlayerPickupItemEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerPickupItemEvent.java
@@ -21,7 +21,7 @@ public class PlayerPickupItemEvent extends PlayerEvent implements Cancellable {
     }
 
     /**
-     * Gets the ItemDrop created by the player
+     * Gets the Item picked up by the player.
      *
      * @return Item
      */

--- a/src/main/java/org/bukkit/event/world/ChunkPopulateEvent.java
+++ b/src/main/java/org/bukkit/event/world/ChunkPopulateEvent.java
@@ -6,7 +6,7 @@ import org.bukkit.generator.BlockPopulator;
 
 /**
  * Thrown when a new chunk has finished being populated.
- * <p />
+ * <p>
  * If your intent is to populate the chunk using this event, please see {@link BlockPopulator}
  */
 public class ChunkPopulateEvent extends ChunkEvent {

--- a/src/main/java/org/bukkit/generator/BlockPopulator.java
+++ b/src/main/java/org/bukkit/generator/BlockPopulator.java
@@ -11,7 +11,7 @@ import org.bukkit.World;
 public abstract class BlockPopulator {
     /**
      * Populates an area of blocks at or around the given chunk.
-     * <p />
+     * <p>
      * The chunks on each side of the specified chunk must already exist; that is,
      * there must be one north, east, south and west of the specified chunk.
      * The "corner" chunks may not exist, in which scenario the populator should

--- a/src/main/java/org/bukkit/generator/ChunkGenerator.java
+++ b/src/main/java/org/bukkit/generator/ChunkGenerator.java
@@ -39,7 +39,7 @@ public abstract class ChunkGenerator {
     @Deprecated
     /**
      * Shapes the chunk for the given coordinates.
-     * <p />
+     * <p>
      * This method should return a byte[32768] in the following format:
      *
      * <pre>
@@ -51,10 +51,10 @@ public abstract class ChunkGenerator {
      *     }
      * }
      * </pre>
-     * <p />
+     * <p>
      * Note that this method should <b>never</b> attempt to get the Chunk at
      * the passed coordinates, as doing so may cause an infinite loop
-     * <p />
+     * <p>
      * Note this deprecated method will only be called when both generateExtBlockSections()
      * and generateBlockSections() are unimplemented and return null.
 
@@ -70,10 +70,10 @@ public abstract class ChunkGenerator {
 
     /**
      * Shapes the chunk for the given coordinates, with extended block IDs supported (0-4095).
-     * <p />
+     * <p>
      * As of 1.2, chunks are represented by a vertical array of chunk sections, each of which is 16 x 16 x 16 blocks.  If a section
      * is empty (all zero), the section does not need to be supplied, reducing memory usage.
-     * <p />
+     * <p>
      * This method must return a short[][] array in the following format:
      * <pre>
      *     short[][] result = new short[world-height / 16][];
@@ -83,7 +83,7 @@ public abstract class ChunkGenerator {
      *     result[sectionID] = new short[4096];
      * </pre>
      * while sections that are not populated can be left null.
-     * <p />
+     * <p>
      * Setting a block at X, Y, Z within the chunk can be done with the following mapping function:
      * <pre>
      *    void setBlock(short[][] result, int x, int y, int z, short blkid) {
@@ -103,7 +103,7 @@ public abstract class ChunkGenerator {
      *    }
      * </pre>
      * while sections that are not populated can be left null.
-     * <p />
+     * <p>
      * Setting a block at X, Y, Z within the chunk can be done with the following mapping function:
      * <pre>
      *    void setBlock(short[][] result, int x, int y, int z, short blkid) {
@@ -122,10 +122,10 @@ public abstract class ChunkGenerator {
      *        return result[y >> 4][((y & 0xF) << 8) | (z << 4) | x];
      *    }
      * </pre>
-     * <p />
+     * <p>
      * Note that this method should <b>never</b> attempt to get the Chunk at
      * the passed coordinates, as doing so may cause an infinite loop
-     * <p />
+     * <p>
      * Note generators that do not return block IDs above 255 should not implement
      * this method, or should have it return null (which will result in the
      * generateBlockSections() method being called).
@@ -143,10 +143,10 @@ public abstract class ChunkGenerator {
 
     /**
      * Shapes the chunk for the given coordinates.
-     * <p />
+     * <p>
      * As of 1.2, chunks are represented by a vertical array of chunk sections, each of which is 16 x 16 x 16 blocks.  If a section
      * is empty (all zero), the section does not need to be supplied, reducing memory usage.
-     * <p />
+     * <p>
      * This method must return a byte[][] array in the following format:
      * <pre>
      *     byte[][] result = new byte[world-height / 16][];
@@ -156,7 +156,7 @@ public abstract class ChunkGenerator {
      *     result[sectionID] = new byte[4096];
      * </pre>
      * while sections that are not populated can be left null.
-     * <p />
+     * <p>
      * Setting a block at X, Y, Z within the chunk can be done with the following mapping function:
      * <pre>
      *    void setBlock(byte[][] result, int x, int y, int z, byte blkid) {
@@ -224,7 +224,7 @@ public abstract class ChunkGenerator {
 
     /**
      * Gets a fixed spawn location to use for a given world.
-     * <p />
+     * <p>
      * A null value is returned if a world should not use a fixed spawn point,
      * and will instead attempt to find one randomly.
      *

--- a/src/main/java/org/bukkit/inventory/EntityEquipment.java
+++ b/src/main/java/org/bukkit/inventory/EntityEquipment.java
@@ -97,7 +97,7 @@ public interface EntityEquipment {
 
     /**
      * Gets the chance of the currently held item being dropped upon this creature's death
-     * <p />
+     * <p>
      * <li />A drop chance of 0F will never drop
      * <li />A drop chance of 1F will always drop
      *
@@ -107,7 +107,7 @@ public interface EntityEquipment {
 
     /**
      * Sets the chance of the item this creature is currently holding being dropped upon this creature's death
-     * <p />
+     * <p>
      * <li />A drop chance of 0F will never drop
      * <li />A drop chance of 1F will always drop
      *
@@ -118,7 +118,7 @@ public interface EntityEquipment {
 
     /**
      * Gets the chance of the helmet being dropped upon this creature's death
-     * <p />
+     * <p>
      * <li />A drop chance of 0F will never drop
      * <li />A drop chance of 1F will always drop
      *
@@ -128,7 +128,7 @@ public interface EntityEquipment {
 
     /**
      * Sets the chance of the helmet being dropped upon this creature's death
-     * <p />
+     * <p>
      * <li />A drop chance of 0F will never drop
      * <li />A drop chance of 1F will always drop
      *
@@ -139,7 +139,7 @@ public interface EntityEquipment {
 
     /**
      * Gets the chance of the chest plate being dropped upon this creature's death
-     * <p />
+     * <p>
      * <li />A drop chance of 0F will never drop
      * <li />A drop chance of 1F will always drop
      *
@@ -149,7 +149,7 @@ public interface EntityEquipment {
 
     /**
      * Sets the chance of the chest plate being dropped upon this creature's death
-     * <p />
+     * <p>
      * <li />A drop chance of 0F will never drop
      * <li />A drop chance of 1F will always drop
      *
@@ -160,7 +160,7 @@ public interface EntityEquipment {
 
     /**
      * Gets the chance of the leggings being dropped upon this creature's death
-     * <p />
+     * <p>
      * <li />A drop chance of 0F will never drop
      * <li />A drop chance of 1F will always drop
      *
@@ -170,7 +170,7 @@ public interface EntityEquipment {
 
     /**
      * Sets the chance of the leggings being dropped upon this creature's death
-     * <p />
+     * <p>
      * <li />A drop chance of 0F will never drop
      * <li />A drop chance of 1F will always drop
      *
@@ -181,7 +181,7 @@ public interface EntityEquipment {
 
     /**
      * Gets the chance of the boots being dropped upon this creature's death
-     * <p />
+     * <p>
      * <li />A drop chance of 0F will never drop
      * <li />A drop chance of 1F will always drop
      *
@@ -191,7 +191,7 @@ public interface EntityEquipment {
 
     /**
      * Sets the chance of the boots being dropped upon this creature's death
-     * <p />
+     * <p>
      * <li />A drop chance of 0F will never drop
      * <li />A drop chance of 1F will always drop
      *

--- a/src/main/java/org/bukkit/inventory/Inventory.java
+++ b/src/main/java/org/bukkit/inventory/Inventory.java
@@ -29,7 +29,7 @@ public interface Inventory extends Iterable<ItemStack> {
 
     /**
      * This method allows you to change the maximum stack size for an inventory.
-     * <p /><b>Caveats:</b>
+     * <p><b>Caveats:</b>
      * <ul>
      * <li>Not all inventories respect this value.
      * <li>Stacks larger than 127 may be clipped when the world is saved.
@@ -68,12 +68,12 @@ public interface Inventory extends Iterable<ItemStack> {
     /**
      * Stores the given ItemStacks in the inventory.
      * This will try to fill existing stacks and empty slots as well as it can.
-     * <p />
+     * <p>
      * The returned HashMap contains what it couldn't store, where the key is the
      * index of the parameter, and the value is the ItemStack at that index
      * of the varargs parameter. If all items are stored, it will return an
      * empty HashMap.
-     * <p />
+     * <p>
      * If you pass in ItemStacks which exceed the maximum stack size for the
      * Material, first they will be added to partial stacks where
      * Material.getMaxStackSize() is not exceeded, up to
@@ -89,10 +89,10 @@ public interface Inventory extends Iterable<ItemStack> {
 
     /**
      * Removes the given ItemStacks from the inventory.
-     * <p />
+     * <p>
      * It will try to remove 'as much as possible' from the types and amounts you
      * give as arguments.
-     * <p />
+     * <p>
      * The returned HashMap contains what it couldn't remove, where the key is the
      * index of the parameter, and the value is the ItemStack at that index of the
      * varargs parameter. If all the given ItemStacks are removed, it will return
@@ -187,7 +187,7 @@ public interface Inventory extends Iterable<ItemStack> {
     /**
      * Returns a HashMap with all slots and ItemStacks in the inventory with
      * given materialId.
-     * <p />
+     * <p>
      * The HashMap contains entries where, the key is the slot index, and the
      * value is the ItemStack in that slot. If no matching ItemStack with the
      * given materialId is found, an empty map is returned.
@@ -200,7 +200,7 @@ public interface Inventory extends Iterable<ItemStack> {
     /**
      * Returns a HashMap with all slots and ItemStacks in the inventory with
      * the given Material.
-     * <p />
+     * <p>
      * The HashMap contains entries where, the key is the slot index, and the
      * value is the ItemStack in that slot. If no matching ItemStack with the
      * given Material is found, an empty map is returned.
@@ -214,7 +214,7 @@ public interface Inventory extends Iterable<ItemStack> {
     /**
      * Finds all slots in the inventory containing any ItemStacks with the given ItemStack
      * This will only match slots if both the type and the amount of the stack match
-     * <p />
+     * <p>
      * The HashMap contains entries where, the key is the
      * slot index, and the value is the ItemStack in that slot. If no matching
      * ImemStrack with the given Material is found, an empty map is returned.

--- a/src/main/java/org/bukkit/inventory/Inventory.java
+++ b/src/main/java/org/bukkit/inventory/Inventory.java
@@ -71,8 +71,15 @@ public interface Inventory extends Iterable<ItemStack> {
      * <p />
      * The returned HashMap contains what it couldn't store, where the key is the
      * index of the parameter, and the value is the ItemStack at that index
-     * of the variadic parameter. If all items are stored, it will return an
+     * of the varargs parameter. If all items are stored, it will return an
      * empty HashMap.
+     * <p />
+     * If you pass in ItemStacks which exceed the maximum stack size for the
+     * Material, first they will be added to partial stacks where
+     * Material.getMaxStackSize() is not exceeded, up to
+     * Material.getMaxStackSize(). When there are no partial stacks left
+     * stacks will be split on Inventory.getMaxStackSize() allowing you to
+     * exceed the maximum stack size for that material.
      *
      * @param items The ItemStacks to add
      * @return A HashMap containing items that didn't fit.
@@ -88,7 +95,7 @@ public interface Inventory extends Iterable<ItemStack> {
      * <p />
      * The returned HashMap contains what it couldn't remove, where the key is the
      * index of the parameter, and the value is the ItemStack at that index of the
-     * variadic parameter. If all the given ItemStacks are removed, it will return
+     * varargs parameter. If all the given ItemStacks are removed, it will return
      * an empty HashMap.
      *
      * @param items The ItemStacks to remove
@@ -169,12 +176,7 @@ public interface Inventory extends Iterable<ItemStack> {
     public boolean contains(ItemStack item, int amount);
 
     /**
-     * Returns a HashMap with all slots and ItemStacks in the inventory with
-     * given materialId.
-     * <p />
-     * The HashMap contains entries where, the key is the slot index, and the
-     * value is the ItemStack in that slot. If no matching ItemStack with the
-     * given materialId is found, an empty map is returned.
+     * Checks if the inventory contains any ItemStacks matching the given ItemStack and at least the minimum amount specified
      *
      * @param item The ItemStack to match against
      * @param amount The minimum amount
@@ -183,7 +185,12 @@ public interface Inventory extends Iterable<ItemStack> {
     public boolean containsAtLeast(ItemStack item, int amount);
 
     /**
-     * Find all slots in the inventory containing any ItemStacks with the given materialId.
+     * Returns a HashMap with all slots and ItemStacks in the inventory with
+     * given materialId.
+     * <p />
+     * The HashMap contains entries where, the key is the slot index, and the
+     * value is the ItemStack in that slot. If no matching ItemStack with the
+     * given materialId is found, an empty map is returned.
      *
      * @param materialId The materialId to look for
      * @return A HashMap containing the slot index, ItemStack pairs

--- a/src/main/java/org/bukkit/inventory/InventoryView.java
+++ b/src/main/java/org/bukkit/inventory/InventoryView.java
@@ -88,7 +88,7 @@ public abstract class InventoryView {
 
     /**
      * Sets one item in this inventory view by its raw slot ID.
-     * <p />
+     * <p>
      * Note: If slot ID -999 is chosen, it may be expected that the item is
      * dropped on the ground. This is not required behaviour, however.
      * @param slot The ID as returned by InventoryClickEvent.getRawSlot()

--- a/src/main/java/org/bukkit/inventory/ItemStack.java
+++ b/src/main/java/org/bukkit/inventory/ItemStack.java
@@ -148,7 +148,7 @@ public class ItemStack implements Cloneable, ConfigurationSerializable {
 
     /**
      * Sets the type of this item
-     * <p />
+     * <p>
      * Note that in doing so you will reset the MaterialData for this stack
      *
      * @param type New type to set the items in this stack to
@@ -170,7 +170,7 @@ public class ItemStack implements Cloneable, ConfigurationSerializable {
 
     /**
      * Sets the type id of this item
-     * <p />
+     * <p>
      * Note that in doing so you will reset the MaterialData for this stack
      *
      * @param type New type id to set the items in this stack to
@@ -381,7 +381,7 @@ public class ItemStack implements Cloneable, ConfigurationSerializable {
 
     /**
      * Adds the specified enchantments to this item stack.
-     * <p />
+     * <p>
      * This method is the same as calling {@link #addEnchantment(org.bukkit.enchantments.Enchantment, int)}
      * for each element of the map.
      *
@@ -400,7 +400,7 @@ public class ItemStack implements Cloneable, ConfigurationSerializable {
 
     /**
      * Adds the specified {@link Enchantment} to this item stack.
-     * <p />
+     * <p>
      * If this item stack already contained the given enchantment (at any level), it will be replaced.
      *
      * @param ench Enchantment to add
@@ -421,7 +421,7 @@ public class ItemStack implements Cloneable, ConfigurationSerializable {
 
     /**
      * Adds the specified enchantments to this item stack in an unsafe manner.
-     * <p />
+     * <p>
      * This method is the same as calling {@link #addUnsafeEnchantment(org.bukkit.enchantments.Enchantment, int)}
      * for each element of the map.
      *
@@ -436,9 +436,9 @@ public class ItemStack implements Cloneable, ConfigurationSerializable {
 
     /**
      * Adds the specified {@link Enchantment} to this item stack.
-     * <p />
+     * <p>
      * If this item stack already contained the given enchantment (at any level), it will be replaced.
-     * <p />
+     * <p>
      * This method is unsafe and will ignore level restrictions or item type. Use at your own
      * discretion.
      *

--- a/src/main/java/org/bukkit/inventory/PlayerInventory.java
+++ b/src/main/java/org/bukkit/inventory/PlayerInventory.java
@@ -103,6 +103,16 @@ public interface PlayerInventory extends Inventory {
     public int getHeldItemSlot();
 
     /**
+     * Set the slot number of the currently held item.
+     * <p>
+     * This validates whether the slot is between 0 and 8 inclusive.
+     *
+     * @param slot The new slot number
+     * @throws IllegalArgumentException Thrown if slot is not between 0 and 8 inclusive
+     */
+    public void setHeldItemSlot(int slot);
+
+    /**
      * Clears all matching items from the inventory. Setting either value to -1 will skip it's check,
      *  while setting both to -1 will clear all items in your inventory unconditionally.
      *

--- a/src/main/java/org/bukkit/inventory/ShapedRecipe.java
+++ b/src/main/java/org/bukkit/inventory/ShapedRecipe.java
@@ -96,6 +96,12 @@ public class ShapedRecipe implements Recipe {
      */
     public ShapedRecipe setIngredient(char key, Material ingredient, int raw) {
         Validate.isTrue(ingredients.containsKey(key), "Symbol does not appear in the shape:", key);
+
+        // -1 is the old wildcard, map to Short.MAX_VALUE as the new one
+        if (raw == -1) {
+            raw = Short.MAX_VALUE;
+        }
+
         ingredients.put(key, new ItemStack(ingredient, 1, (short) raw));
         return this;
     }

--- a/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
+++ b/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
@@ -97,6 +97,11 @@ public class ShapelessRecipe implements Recipe {
     public ShapelessRecipe addIngredient(int count, Material ingredient, int rawdata) {
         Validate.isTrue(ingredients.size() + count <= 9, "Shapeless recipes cannot have more than 9 ingredients");
 
+        // -1 is the old wildcard, map to Short.MAX_VALUE as the new one
+        if (rawdata == -1) {
+            rawdata = Short.MAX_VALUE;
+        }
+
         while (count-- > 0) {
             ingredients.add(new ItemStack(ingredient, 1, (short) rawdata));
         }

--- a/src/main/java/org/bukkit/inventory/meta/EnchantmentStorageMeta.java
+++ b/src/main/java/org/bukkit/inventory/meta/EnchantmentStorageMeta.java
@@ -61,5 +61,13 @@ public interface EnchantmentStorageMeta extends ItemMeta {
      */
     boolean removeStoredEnchant(Enchantment ench) throws IllegalArgumentException;
 
+    /**
+     * Checks if the specified enchantment conflicts with any enchantments in this ItemMeta.
+     *
+     * @param ench enchantment to test
+     * @return true if the enchantment conflicts, false otherwise
+     */
+    boolean hasConflictingStoredEnchant(Enchantment ench);
+
     EnchantmentStorageMeta clone();
 }

--- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
+++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
@@ -107,6 +107,14 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable {
      */
     boolean removeEnchant(Enchantment ench);
 
+   /**
+    * Checks if the specified enchantment conflicts with any enchantments in this ItemMeta.
+    *
+    * @param ench enchantment to test
+    * @return true if the enchantment conflicts, false otherwise
+    */
+    boolean hasConflictingEnchant(Enchantment ench);
+
     @SuppressWarnings("javadoc")
     ItemMeta clone();
 }

--- a/src/main/java/org/bukkit/material/Dispenser.java
+++ b/src/main/java/org/bukkit/material/Dispenser.java
@@ -33,6 +33,63 @@ public class Dispenser extends FurnaceAndDispenser {
         super(type, data);
     }
 
+    public void setFacingDirection(BlockFace face) {
+        byte data;
+
+        switch (face) {
+            case DOWN:
+                data = 0x0;
+                break;
+
+            case UP:
+                data = 0x1;
+                break;
+
+            case NORTH:
+                data = 0x2;
+                break;
+
+            case SOUTH:
+                data = 0x3;
+                break;
+
+            case WEST:
+                data = 0x4;
+                break;
+
+            case EAST:
+            default:
+                data = 0x5;
+        }
+
+        setData(data);
+    }
+
+    public BlockFace getFacing() {
+        int data = getData() & 0x7;
+
+        switch (data) {
+            case 0x0:
+                return BlockFace.DOWN;
+
+            case 0x1:
+                return BlockFace.UP;
+
+            case 0x2:
+                return BlockFace.NORTH;
+
+            case 0x3:
+                return BlockFace.SOUTH;
+
+            case 0x4:
+                return BlockFace.WEST;
+
+            case 0x5:
+            default:
+                return BlockFace.EAST;
+        }
+    }
+
     @Override
     public Dispenser clone() {
         return (Dispenser) super.clone();

--- a/src/main/java/org/bukkit/material/MaterialData.java
+++ b/src/main/java/org/bukkit/material/MaterialData.java
@@ -75,7 +75,7 @@ public class MaterialData implements Cloneable {
     /**
      * Creates a new ItemStack based on this MaterialData
      *
-     * @param amount The stack size of the new stak
+     * @param amount The stack size of the new stack
      * @return New ItemStack containing a copy of this MaterialData
      */
     public ItemStack toItemStack(int amount) {

--- a/src/main/java/org/bukkit/material/TrapDoor.java
+++ b/src/main/java/org/bukkit/material/TrapDoor.java
@@ -43,6 +43,26 @@ public class TrapDoor extends SimpleAttachableMaterialData implements Openable {
         setData(data);
     }
 
+    /**
+     * Test if trapdoor is inverted
+     * @return true if inverted (top half), false if normal (bottom half)
+     */
+    public boolean isInverted() {
+        return ((getData() & 0x8) != 0);
+    }
+
+    /**
+     * Set trapdoor inverted state
+     * @param inv - true if inverted (top half), false if normal (bottom half)
+     */
+    public void setInverted(boolean inv) {
+        int dat = getData() & 0x7;
+        if (inv) {
+            dat |= 0x8;
+        }
+        setData((byte) dat);
+    }
+
     public BlockFace getAttachedFace() {
         byte data = (byte) (getData() & 0x3);
 
@@ -65,7 +85,7 @@ public class TrapDoor extends SimpleAttachableMaterialData implements Openable {
     }
 
     public void setFacingDirection(BlockFace face) {
-        byte data = (byte) (getData() & 0x4);
+        byte data = (byte) (getData() & 0xC);
 
         switch (face) {
             case SOUTH:
@@ -84,7 +104,7 @@ public class TrapDoor extends SimpleAttachableMaterialData implements Openable {
 
     @Override
     public String toString() {
-        return (isOpen() ? "OPEN " : "CLOSED ") + super.toString() + " with hinges set " + getAttachedFace();
+        return (isOpen() ? "OPEN " : "CLOSED ") + super.toString() + " with hinges set " + getAttachedFace() + (isInverted() ? " inverted" : "");
     }
 
     @Override

--- a/src/main/java/org/bukkit/metadata/FixedMetadataValue.java
+++ b/src/main/java/org/bukkit/metadata/FixedMetadataValue.java
@@ -6,9 +6,15 @@ import java.util.concurrent.Callable;
 
 /**
  * A FixedMetadataValue is a special case metadata item that contains the same value forever after initialization.
- * Invalidating a FixedMetadataValue has no affect.
+ * Invalidating a FixedMetadataValue has no effect.
+ *
+ * This class extends LazyMetadataValue for historical reasons, even though it overrides all the implementation
+ * methods. it is possible that in the future that the inheritance hierarchy may change.
  */
 public class FixedMetadataValue extends LazyMetadataValue {
+    /** Store the internal value that is represented by this fixed value. */
+    private final Object internalValue;
+
     /**
      * Initializes a FixedMetadataValue with an Object
      *
@@ -16,10 +22,17 @@ public class FixedMetadataValue extends LazyMetadataValue {
      * @param value the value assigned to this metadata value.
      */
     public FixedMetadataValue(Plugin owningPlugin, final Object value) {
-        super(owningPlugin, CacheStrategy.CACHE_ETERNALLY, new Callable<Object>() {
-            public Object call() throws Exception {
-                return value;
-            }
-        });
+        super(owningPlugin);
+        this.internalValue = value;
+    }
+
+    @Override
+    public void invalidate() {
+
+    }
+
+    @Override
+    public Object value() {
+        return internalValue;
     }
 }

--- a/src/main/java/org/bukkit/metadata/LazyMetadataValue.java
+++ b/src/main/java/org/bukkit/metadata/LazyMetadataValue.java
@@ -16,7 +16,7 @@ import org.bukkit.plugin.Plugin;
 public class LazyMetadataValue extends MetadataValueAdapter implements MetadataValue {
     private Callable<Object> lazyValue;
     private CacheStrategy cacheStrategy;
-    private SoftReference<Object> internalValue = new SoftReference<Object>(null);
+    private SoftReference<Object> internalValue;
     private static final Object ACTUALLY_NULL = new Object();
 
     /**
@@ -40,9 +40,14 @@ public class LazyMetadataValue extends MetadataValueAdapter implements MetadataV
         super(owningPlugin);
         Validate.notNull(cacheStrategy, "cacheStrategy cannot be null");
         Validate.notNull(lazyValue, "lazyValue cannot be null");
-
+        this.internalValue = new SoftReference<Object>(null);
         this.lazyValue = lazyValue;
         this.cacheStrategy = cacheStrategy;
+    }
+
+    /** Protected special constructor used by FixedMetadataValue to bypass standard setup. */
+    protected LazyMetadataValue(Plugin owningPlugin) {
+        super(owningPlugin);
     }
 
     public Object value() {

--- a/src/main/java/org/bukkit/metadata/LazyMetadataValue.java
+++ b/src/main/java/org/bukkit/metadata/LazyMetadataValue.java
@@ -5,7 +5,6 @@ import java.util.concurrent.Callable;
 
 import org.apache.commons.lang.Validate;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.util.NumberConversions;
 
 /**
  * The LazyMetadataValue class implements a type of metadata that is not computed until another plugin asks for it.
@@ -14,11 +13,10 @@ import org.bukkit.util.NumberConversions;
  * or invalidated at the individual or plugin level. Once invalidated, the LazyMetadataValue will recompute its value
  * when asked.
  */
-public class LazyMetadataValue implements MetadataValue {
+public class LazyMetadataValue extends MetadataValueAdapter implements MetadataValue {
     private Callable<Object> lazyValue;
     private CacheStrategy cacheStrategy;
     private SoftReference<Object> internalValue = new SoftReference<Object>(null);
-    private Plugin owningPlugin;
     private static final Object ACTUALLY_NULL = new Object();
 
     /**
@@ -39,17 +37,12 @@ public class LazyMetadataValue implements MetadataValue {
      * @param lazyValue the lazy value assigned to this metadata value.
      */
     public LazyMetadataValue(Plugin owningPlugin, CacheStrategy cacheStrategy, Callable<Object> lazyValue) {
-        Validate.notNull(owningPlugin, "owningPlugin cannot be null");
+        super(owningPlugin);
         Validate.notNull(cacheStrategy, "cacheStrategy cannot be null");
         Validate.notNull(lazyValue, "lazyValue cannot be null");
 
         this.lazyValue = lazyValue;
-        this.owningPlugin = owningPlugin;
         this.cacheStrategy = cacheStrategy;
-    }
-
-    public Plugin getOwningPlugin() {
-        return owningPlugin;
     }
 
     public Object value() {
@@ -59,56 +52,6 @@ public class LazyMetadataValue implements MetadataValue {
             return null;
         }
         return value;
-    }
-
-    public int asInt() {
-        return NumberConversions.toInt(value());
-    }
-
-    public float asFloat() {
-        return NumberConversions.toFloat(value());
-    }
-
-    public double asDouble() {
-        return NumberConversions.toDouble(value());
-    }
-
-    public long asLong() {
-        return NumberConversions.toLong(value());
-    }
-
-    public short asShort() {
-        return NumberConversions.toShort(value());
-    }
-
-    public byte asByte() {
-        return NumberConversions.toByte(value());
-    }
-
-    public boolean asBoolean() {
-        Object value = value();
-        if (value instanceof Boolean) {
-            return (Boolean) value;
-        }
-
-        if (value instanceof Number) {
-            return ((Number) value).intValue() != 0;
-        }
-
-        if (value instanceof String) {
-            return Boolean.parseBoolean((String) value);
-        }
-
-        return value != null;
-    }
-
-    public String asString() {
-        Object value = value();
-
-        if (value == null) {
-            return "";
-        }
-        return value.toString();
     }
 
     /**

--- a/src/main/java/org/bukkit/metadata/MetadataValueAdapter.java
+++ b/src/main/java/org/bukkit/metadata/MetadataValueAdapter.java
@@ -1,5 +1,7 @@
 package org.bukkit.metadata;
 
+import java.lang.ref.WeakReference;
+
 import org.apache.commons.lang.Validate;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.util.NumberConversions;
@@ -13,15 +15,15 @@ import org.bukkit.util.NumberConversions;
  *
  */
 public abstract class MetadataValueAdapter implements MetadataValue {
-    protected final Plugin owningPlugin;
+    protected final WeakReference<Plugin> owningPlugin;
 
     protected MetadataValueAdapter(Plugin owningPlugin) {
         Validate.notNull(owningPlugin, "owningPlugin cannot be null");
-        this.owningPlugin = owningPlugin;
+        this.owningPlugin = new WeakReference<Plugin>(owningPlugin);
     }
 
     public Plugin getOwningPlugin() {
-        return owningPlugin;
+        return owningPlugin.get();
     }
 
     public int asInt() {

--- a/src/main/java/org/bukkit/metadata/MetadataValueAdapter.java
+++ b/src/main/java/org/bukkit/metadata/MetadataValueAdapter.java
@@ -1,0 +1,77 @@
+package org.bukkit.metadata;
+
+import org.apache.commons.lang.Validate;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.util.NumberConversions;
+
+/**
+ * Optional base class for facilitating MetadataValue implementations.
+ *
+ * This provides all the conversion functions for MetadataValue
+ * so that writing an implementation of MetadataValue is as simple
+ * as implementing value() and invalidate().
+ *
+ */
+public abstract class MetadataValueAdapter implements MetadataValue {
+    protected final Plugin owningPlugin;
+
+    protected MetadataValueAdapter(Plugin owningPlugin) {
+        Validate.notNull(owningPlugin, "owningPlugin cannot be null");
+        this.owningPlugin = owningPlugin;
+    }
+
+    public Plugin getOwningPlugin() {
+        return owningPlugin;
+    }
+
+    public int asInt() {
+        return NumberConversions.toInt(value());
+    }
+
+    public float asFloat() {
+        return NumberConversions.toFloat(value());
+    }
+
+    public double asDouble() {
+        return NumberConversions.toDouble(value());
+    }
+
+    public long asLong() {
+        return NumberConversions.toLong(value());
+    }
+
+    public short asShort() {
+        return NumberConversions.toShort(value());
+    }
+
+    public byte asByte() {
+        return NumberConversions.toByte(value());
+    }
+
+    public boolean asBoolean() {
+        Object value = value();
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+
+        if (value instanceof Number) {
+            return ((Number) value).intValue() != 0;
+        }
+
+        if (value instanceof String) {
+            return Boolean.parseBoolean((String) value);
+        }
+
+        return value != null;
+    }
+
+    public String asString() {
+        Object value = value();
+
+        if (value == null) {
+            return "";
+        }
+        return value.toString();
+    }
+
+}

--- a/src/main/java/org/bukkit/permissions/Permissible.java
+++ b/src/main/java/org/bukkit/permissions/Permissible.java
@@ -25,7 +25,7 @@ public interface Permissible extends ServerOperator {
 
     /**
      * Gets the value of the specified permission, if set.
-     * <p />
+     * <p>
      * If a permission override is not set on this object, the default value of the permission will be returned.
      *
      * @param name Name of the permission
@@ -35,7 +35,7 @@ public interface Permissible extends ServerOperator {
 
     /**
      * Gets the value of the specified permission, if set.
-     * <p />
+     * <p>
      * If a permission override is not set on this object, the default value of the permission will be returned
      *
      * @param perm Permission to get
@@ -91,7 +91,7 @@ public interface Permissible extends ServerOperator {
 
     /**
      * Recalculates the permissions for this object, if the attachments have changed values.
-     * <p />
+     * <p>
      * This should very rarely need to be called from a plugin.
      */
     public void recalculatePermissions();

--- a/src/main/java/org/bukkit/permissions/Permission.java
+++ b/src/main/java/org/bukkit/permissions/Permission.java
@@ -96,7 +96,7 @@ public class Permission {
 
     /**
      * Sets the default value of this permission.
-     * <p />
+     * <p>
      * This will not be saved to disk, and is a temporary operation until the server reloads permissions.
      * Changing this default will cause all {@link Permissible}s that contain this permission to recalculate their permissions
      *
@@ -122,7 +122,7 @@ public class Permission {
 
     /**
      * Sets the description of this permission.
-     * <p />
+     * <p>
      * This will not be saved to disk, and is a temporary operation until the server reloads permissions.
      *
      * @param value The new description to set
@@ -137,7 +137,7 @@ public class Permission {
 
     /**
      * Gets a set containing every {@link Permissible} that has this permission.
-     * <p />
+     * <p>
      * This set cannot be modified.
      *
      * @return Set containing permissibles with this permission
@@ -148,7 +148,7 @@ public class Permission {
 
     /**
      * Recalculates all {@link Permissible}s that contain this permission.
-     * <p />
+     * <p>
      * This should be called after modifying the children, and is automatically called after modifying the default value
      */
     public void recalculatePermissibles() {
@@ -163,7 +163,7 @@ public class Permission {
 
     /**
      * Adds this permission to the specified parent permission.
-     * <p />
+     * <p>
      * If the parent permission does not exist, it will be created and registered.
      *
      * @param name Name of the parent permission
@@ -199,7 +199,7 @@ public class Permission {
 
     /**
      * Loads a list of Permissions from a map of data, usually used from retrieval from a yaml file.
-     * <p />
+     * <p>
      * The data may contain a list of name:data, where the data contains the following keys:
      * default: Boolean true or false. If not specified, false.
      * children: Map<String, Boolean> of child permissions. If not specified, empty list.
@@ -226,7 +226,7 @@ public class Permission {
 
     /**
      * Loads a Permission from a map of data, usually used from retrieval from a yaml file.
-     * <p />
+     * <p>
      * The data may contain the following keys:
      * default: Boolean true or false. If not specified, false.
      * children: Map<String, Boolean> of child permissions. If not specified, empty list.
@@ -242,7 +242,7 @@ public class Permission {
 
     /**
      * Loads a Permission from a map of data, usually used from retrieval from a yaml file.
-     * <p />
+     * <p>
      * The data may contain the following keys:
      * default: Boolean true or false. If not specified, false.
      * children: Map<String, Boolean> of child permissions. If not specified, empty list.

--- a/src/main/java/org/bukkit/permissions/PermissionAttachment.java
+++ b/src/main/java/org/bukkit/permissions/PermissionAttachment.java
@@ -62,7 +62,7 @@ public class PermissionAttachment {
 
     /**
      * Gets a copy of all set permissions and values contained within this attachment.
-     * <p />
+     * <p>
      * This map may be modified but will not affect the attachment, as it is a copy.
      *
      * @return Copy of all permissions and values expressed by this attachment
@@ -94,7 +94,7 @@ public class PermissionAttachment {
 
     /**
      * Removes the specified permission from this attachment.
-     * <p />
+     * <p>
      * If the permission does not exist in this attachment, nothing will happen.
      *
      * @param name Name of the permission to remove
@@ -106,7 +106,7 @@ public class PermissionAttachment {
 
     /**
      * Removes the specified permission from this attachment.
-     * <p />
+     * <p>
      * If the permission does not exist in this attachment, nothing will happen.
      *
      * @param perm Permission to remove

--- a/src/main/java/org/bukkit/plugin/Plugin.java
+++ b/src/main/java/org/bukkit/plugin/Plugin.java
@@ -13,7 +13,7 @@ import com.avaje.ebean.EbeanServer;
 
 /**
  * Represents a Plugin
- * <p />
+ * <p>
  * The use of {@link PluginBase} is recommended for actual Implementation
  */
 public interface Plugin extends TabExecutor {
@@ -34,7 +34,7 @@ public interface Plugin extends TabExecutor {
 
     /**
      * Gets a {@link FileConfiguration} for this plugin, read through "config.yml"
-     * <p />
+     * <p>
      * If there is a default config.yml embedded in this plugin, it will be provided
      * as a default for this Configuration.
      *

--- a/src/main/java/org/bukkit/plugin/Plugin.java
+++ b/src/main/java/org/bukkit/plugin/Plugin.java
@@ -130,9 +130,20 @@ public interface Plugin extends TabExecutor {
     public void setNaggable(boolean canNag);
 
     /**
-     * Gets the {@link EbeanServer} tied to this plugin
+     * Gets the {@link EbeanServer} tied to this plugin. This will only be
+     * available if enabled in the {@link
+     * PluginDescriptionFile#isDatabaseEnabled()}
+     * <p>
+     * <i>For more information on the use of <a href="http://www.avaje.org/">
+     * Avaje Ebeans ORM</a>, see <a
+     * href="http://www.avaje.org/ebean/documentation.html">Avaje Ebeans
+     * Documentation</a></i>
+     * <p>
+     * <i>For an example using Ebeans ORM, see <a
+     * href="https://github.com/Bukkit/HomeBukkit">Bukkit's Homebukkit Plugin
+     * </a></i>
      *
-     * @return Ebean server instance
+     * @return ebean server instance or null if not enabled
      */
     public EbeanServer getDatabase();
 

--- a/src/main/java/org/bukkit/plugin/PluginBase.java
+++ b/src/main/java/org/bukkit/plugin/PluginBase.java
@@ -2,7 +2,7 @@ package org.bukkit.plugin;
 
 /**
  * Represents a base {@link Plugin}
- * <p />
+ * <p>
  * Extend this class if your plugin is not a {@link org.bukkit.plugin.java.JavaPlugin}
  */
 public abstract class PluginBase implements Plugin {

--- a/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
+++ b/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
@@ -7,6 +7,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.permissions.Permissible;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
 import org.yaml.snakeyaml.Yaml;
@@ -16,7 +21,148 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 /**
- * Provides access to a Plugins description file, plugin.yaml
+ * This type is the runtime-container for the information in the plugin.yml.
+ * All plugins must have a respective plugin.yml. For plugins written in java
+ * using the standard plugin loader, this file must be in the root of the jar
+ * file.
+ * <p>
+ * When Bukkit loads a plugin, it needs to know some basic information about
+ * it. It reads this information from a YAML file, 'plugin.yml'. This file
+ * consists of a set of attributes, each defined on a new line and with no
+ * indentation.
+ * <p>
+ * Every (almost* every) method corresponds with a specific entry in the
+ * plugin.yml. These are the <b>required</b> entries for every plugin.yml:
+ * <ul>
+ * <li>{@link #getName()} - <code>name</code>
+ * <li>{@link #getVersion()} - <code>version</code>
+ * <li>{@link #getMain()} - <code>main</code>
+ * </ul>
+ * <p>
+ * Failing to include any of these items will throw an exception and cause the
+ * server to ignore your plugin.
+ * <p>
+ * This is a list of the possible yaml keys, with specific details included in
+ * the respective method documentations:
+ * <table border=1>
+ * <tr>
+ *     <th>Node</th>
+ *     <th>Method</th>
+ *     <th>Summary</th>
+ * </tr><tr>
+ *     <td><code>name</code></td>
+ *     <td>{@link #getName()}</td>
+ *     <td>The unique name of plugin</td>
+ * </tr><tr>
+ *     <td><code>version</code></td>
+ *     <td>{@link #getVersion()}</td>
+ *     <td>A plugin revision identifier</td>
+ * </tr><tr>
+ *     <td><code>main</code></td>
+ *     <td>{@link #getMain()}</td>
+ *     <td>The plugin's initial class file</td>
+ * </tr><tr>
+ *     <td><code>author</code><br><code>authors</code></td>
+ *     <td>{@link #getAuthors()}</td>
+ *     <td>The plugin contributors</td>
+ * </tr><tr>
+ *     <td><code>description</code></td>
+ *     <td>{@link #getDescription()}</td>
+ *     <td>Human readable plugin summary</td>
+ * </tr><tr>
+ *     <td><code>website</code></td>
+ *     <td>{@link #getWebsite()}</td>
+ *     <td>The URL to the plugin's site</td>
+ * </tr><tr>
+ *     <td><code>prefix</code></td>
+ *     <td>{@link #getPrefix()}</td>
+ *     <td>The token to prefix plugin log entries</td>
+ * </tr><tr>
+ *     <td><code>database</code></td>
+ *     <td>{@link #isDatabaseEnabled()}</td>
+ *     <td>Indicator to enable database support</td>
+ * </tr><tr>
+ *     <td><code>load</code></td>
+ *     <td>{@link #getLoad()}</td>
+ *     <td>The phase of server-startup this plugin will load during</td>
+ * </tr><tr>
+ *     <td><code>depend</code></td>
+ *     <td>{@link #getDepend()}</td>
+ *     <td>Other required plugins</td>
+ * </tr><tr>
+ *     <td><code>softdepend</code></td>
+ *     <td>{@link #getSoftDepend()}</td>
+ *     <td>Other plugins that add functionality</td>
+ * </tr><tr>
+ *     <td><code>loadbefore</code></td>
+ *     <td>{@link #getLoadBefore()}</td>
+ *     <td>The inverse softdepend</td>
+ * </tr><tr>
+ *     <td><code>commands</code></td>
+ *     <td>{@link #getCommands()}</td>
+ *     <td>The commands the plugin will register</td>
+ * </tr><tr>
+ *     <td><code>permissions</code></td>
+ *     <td>{@link #getPermissions()}</td>
+ *     <td>The permissions the plugin will register</td>
+ * </tr><tr>
+ *     <td><code>default-permission</code></td>
+ *     <td>{@link #getPermissionDefault()}</td>
+ *     <td>The default {@link Permission#getDefault() default} permission
+ *         state for defined {@link #getPermissions() permissions} the plugin
+ *         will register</td>
+ * </tr>
+ * </table>
+ * <p>
+ * A plugin.yml example:<blockquote><pre>
+ *name: Inferno
+ *version: 1.4.1
+ *description: This plugin is so 31337. You can set yourself on fire.
+ *# We could place every author in the authors list, but chose not to for illustrative purposes
+ *# Also, having an author distinguishes that person as the project lead, and ensures their
+ *# name is displayed first
+ *author: CaptainInflamo
+ *authors: [Cogito, verrier, EvilSeph]
+ *website: http://www.curse.com/server-mods/minecraft/myplugin
+ *
+ *main: com.captaininflamo.bukkit.inferno.Inferno
+ *database: false
+ *depend: [NewFire, FlameWire]
+ *
+ *commands:
+ *  flagrate:
+ *    description: Set yourself on fire.
+ *    aliases: [combust_me, combustMe]
+ *    permission: inferno.flagrate
+ *    usage: Syntax error! Simply type /&lt;command&gt; to ignite yourself.
+ *  burningdeaths:
+ *    description: List how many times you have died by fire.
+ *    aliases: [burning_deaths, burningDeaths]
+ *    permission: inferno.burningdeaths
+ *    usage: |
+ *      /&lt;command&gt; [player]
+ *      Example: /&lt;command&gt; - see how many times you have burned to death
+ *      Example: /&lt;command&gt; CaptainIce - see how many times CaptainIce has burned to death
+ *
+ *permissions:
+ *  inferno.*:
+ *    description: Gives access to all Inferno commands
+ *    children:
+ *      inferno.flagrate: true
+ *      inferno.burningdeaths: true
+ *      inferno.burningdeaths.others: true
+ *  inferno.flagrate:
+ *    description: Allows you to ignite yourself
+ *    default: true
+ *  inferno.burningdeaths:
+ *    description: Allows you to see how many times you have burned to death
+ *    default: true
+ *  inferno.burningdeaths.others:
+ *    description: Allows you to see how many times others have burned to death
+ *    default: op
+ *    children:
+ *      inferno.burningdeaths: true
+ *</pre></blockquote>
  */
 public final class PluginDescriptionFile {
     private static final Yaml yaml = new Yaml(new SafeConstructor());
@@ -46,7 +192,8 @@ public final class PluginDescriptionFile {
      * Loads a PluginDescriptionFile from the specified reader
      *
      * @param reader The reader
-     * @throws InvalidDescriptionException If the PluginDescriptionFile is invalid
+     * @throws InvalidDescriptionException If the PluginDescriptionFile is
+     *     invalid
      */
     public PluginDescriptionFile(final Reader reader) throws InvalidDescriptionException {
         loadMap(asMap(yaml.load(reader)));
@@ -66,99 +213,522 @@ public final class PluginDescriptionFile {
     }
 
     /**
-     * Saves this PluginDescriptionFile to the given writer
+     * Gives the name of the plugin. This name is a unique identifier for
+     * plugins.
+     * <ul>
+     * <li>Must consist of all alphanumeric characters, underscores, hyphon,
+     *     and period (a-z,A-Z,0-9, _.-). Any other character will cause the
+     *     plugin.yml to fail loading.
+     * <li>Used to determine the name of the plugin's data folder. Data
+     *     folders are placed in the ./plugins/ directory by default, but this
+     *     behavior should not be relied on. {@link Plugin#getDataFolder()}
+     *     should be used to reference the data folder.
+     * <li>It is good practice to name your jar the same as this, for example
+     *     'MyPlugin.jar'.
+     * <li>Case sensitive.
+     * <li>The is the token referenced in {@link #getDepend()}, {@link
+     *     #getSoftDepend()}, and {@link #getLoadBefore()}.
+     * </ul>
+     * <p>
+     * In the plugin.yml, this entry is named <code>name</code>.
+     * <p>
+     * Example:<blockquote><pre>name: MyPlugin</pre></blockquote>
      *
-     * @param writer Writer to output this file to
-     */
-    public void save(Writer writer) {
-        yaml.dump(saveMap(), writer);
-    }
-
-    /**
-     * Returns the name of a plugin
-     *
-     * @return String name
+     * @return the name of the plugin
      */
     public String getName() {
         return name;
     }
 
     /**
-     * Returns the version of a plugin
+     * Gives the version of the plugin.
+     * <ul>
+     * <li>Version is an arbitrary string, however the most common format is
+     *     MajorRelease.MinorRelease.Build (eg: 1.4.1).
+     * <li>Typically you will increment this every time you release a new
+     *     feature or bug fix.
+     * <li>Displayed when a user types <code>/version PluginName</code>
+     * </ul>
+     * <p>
+     * In the plugin.yml, this entry is named <code>version</code>.
+     * <p>
+     * Example:<blockquote><pre>version: 1.4.1</pre></blockquote>
      *
-     * @return String name
+     * @return the version of the plugin
      */
     public String getVersion() {
         return version;
     }
 
     /**
-     * Returns the name of a plugin including the version
+     * Gives the fully qualified name of the main class for a plugin. The
+     * format should follow the {@link ClassLoader#loadClass(String)} syntax
+     * to successfully be resolved at runtime. For most plugins, this is the
+     * class that extends {@link JavaPlugin}.
+     * <ul>
+     * <li>This must contain the full namespace including the class file
+     *     itself.
+     * <li>If your namespace is <code>org.bukkit.plugin</code>, and your class
+     *     file is called <code>MyPlugin</code> then this must be
+     *     <code>org.bukkit.plugin.MyPlugin</code>
+     * <li>No plugin can use <code>org.bukkit.</code> as a base package for
+     *     <b>any class</b>, including the main class.
+     * </ul>
+     * <p>
+     * In the plugin.yml, this entry is named <code>main</code>.
+     * <p>
+     * Example:
+     * <blockquote><pre>main: org.bukkit.plugin.MyPlugin</pre></blockquote>
      *
-     * @return String name
-     */
-    public String getFullName() {
-        return name + " v" + version;
-    }
-
-    /**
-     * Returns the main class for a plugin
-     *
-     * @return Java classpath
+     * @return the fully qualified main class for the plugin
      */
     public String getMain() {
         return main;
     }
 
-    public Map<String, Map<String, Object>> getCommands() {
-        return commands;
-    }
-
-    public List<String> getDepend() {
-        return depend;
-    }
-
-    public List<String> getSoftDepend() {
-        return softDepend;
-    }
-
     /**
-     * Gets the list of plugins that should consider this plugin a soft-dependency
-     * @return immutable list of plugins that should consider this plugin a soft-dependency
-     */
-    public List<String> getLoadBefore() {
-        return loadBefore;
-    }
-
-    public PluginLoadOrder getLoad() {
-        return order;
-    }
-
-    /**
-     * Gets the description of this plugin
+     * Gives a human-friendly description of the functionality the plugin
+     * provides.
+     * <ul>
+     * <li>The description can have multiple lines.
+     * <li>Displayed when a user types <code>/version PluginName</code>
+     * </ul>
+     * <p>
+     * In the plugin.yml, this entry is named <code>description</code>.
+     * <p>
+     * Example:
+     * <blockquote><pre>description: This plugin is so 31337. You can set yourself on fire.</pre></blockquote>
      *
-     * @return Description of this plugin
+     * @return description of this plugin, or null if not specified
      */
     public String getDescription() {
         return description;
     }
 
+    /**
+     * Gives the phase of server startup that the plugin should be loaded.
+     * <ul>
+     * <li>Possible values are in {@link PluginLoadOrder}.
+     * <li>Defaults to {@link PluginLoadOrder#POSTWORLD}.
+     * <li>Certain caveats apply to each phase.
+     * <li>When different, {@link #getDepend()}, {@link #getSoftDepend()}, and
+     *     {@link #getLoadBefore()} become relative in order loaded per-phase.
+     *     If a plugin loads at <code>STARTUP</code>, but a dependency loads
+     *     at <code>POSTWORLD</code>, the dependency will not be loaded before
+     *     the plugin is loaded.
+     * </ul>
+     * <p>
+     * In the plugin.yml, this entry is named <code>load</code>.
+     * <p>
+     * Example:<blockquote><pre>load: STARTUP</pre></blockquote>
+     *
+     * @return the phase when the plugin should be loaded
+     */
+    public PluginLoadOrder getLoad() {
+        return order;
+    }
+
+    /**
+     * Gives the list of authors for the plugin.
+     * <ul>
+     * <li>Gives credit to the developer.
+     * <li>Used in some server error messages to provide helpful feedback on
+     *     who to contact when an error occurs.
+     * <li>A bukkit.org forum handle or email address is recommended.
+     * <li>Is displayed when a user types <code>/version PluginName</code>
+     * <li><code>authors</code> must be in <a
+     *     href="http://en.wikipedia.org/wiki/YAML#Lists">YAML list
+     *     format</a>.
+     * </ul>
+     * <p>
+     * In the plugin.yml, this has two entries, <code>author</code> and
+     * <code>authors</code>.
+     * <p>
+     * Single author example:
+     * <blockquote><pre>author: CaptainInflamo</pre></blockquote>
+     * Multiple author example:
+     * <blockquote><pre>authors: [Cogito, verrier, EvilSeph]</pre></blockquote>
+     * When both are specified, author will be the first entry in the list, so
+     * this example:
+     * <blockquote><pre>author: Grum
+     *authors:
+     *- feildmaster
+     *- amaranth</pre></blockquote>
+     * Is equivilant to this example:
+     * <blockquote><pre>authors: [Grum, feildmaster, aramanth]<pre></blockquote>
+     *
+     * @return an immutable list of the plugin's authors
+     */
     public List<String> getAuthors() {
         return authors;
     }
 
+    /**
+     * Gives the plugin's or plugin's author's website.
+     * <ul>
+     * <li>A link to the Curse page that includes documentation and downloads
+     *     is highly recommended.
+     * <li>Displayed when a user types <code>/version PluginName</code>
+     * </ul>
+     * <p>
+     * In the plugin.yml, this entry is named <code>website</code>.
+     * <p>
+     * Example:
+     * <blockquote><pre>website: http://www.curse.com/server-mods/minecraft/myplugin</pre></blockquote>
+     *
+     * @return description of this plugin, or null if not specified
+     */
     public String getWebsite() {
         return website;
     }
 
+    /**
+     * Gives if the plugin uses a database.
+     * <ul>
+     * <li>Using a database is non-trivial.
+     * <li>Valid values include <code>true</code> and <code>false</code>
+     * </ul>
+     * <p>
+     * In the plugin.yml, this entry is named <code>database</code>.
+     * <p>
+     * Example:
+     * <blockquote><pre>database: false</pre></blockquote>
+     *
+     * @return if this plugin requires a database
+     * @see Plugin#getDatabase()
+     */
     public boolean isDatabaseEnabled() {
         return database;
     }
 
-    public void setDatabaseEnabled(boolean database) {
-        this.database = database;
+    /**
+     * Gives a list of other plugins that the plugin requires.
+     * <ul>
+     * <li>Use the value in the {@link #getName()} of the target plugin to
+     *     specify the dependency.
+     * <li>If any plugin listed here is not found, your plugin will fail to
+     *     load at startup.
+     * <li>If multiple plugins list each other in <code>depend</code>,
+     *     creating a network with no individual plugin does not list another
+     *     plugin in the <a
+     *     href=https://en.wikipedia.org/wiki/Circular_dependency>network</a>,
+     *     all plugins in that network will fail.
+     * <li><code>depend</code> must be in must be in <a
+     *     href="http://en.wikipedia.org/wiki/YAML#Lists">YAML list
+     *     format</a>.
+     * </ul>
+     * <p>
+     * In the plugin.yml, this entry is named <code>depend</code>.
+     * <p>
+     * Example:
+     * <blockquote><pre>depend:
+     *- OnePlugin
+     *- AnotherPlugin</pre></blockquote>
+     *
+     * @return immutable list of the plugin's dependencies
+     */
+    public List<String> getDepend() {
+        return depend;
     }
 
+    /**
+     * Gives a list of other plugins that the plugin requires for full
+     * functionality. The {@link PluginManager} will make best effort to treat
+     * all entries here as if they were a {@link #getDepend() dependency}, but
+     * will never fail because of one of these entries.
+     * <ul>
+     * <li>Use the value in the {@link #getName()} of the target plugin to
+     *     specify the dependency.
+     * <li>When an unresolvable plugin is listed, it will be ignored and does
+     *     not affect load order.
+     * <li>When a circular dependency occurs (a network of plugins depending
+     *     or soft-dependending each other), it will arbitrarily choose a
+     *     plugin that can be resolved when ignoring soft-dependencies.
+     * <li><code>softdepend</code> must be in <a
+     *     href="http://en.wikipedia.org/wiki/YAML#Lists">YAML list
+     *     format</a>.
+     * </ul>
+     * <p>
+     * In the plugin.yml, this entry is named <code>softdepend</code>.
+     * <p>
+     * Example:
+     * <blockquote><pre>softdepend: [OnePlugin, AnotherPlugin]</pre></blockquote>
+     *
+     * @return immutable list of the plugin's preferred dependencies
+     */
+    public List<String> getSoftDepend() {
+        return softDepend;
+    }
+
+    /**
+     * Gets the list of plugins that should consider this plugin a
+     * soft-dependency.
+     * <ul>
+     * <li>Use the value in the {@link #getName()} of the target plugin to
+     *     specify the dependency.
+     * <li>The plugin should load before any other plugins listed here.
+     * <li>Specifying another plugin here is strictly equivalent to having the
+     *     specified plugin's {@link #getSoftDepend()} include {@link
+     *     #getName() this plugin}.
+     * <li><code>loadbefore</code> must be in <a
+     *     href="http://en.wikipedia.org/wiki/YAML#Lists">YAML list
+     *     format</a>.
+     * </ul>
+     * <p>
+     * In the plugin.yml, this entry is named <code>loadbefore</code>.
+     * <p>
+     * Example:
+     * <blockquote><pre>loadbefore:
+     *- OnePlugin
+     *- AnotherPlugin</pre></blockquote>
+     *
+     * @return immutable list of plugins that should consider this plugin a
+     *     soft-dependency
+     */
+    public List<String> getLoadBefore() {
+        return loadBefore;
+    }
+
+    /**
+     * Gives the token to prefix plugin-specific logging messages with.
+     * <ul>
+     * <li>This includes all messages using {@link Plugin#getLogger()}.
+     * <li>If not specified, the server uses the plugin's {@link #getName()
+     *     name}.
+     * <li>This should clearly indicate what plugin is being logged.
+     * </ul>
+     * <p>
+     * In the plugin.yml, this entry is named <code>prefix</code>.
+     * <p>
+     * Example:<blockquote><pre>prefix: ex-why-zee</pre></blockquote>
+     *
+     * @return the prefixed logging token, or null if not specified
+     */
+    public String getPrefix() {
+        return prefix;
+    }
+
+    /**
+     * Gives the map of command-name to command-properties. Each entry in this
+     * map corresponds to a single command and the respective values are the
+     * properties of the command. Each property, <i>with the exception of
+     * aliases</i>, can be defined at runtime using methods in {@link
+     * PluginCommand} and are defined here only as a convenience.
+     * <table border=1>
+     * <tr>
+     *     <th>Node</th>
+     *     <th>Method</th>
+     *     <th>Type</th>
+     *     <th>Description</th>
+     *     <th>Example</th>
+     * </tr><tr>
+     *     <td><code>description</code></td>
+     *     <td>{@link PluginCommand#setDescription(String)}</td>
+     *     <td>String</td>
+     *     <td>A user-friendly description for a command. It is useful for
+     *         documentation purposes as well as in-game help.</td>
+     *     <td><blockquote><pre>description: Set yourself on fire</pre></blockquote></td>
+     * </tr><tr>
+     *     <td><code>aliases</code></td>
+     *     <td>{@link PluginCommand#setAliases(List)}</td>
+     *     <td>String or <a
+     *         href="http://en.wikipedia.org/wiki/YAML#Lists">List</a> of
+     *         strings</td>
+     *     <td>Alternative command names, with special usefulness for commands
+     *         that are already registered. <i>Aliases are not effective when
+     *         defined at runtime,</i> so the plugin description file is the
+     *         only way to have them properly defined.</td>
+     *     <td>Single alias format:
+     *         <blockquote><pre>aliases: combust_me</pre></blockquote> or
+     *         multiple alias format:
+     *         <blockquote><pre>aliases: [combust_me, combustMe]</pre></blockquote></td>
+     * </tr><tr>
+     *     <td><code>permission</code></td>
+     *     <td>{@link PluginCommand#setPermission(String)}</td>
+     *     <td>String</td>
+     *     <td>The name of the {@link Permission} required to use the command.
+     *         A user without the permission will receive the specified
+     *         message (see {@linkplain
+     *         PluginCommand#setPermissionMessage(String) below}), or a
+     *         standard one if no specific message is defined. Without the
+     *         permission node, no {@link
+     *         PluginCommand#setExecutor(CommandExecutor) CommandExecutor} or
+     *         {@link PluginCommand#setTabCompleter(TabCompleter)
+     *         TabCompleter} will be called.</td>
+     *     <td><blockquote><pre>permission: inferno.flagrate</pre></blockquote></td>
+     * </tr><tr>
+     *     <td><code>permission-message</code></td>
+     *     <td>{@link PluginCommand#setPermissionMessage(String)}</td>
+     *     <td>String</td>
+     *     <td><ul>
+     *         <li>Displayed to a player that attempts to use a command, but
+     *             does not have the required permission. See {@link
+     *             PluginCommand#getPermission() above}.
+     *         <li>&lt;permission&gt; is a macro that is replaced with the
+     *             permission node required to use the command.
+     *         <li>Using empty quotes is a valid way to indicate nothing
+     *             should be displayed to a player.
+     *         </ul></td>
+     *     <td><blockquote><pre>permission-message: You do not have /&lt;permission&gt;</pre></blockquote></td>
+     * </tr><tr>
+     *     <td><code>usage</code></td>
+     *     <td>{@link PluginCommand#setUsage(String)}</td>
+     *     <td>String</td>
+     *     <td>This message is displayed to a player when the {@link
+     *         PluginCommand#setExecutor(CommandExecutor)} {@linkplain
+     *         CommandExecutor#onCommand(CommandSender,Command,String,String[])
+     *         returns false}. &lt;command&gt; is a macro that is replaced
+     *         the command issued.</td>
+     *     <td><blockquote><pre>usage: Syntax error! Perhaps you meant /&lt;command&gt; PlayerName?</pre></blockquote>
+     *         It is worth noting that to use a colon in a yaml, like
+     *         <code>`usage: Usage: /god [player]'</code>, you need to
+     *         <a href="http://yaml.org/spec/current.html#id2503232">surround
+     *         the message with double-quote</a>:
+     *         <blockquote><pre>usage: "Usage: /god [player]"</pre></blockquote></td>
+     * </tr>
+     * </table>
+     * The commands are structured as a hiearchy of <a
+     * href="http://yaml.org/spec/current.html#id2502325">nested mappings</a>.
+     * The primary (top-level, no intendentation) node is
+     * `<code>commands</code>', while each individual command name is
+     * indented, indicating it maps to some value (in our case, the
+     * properties of the table above).
+     * <p>
+     * Here is an example bringing together the piecemeal examples above, as
+     * well as few more definitions:<blockquote><pre>
+     *commands:
+     *  flagrate:
+     *    description: Set yourself on fire.
+     *    aliases: [combust_me, combustMe]
+     *    permission: inferno.flagrate
+     *    permission-message: You do not have /&lt;permission&gt;
+     *    usage: Syntax error! Perhaps you meant /&lt;command&gt; PlayerName?
+     *  burningdeaths:
+     *    description: List how many times you have died by fire.
+     *    aliases:
+     *    - burning_deaths
+     *    - burningDeaths
+     *    permission: inferno.burningdeaths
+     *    usage: |
+     *      /&lt;command&gt; [player]
+     *      Example: /&lt;command&gt; - see how many times you have burned to death
+     *      Example: /&lt;command&gt; CaptainIce - see how many times CaptainIce has burned to death
+     *  # The next command has no description, aliases, etc. defined, but is still valid
+     *  # Having an empty declaration is useful for defining the description, permission, and messages from a configuration dynamically
+     *  apocalypse:
+     *</pre></blockquote>
+     *
+     * @return the commands this plugin will register
+     */
+    public Map<String, Map<String, Object>> getCommands() {
+        return commands;
+    }
+
+    /**
+     * Gives the list of permissions the plugin will register at runtime,
+     * immediately proceding enabling. The format for defining permissions is
+     * a map from permission name to properties. To represent a map without
+     * any specific property, empty <a
+     * href="http://yaml.org/spec/current.html#id2502702">curly-braces</a> (
+     * <code>&#123;&#125;</code> ) may be used (as a null value is not
+     * accepted, unlike the {@link #getCommands() commands} above).
+     * <p>
+     * A list of optional properties for permissions:
+     * <table border=1>
+     * <tr>
+     *     <th>Node</th>
+     *     <th>Description</th>
+     *     <th>Example</th>
+     * </tr><tr>
+     *     <td><code>description</code></td>
+     *     <td>Plaintext (user-friendly) description of what the permission
+     *         is for.</td>
+     *     <td><blockquote><pre>description: Allows you to set yourself on fire</pre></blockquote></td>
+     * </tr><tr>
+     *     <td><code>default</code></td>
+     *     <td>The default state for the permission, as defined by {@link
+     *         Permission#getDefault()}. If not defined, it will be set to
+     *         the value of {@link PluginDescriptionFile#getPermissionDefault()}.
+     *         <p>
+     *         For reference:<ul>
+     *         <li><code>true</code> - Represents a positive assignment to
+     *             {@link Permissible permissibles}.
+     *         <li><code>false</code> - Represents no assignment to {@link
+     *             Permissible permissibles}.
+     *         <li><code>op</code> - Represents a positive assignment to
+     *             {@link Permissible#isOp() operator permissibles}.
+     *         <li><code>notop</code> - Represents a positive assignment to
+     *             {@link Permissible#isOp() non-operator permissibiles}.
+     *         </ul></td>
+     *     <td><blockquote><pre>default: true</pre></blockquote></td>
+     * </tr><tr>
+     *     <td><code>children</code></td>
+     *     <td>Allows other permissions to be set as a {@linkplain
+     *         Permission#getChildren() relation} to the parent permission.
+     *         When a parent permissions is assigned, child permissions are
+     *         respectively assigned as well.
+     *         <ul>
+     *         <li>When a parent permission is assigned negatively, child
+     *             permissions are assigned based on an inversion of their
+     *             association.
+     *         <li>When a parent permission is assigned positively, child
+     *             permissions are assigned based on their association.
+     *         </ul>
+     *         <p>
+     *         Child permissions may be defined in a number of ways:<ul>
+     *         <li>Children may be defined as a <a
+     *             href="http://en.wikipedia.org/wiki/YAML#Lists">list</a> of
+     *             names. Using a list will treat all children associated
+     *             positively to their parent.
+     *         <li>Children may be defined as a map. Each permission name maps
+     *             to either a boolean (representing the association), or a
+     *             nested permission definition (just as another permission).
+     *             Using a nested definition treats the child as a positive
+     *             association.
+     *         <li>A nested permission definition must be a map of these same
+     *             properties. To define a valid nested permission without
+     *             defining any specific property, empty curly-braces (
+     *             <code>&#123;&#125;</code> ) must be used.
+     *          <li>A nested permission may carry it's own nested permissions
+     *              as children, as they may also have nested permissions, and
+     *              so forth. There is no direct limit to how deep the
+     *              permission tree is defined.
+     *         </ul></td>
+     *     <td>As a list:
+     *         <blockquote><pre>children: [inferno.flagrate, inferno.burningdeaths]</pre></blockquote>
+     *         Or as a mapping:
+     *         <blockquote><pre>children:
+     *  inferno.flagrate: true
+     *  inferno.burningdeaths: true</pre></blockquote>
+     *         An additional example showing basic nested values can be seen
+     *         <a href="doc-files/permissions-example_plugin.yml">here</a>.
+     *         </td>
+     * </tr>
+     * </table>
+     * The permissions are structured as a hiearchy of <a
+     * href="http://yaml.org/spec/current.html#id2502325">nested mappings</a>.
+     * The primary (top-level, no intendentation) node is
+     * `<code>permissions</code>', while each individual permission name is
+     * indented, indicating it maps to some value (in our case, the
+     * properties of the table above).
+     * <p>
+     * Here is an example using some of the properties:<blockquote><pre>
+     *permissions:
+     *  inferno.*:
+     *    description: Gives access to all Inferno commands
+     *    children:
+     *      inferno.flagrate: true
+     *      inferno.burningdeaths: true
+     *  inferno.flagate:
+     *    description: Allows you to ignite yourself
+     *    default: true
+     *  inferno.burningdeaths:
+     *    description: Allows you to see how many times you have burned to death
+     *    default: true
+     *</pre></blockquote>
+     * Another example, with nested definitions, can be found <a
+     * href="doc-files/permissions-example_plugin.yml">here</a>.
+     */
     public List<Permission> getPermissions() {
         if (permissions == null) {
             if (lazyPermissions == null) {
@@ -171,16 +741,53 @@ public final class PluginDescriptionFile {
         return permissions;
     }
 
+    /**
+     * Gives the default {@link Permission#getDefault() default} state of
+     * {@link #getPermissions() permissions} registered for the plugin.
+     * <ul>
+     * <li>If not specified, it will be {@link PermissionDefault#OP}.
+     * <li>It is matched using {@link PermissionDefault#getByName(String)}
+     * <li>It only affects permissions that do not define the
+     *     <code>default</code> node.
+     * <li>It may be any value in {@link PermissionDefault}.
+     * </ul>
+     * <p>
+     * In the plugin.yml, this entry is named <code>default-permission</code>.
+     * <p>
+     * Example:<blockquote><pre>default-permission: NOT_OP</pre></blockquote>
+     *
+     * @return the default value for the plugin's permissions
+     */
     public PermissionDefault getPermissionDefault() {
         return defaultPerm;
+    }
+
+    /**
+     * Returns the name of a plugin, including the version. This method is
+     * provided for convenience; it uses the {@link #getName()} and {@link
+     * #getVersion()} entries.
+     *
+     * @return a descriptive name of the plugin and respective version
+     */
+    public String getFullName() {
+        return name + " v" + version;
     }
 
     public String getClassLoaderOf() {
         return classLoaderOf;
     }
 
-    public String getPrefix() {
-        return prefix;
+    public void setDatabaseEnabled(boolean database) {
+        this.database = database;
+    }
+
+    /**
+     * Saves this PluginDescriptionFile to the given writer
+     *
+     * @param writer Writer to output this file to
+     */
+    public void save(Writer writer) {
+        yaml.dump(saveMap(), writer);
     }
 
     private void loadMap(Map<?, ?> map) throws InvalidDescriptionException {

--- a/src/main/java/org/bukkit/plugin/PluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/PluginLoader.java
@@ -52,7 +52,7 @@ public interface PluginLoader {
 
     /**
      * Enables the specified plugin
-     * <p />
+     * <p>
      * Attempting to enable a plugin that is already enabled will have no effect
      *
      * @param plugin Plugin to enable
@@ -61,7 +61,7 @@ public interface PluginLoader {
 
     /**
      * Disables the specified plugin
-     * <p />
+     * <p>
      * Attempting to disable a plugin that is not enabled will have no effect
      *
      * @param plugin Plugin to disable

--- a/src/main/java/org/bukkit/plugin/PluginManager.java
+++ b/src/main/java/org/bukkit/plugin/PluginManager.java
@@ -24,7 +24,7 @@ public interface PluginManager {
 
     /**
      * Checks if the given plugin is loaded and returns it when applicable
-     * <p />
+     * <p>
      * Please note that the name of the plugin is case-sensitive
      *
      * @param name Name of the plugin to check
@@ -41,7 +41,7 @@ public interface PluginManager {
 
     /**
      * Checks if the given plugin is enabled or not
-     * <p />
+     * <p>
      * Please note that the name of the plugin is case-sensitive.
      *
      * @param name Name of the plugin to check
@@ -59,7 +59,7 @@ public interface PluginManager {
 
     /**
      * Loads the plugin in the specified file
-     * <p />
+     * <p>
      * File must be valid according to the current enabled Plugin interfaces
      *
      * @param file File containing the plugin to load
@@ -131,7 +131,7 @@ public interface PluginManager {
 
     /**
      * Enables the specified plugin
-     * <p />
+     * <p>
      * Attempting to enable a plugin that is already enabled will have no effect
      *
      * @param plugin Plugin to enable
@@ -140,7 +140,7 @@ public interface PluginManager {
 
     /**
      * Disables the specified plugin
-     * <p />
+     * <p>
      * Attempting to disable a plugin that is not enabled will have no effect
      *
      * @param plugin Plugin to disable
@@ -157,7 +157,7 @@ public interface PluginManager {
 
     /**
      * Adds a {@link Permission} to this plugin manager.
-     * <p />
+     * <p>
      * If a permission is already defined with the given name of the new permission,
      * an exception will be thrown.
      *
@@ -168,9 +168,9 @@ public interface PluginManager {
 
     /**
      * Removes a {@link Permission} registration from this plugin manager.
-     * <p />
+     * <p>
      * If the specified permission does not exist in this plugin manager, nothing will happen.
-     * <p />
+     * <p>
      * Removing a permission registration will <b>not</b> remove the permission from any {@link Permissible}s that have it.
      *
      * @param perm Permission to remove
@@ -179,9 +179,9 @@ public interface PluginManager {
 
     /**
      * Removes a {@link Permission} registration from this plugin manager.
-     * <p />
+     * <p>
      * If the specified permission does not exist in this plugin manager, nothing will happen.
-     * <p />
+     * <p>
      * Removing a permission registration will <b>not</b> remove the permission from any {@link Permissible}s that have it.
      *
      * @param name Permission to remove
@@ -198,7 +198,7 @@ public interface PluginManager {
 
     /**
      * Recalculates the defaults for the given {@link Permission}.
-     * <p />
+     * <p>
      * This will have no effect if the specified permission is not registered here.
      *
      * @param perm Permission to recalculate
@@ -207,7 +207,7 @@ public interface PluginManager {
 
     /**
      * Subscribes the given Permissible for information about the requested Permission, by name.
-     * <p />
+     * <p>
      * If the specified Permission changes in any form, the Permissible will be asked to recalculate.
      *
      * @param permission Permission to subscribe to
@@ -233,7 +233,7 @@ public interface PluginManager {
 
     /**
      * Subscribes to the given Default permissions by operator status
-     * <p />
+     * <p>
      * If the specified defaults change in any form, the Permissible will be asked to recalculate.
      *
      * @param op Default list to subscribe to
@@ -259,7 +259,7 @@ public interface PluginManager {
 
     /**
      * Gets a set of all registered permissions.
-     * <p />
+     * <p>
      * This set is a copy and will not be modified live.
      *
      * @return Set containing all current registered permissions

--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -279,7 +279,7 @@ public final class SimplePluginManager implements PluginManager {
 
     /**
      * Loads the plugin in the specified file
-     * <p />
+     * <p>
      * File must be valid according to the current enabled Plugin interfaces
      *
      * @param file File containing the plugin to load
@@ -327,7 +327,7 @@ public final class SimplePluginManager implements PluginManager {
 
     /**
      * Checks if the given plugin is loaded and returns it when applicable
-     * <p />
+     * <p>
      * Please note that the name of the plugin is case-sensitive
      *
      * @param name Name of the plugin to check
@@ -343,7 +343,7 @@ public final class SimplePluginManager implements PluginManager {
 
     /**
      * Checks if the given plugin is enabled or not
-     * <p />
+     * <p>
      * Please note that the name of the plugin is case-sensitive.
      *
      * @param name Name of the plugin to check

--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
@@ -334,7 +334,6 @@ public abstract class JavaPlugin extends PluginBase {
     public void onEnable() {}
 
     public ChunkGenerator getDefaultWorldGenerator(String worldName, String id) {
-        getServer().getLogger().severe("Plugin " + description.getFullName() + " does not contain any generators that may be used in the default world!");
         return null;
     }
 

--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
@@ -223,7 +223,7 @@ public abstract class JavaPlugin extends PluginBase {
 
     /**
      * Initializes this plugin with the given variables.
-     * <p />
+     * <p>
      * This method should never be called manually.
      *
      * @param loader PluginLoader that is responsible for this plugin

--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
@@ -307,10 +307,12 @@ public abstract class JavaPlugin extends PluginBase {
     }
 
     /**
-     * Gets the command with the given name, specific to this plugin
+     * Gets the command with the given name, specific to this plugin. Commands
+     * need to be registered in the {@link PluginDescriptionFile#getCommands()
+     * PluginDescriptionFile} to exist at runtime.
      *
-     * @param name Name or alias of the command
-     * @return PluginCommand if found, otherwise null
+     * @param name name or alias of the command
+     * @return the plugin command if found, otherwise null
      */
     public PluginCommand getCommand(String name) {
         String alias = name.toLowerCase();

--- a/src/main/java/org/bukkit/plugin/messaging/Messenger.java
+++ b/src/main/java/org/bukkit/plugin/messaging/Messenger.java
@@ -161,7 +161,7 @@ public interface Messenger {
 
     /**
      * Checks if the specified plugin message listener registration is valid.
-     * <p />
+     * <p>
      * A registration is considered valid if it has not be unregistered and that the plugin
      * is still enabled.
      *

--- a/src/main/java/org/bukkit/plugin/messaging/PluginMessageRecipient.java
+++ b/src/main/java/org/bukkit/plugin/messaging/PluginMessageRecipient.java
@@ -9,7 +9,7 @@ import org.bukkit.plugin.Plugin;
 public interface PluginMessageRecipient {
     /**
      * Sends this recipient a Plugin Message on the specified outgoing channel.
-     * <p />
+     * <p>
      * The message may not be larger than {@link Messenger#MAX_MESSAGE_SIZE} bytes, and the plugin must be registered to send
      * messages on the specified channel.
      *

--- a/src/main/java/org/bukkit/potion/PotionEffect.java
+++ b/src/main/java/org/bukkit/potion/PotionEffect.java
@@ -44,11 +44,11 @@ public class PotionEffect implements ConfigurationSerializable {
     }
 
     /**
-     * Creates a potion affect. Assumes ambient is true.
+     * Creates a potion effect. Assumes ambient is true.
      *
      * @param type Effect type
      * @param duration measured in ticks
-     * @param amplifier the amplifier for the affect
+     * @param amplifier the amplifier for the effect
      * @see PotionEffect#PotionEffect(PotionEffectType, int, int, boolean)
      */
     public PotionEffect(PotionEffectType type, int duration, int amplifier) {

--- a/src/main/java/org/bukkit/potion/PotionEffectType.java
+++ b/src/main/java/org/bukkit/potion/PotionEffectType.java
@@ -212,7 +212,7 @@ public abstract class PotionEffectType {
 
     /**
      * Registers an effect type with the given object.
-     * <p />
+     * <p>
      * Generally not to be used from within a plugin.
      *
      * @param type PotionType to register

--- a/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
+++ b/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
@@ -91,7 +91,7 @@ public interface BukkitScheduler {
     /**
      * Calls a method on the main thread and returns a Future object
      * This task will be executed by the main server thread.
-     * <p />
+     * <p>
      * Note: The Future.get() methods must NOT be called from the main thread.
      * Note2: There is at least an average of 10ms latency until the isDone() method returns true.
      *
@@ -123,33 +123,33 @@ public interface BukkitScheduler {
 
     /**
      * Check if the task currently running.
-     * <p />
+     * <p>
      * A repeating task might not be running currently, but will be running in the future.
      * A task that has finished, and does not repeat, will not be running ever again.
-     * <p />
+     * <p>
      * Explicitly, a task is running if there exists a thread for it, and that thread is alive.
      *
      * @param taskId The task to check.
-     * <p />
+     * <p>
      * @return If the task is currently running.
      */
     public boolean isCurrentlyRunning(int taskId);
 
     /**
      * Check if the task queued to be run later.
-     * <p />
+     * <p>
      * If a repeating task is currently running, it might not be queued now but could be in the future.
      * A task that is not queued, and not running, will not be queued again.
      *
      * @param taskId The task to check.
-     * <p />
+     * <p>
      * @return If the task is queued to be run.
      */
     public boolean isQueued(int taskId);
 
     /**
      * Returns a list of all active workers.
-     * <p />
+     * <p>
      * This list contains asynch tasks that are being executed by separate threads.
      *
      * @return Active workers

--- a/src/main/java/org/bukkit/scoreboard/Criterias.java
+++ b/src/main/java/org/bukkit/scoreboard/Criterias.java
@@ -1,0 +1,20 @@
+package org.bukkit.scoreboard;
+
+/**
+ * Criteria names which trigger an objective to be modified by actions in-game
+ */
+public class Criterias {
+    public static final String HEALTH;
+    public static final String PLAYER_KILLS;
+    public static final String TOTAL_KILLS;
+    public static final String DEATHS;
+
+    static {
+        HEALTH="health";
+        PLAYER_KILLS="playerKillCount";
+        TOTAL_KILLS="totalKillCount";
+        DEATHS="deathCount";
+    }
+
+    private Criterias() {}
+}

--- a/src/main/java/org/bukkit/scoreboard/DisplaySlot.java
+++ b/src/main/java/org/bukkit/scoreboard/DisplaySlot.java
@@ -1,0 +1,10 @@
+package org.bukkit.scoreboard;
+
+/**
+ * Locations for displaying objectives to the player
+ */
+public enum DisplaySlot {
+    BELOW_NAME,
+    PLAYER_LIST,
+    SIDEBAR;
+}

--- a/src/main/java/org/bukkit/scoreboard/Objective.java
+++ b/src/main/java/org/bukkit/scoreboard/Objective.java
@@ -1,0 +1,98 @@
+package org.bukkit.scoreboard;
+
+import org.bukkit.OfflinePlayer;
+
+/**
+ * An objective on a scoreboard that can show scores specific to players. This
+ * objective is only relevant to the display of the associated {@link
+ * #getScoreboard() scoreboard}.
+ */
+public interface Objective {
+
+    /**
+     * Gets the name of this Objective
+     *
+     * @return this objective'ss name
+     * @throws IllegalStateException if this objective has been unregistered
+     */
+    String getName() throws IllegalStateException;
+
+    /**
+     * Gets the name displayed to players for this objective
+     *
+     * @return this objective's display name
+     * @throws IllegalStateException if this objective has been unregistered
+     */
+    String getDisplayName() throws IllegalStateException;
+
+    /**
+     * Sets the name displayed to players for this objective.
+     *
+     * @param displayName Display name to set
+     * @throws IllegalStateException if this objective has been unregistered
+     * @throws IllegalArgumentException if displayName is null
+     * @throws IllegalArgumentException if displayName is longer than 32
+     *     characters.
+     */
+    void setDisplayName(String displayName) throws IllegalStateException, IllegalArgumentException;
+
+    /**
+     * Gets the criteria this objective tracks.
+     *
+     * @return this objective's criteria
+     * @throws IllegalStateException if this objective has been unregistered
+     */
+    String getCriteria() throws IllegalStateException;
+
+    /**
+     * Gets if the objective's scores can be modified directly by a plugin.
+     *
+     * @return true if scores are modifiable
+     * @throws IllegalStateException if this objective has been unregistered
+     * @see Criterias#HEALTH
+     */
+    boolean isModifiable() throws IllegalStateException;
+
+    /**
+     * Gets the scoreboard to which this objective is attached.
+     *
+     * @return Owning scoreboard, or null if it has been {@link #unregister()
+     *     unregistered}
+     */
+    Scoreboard getScoreboard();
+
+    /**
+     * Unregisters this objective from the {@link Scoreboard scoreboard.}
+     *
+     * @throws IllegalStateException if this objective has been unregistered
+     */
+    void unregister() throws IllegalStateException;
+
+    /**
+     * Sets this objective to display on the specified slot for the
+     * scoreboard, removing it from any other display slot.
+     *
+     * @param slot display slot to change, or null to not display
+     * @throws IllegalStateException if this objective has been unregistered
+     */
+    void setDisplaySlot(DisplaySlot slot) throws IllegalStateException;
+
+    /**
+     * Gets the display slot this objective is displayed at.
+     *
+     * @return the display slot for this objective, or null if not displayed
+     * @throws IllegalStateException if this objective has been unregistered
+     */
+    DisplaySlot getDisplaySlot() throws IllegalStateException;
+
+    /**
+     * Gets a player's Score for an Objective on this Scoreboard
+     *
+     * @param objective Objective for the Score
+     * @param player Player for the Score
+     * @return Score tracking the Objective and player specified
+     * @throws IllegalArgumentException if player is null
+     * @throws IllegalStateException if this objective has been unregistered
+     */
+    Score getScore(OfflinePlayer player) throws IllegalArgumentException, IllegalStateException;
+}

--- a/src/main/java/org/bukkit/scoreboard/Objective.java
+++ b/src/main/java/org/bukkit/scoreboard/Objective.java
@@ -88,7 +88,6 @@ public interface Objective {
     /**
      * Gets a player's Score for an Objective on this Scoreboard
      *
-     * @param objective Objective for the Score
      * @param player Player for the Score
      * @return Score tracking the Objective and player specified
      * @throws IllegalArgumentException if player is null

--- a/src/main/java/org/bukkit/scoreboard/Score.java
+++ b/src/main/java/org/bukkit/scoreboard/Score.java
@@ -1,0 +1,51 @@
+package org.bukkit.scoreboard;
+
+import org.bukkit.OfflinePlayer;
+
+/**
+ * A score entry for a {@link #getPlayer() player} on an {@link
+ * #getObjective() objective}. Changing this will not affect any other
+ * objective or scoreboard.
+ */
+public interface Score {
+
+    /**
+     * Gets the OfflinePlayer being tracked by this Score
+     *
+     * @return this Score's tracked player
+     */
+    OfflinePlayer getPlayer();
+
+    /**
+     * Gets the Objective being tracked by this Score
+     *
+     * @return this Score's tracked objective
+     */
+    Objective getObjective();
+
+    /**
+     * Gets the current score
+     *
+     * @return the current score
+     * @throws IllegalStateException if the associated objective has been
+     *     unregistered
+     */
+    int getScore() throws IllegalStateException;
+
+    /**
+     * Sets the current score.
+     *
+     * @param score New score
+     * @throws IllegalStateException if the associated objective has been
+     *     unregistered
+     */
+    void setScore(int score) throws IllegalStateException;
+
+    /**
+     * Gets the scoreboard for the associated objective.
+     *
+     * @return the owning objective's scoreboard, or null if it has been
+     *     {@link Objective#unregister() unregistered}
+     */
+    Scoreboard getScoreboard();
+}

--- a/src/main/java/org/bukkit/scoreboard/Scoreboard.java
+++ b/src/main/java/org/bukkit/scoreboard/Scoreboard.java
@@ -1,0 +1,123 @@
+package org.bukkit.scoreboard;
+
+import java.util.Set;
+
+import org.bukkit.OfflinePlayer;
+
+/**
+ * A scoreboard
+ */
+public interface Scoreboard {
+
+    /**
+     * Registers an Objective on this Scoreboard
+     *
+     * @param name Name of the Objective
+     * @param criteria Criteria for the Objective
+     * @return The registered Objective
+     * @throws IllegalArgumentException if name is null
+     * @throws IllegalArgumentException if criteria is null
+     * @throws IllegalArgumentException if an objective by that name already exists
+     */
+    Objective registerNewObjective(String name, String criteria) throws IllegalArgumentException;
+
+    /**
+     * Gets an Objective on this Scoreboard by name
+     *
+     * @param name Name of the Objective
+     * @return the Objective or null if it does not exist
+     * @throws IllegalArgumentException if name is null
+     */
+    Objective getObjective(String name) throws IllegalArgumentException;
+
+    /**
+     * Gets all Objectives of a Criteria on the Scoreboard
+     *
+     * @param criteria Criteria to search by
+     * @return an immutable set of Objectives using the specified Criteria
+     */
+    Set<Objective> getObjectivesByCriteria(String criteria) throws IllegalArgumentException;
+
+    /**
+     * Gets all Objectives on this Scoreboard
+     *
+     * @return An immutable set of all Objectives on this Scoreboard
+     */
+    Set<Objective> getObjectives();
+
+    /**
+     * Gets the Objective currently displayed in a DisplaySlot on this Scoreboard
+     *
+     * @param slot The DisplaySlot
+     * @return the Objective currently displayed or null if nothing is displayed in that DisplaySlot
+     * @throws IllegalArgumentException if slot is null
+     */
+    Objective getObjective(DisplaySlot slot) throws IllegalArgumentException;
+
+    /**
+     * Gets all scores for a player on this Scoreboard
+     *
+     * @param player the player whose scores are being retrieved
+     * @return immutable set of all scores tracked for the player
+     * @throws IllegalArgumentException if player is null
+     */
+    Set<Score> getScores(OfflinePlayer player) throws IllegalArgumentException;
+
+    /**
+     * Removes all scores for a player on this Scoreboard
+     *
+     * @param player the player to drop all current scores
+     * @throws IllegalArgumentException if player is null
+     */
+    void resetScores(OfflinePlayer player) throws IllegalArgumentException;
+
+    /**
+     * Gets a player's Team on this Scoreboard
+     *
+     * @param player the player to search for
+     * @return the player's Team or null if the player is not on a team
+     * @throws IllegalArgumentException if player is null
+     */
+    Team getPlayerTeam(OfflinePlayer player) throws IllegalArgumentException;
+
+    /**
+     * Gets a Team by name on this Scoreboard
+     *
+     * @param teamName Team name
+     * @return the matching Team or null if no matches
+     * @throws IllegalArgumentException if teamName is null
+     */
+    Team getTeam(String teamName) throws IllegalArgumentException;
+
+    /**
+     * Gets all teams on this Scoreboard
+     *
+     * @return an immutable set of Teams
+     */
+    Set<Team> getTeams();
+
+    /**
+     * Registers a Team on this Scoreboard
+     *
+     * @param name Team name
+     * @return registered Team
+     * @throws IllegalArgumentException if name is null
+     * @throws IllegalArgumentException if team by that name already exists
+     */
+    Team registerNewTeam(String name) throws IllegalArgumentException;
+
+    /**
+     * Gets all players tracked by this Scoreboard
+     *
+     * @return immutable set of all tracked players
+     */
+    Set<OfflinePlayer> getPlayers();
+
+    /**
+     * Clears any objective in the specified slot.
+     *
+     * @param slot the slot to remove objectives
+     * @throws IllegalArgumentException if slot is null
+     */
+    void clearSlot(DisplaySlot slot) throws IllegalArgumentException;
+}

--- a/src/main/java/org/bukkit/scoreboard/ScoreboardManager.java
+++ b/src/main/java/org/bukkit/scoreboard/ScoreboardManager.java
@@ -1,0 +1,29 @@
+package org.bukkit.scoreboard;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * Manager of Scoreboards
+ */
+public interface ScoreboardManager {
+
+    /**
+     * Gets the primary Scoreboard controlled by the server.
+     * <p>
+     * This Scoreboard is saved by the server, is affected by the /scoreboard
+     * command, and is the scoreboard shown by default to players.
+     *
+     * @return the default sever scoreboard
+     */
+    Scoreboard getMainScoreboard();
+
+    /**
+     * Gets a new Scoreboard to be tracked by the server. This scoreboard will
+     * be tracked as long as a reference is kept, either by a player or by a
+     * plugin.
+     *
+     * @return the registered Scoreboard
+     * @see WeakReference
+     */
+    Scoreboard getNewScoreboard();
+}

--- a/src/main/java/org/bukkit/scoreboard/Team.java
+++ b/src/main/java/org/bukkit/scoreboard/Team.java
@@ -1,0 +1,175 @@
+package org.bukkit.scoreboard;
+
+import java.util.Set;
+
+import org.bukkit.OfflinePlayer;
+import org.bukkit.potion.PotionEffectType;
+
+/**
+ * A team on a scoreboard that has a common display theme and other
+ * properties. This team is only relevant to the display of the associated
+ * {@link #getScoreboard() scoreboard}.
+ */
+public interface Team {
+
+    /**
+     * Gets the name of this Team
+     *
+     * @return Objective name
+     * @throws IllegalStateException if this team has been unregistered
+     */
+    String getName() throws IllegalStateException;
+
+    /**
+     * Gets the name displayed to players for this team
+     *
+     * @return Team display name
+     * @throws IllegalStateException if this team has been unregistered
+     */
+    String getDisplayName() throws IllegalStateException;
+
+    /**
+     * Sets the name displayed to players for this team
+     *
+     * @param displayName New display name
+     * @throws IllegalArgumentException if displayName is longer than 32
+     *     characters.
+     * @throws IllegalStateException if this team has been unregistered
+     */
+    void setDisplayName(String displayName) throws IllegalStateException, IllegalArgumentException;
+
+    /**
+     * Sets the prefix prepended to the display of players on this team.
+     *
+     * @return Team prefix
+     * @throws IllegalStateException if this team has been unregistered
+     */
+    String getPrefix() throws IllegalStateException;
+
+    /**
+     * Sets the prefix prepended to the display of players on this team.
+     *
+     * @param prefix New prefix
+     * @throws IllegalArgumentException if prefix is null
+     * @throws IllegalArgumentException if prefix is longer than 16
+     *     characters
+     * @throws IllegalStateException if this team has been unregistered
+     */
+    void setPrefix(String prefix) throws IllegalStateException, IllegalArgumentException;
+
+    /**
+     * Gets the suffix appended to the display of players on this team.
+     *
+     * @return the team's current suffix
+     * @throws IllegalStateException if this team has been unregistered
+     */
+    String getSuffix() throws IllegalStateException;
+
+    /**
+     * Sets the suffix appended to the display of players on this team.
+     *
+     * @param suffix the new suffix for this team.
+     * @throws IllegalArgumentException if suffix is null
+     * @throws IllegalArgumentException if suffix is longer than 16
+     *     characters
+     * @throws IllegalStateException if this team has been unregistered
+     */
+    void setSuffix(String suffix) throws IllegalStateException, IllegalArgumentException;
+
+    /**
+     * Gets the team friendly fire state
+     *
+     * @return true if friendly fire is enabled
+     * @throws IllegalStateException if this team has been unregistered
+     */
+    boolean allowFriendlyFire() throws IllegalStateException;
+
+    /**
+     * Sets the team friendly fire state
+     *
+     * @param enabled true if friendly fire is to be allowed
+     * @throws IllegalStateException if this team has been unregistered
+     */
+    void setAllowFriendlyFire(boolean enabled) throws IllegalStateException;
+
+    /**
+     * Gets the team's ability to see {@link PotionEffectType#INVISIBILITY
+     * invisible} teammates.
+     *
+     * @return true if team members can see invisible members
+     * @throws IllegalStateException if this team has been unregistered
+     */
+    boolean canSeeFriendlyInvisibles() throws IllegalStateException;
+
+    /**
+     * Sets the team's ability to see invisible {@link
+     * PotionEffectType#INVISIBILITY invisible} teammates.
+     *
+     * @param enabled true if invisible teammates are to be visible
+     * @throws IllegalStateException if this team has been unregistered
+     */
+    void setCanSeeFriendlyInvisibles(boolean enabled) throws IllegalStateException;
+
+    /**
+     * Gets the Set of players on the team
+     *
+     * @return players on the team
+     * @throws IllegalStateException if this team has been unregistered
+     */
+    Set<OfflinePlayer> getPlayers() throws IllegalStateException;
+
+    /**
+     * Gets the size of the team
+     *
+     * @return number of players on the team
+     * @throws IllegalStateException if this team has been unregistered
+     */
+    int getSize() throws IllegalStateException;
+
+    /**
+     * Gets the Scoreboard to which this team is attached
+     *
+     * @return Owning scoreboard, or null if this team has been {@link
+     *     #unregister() unregistered}
+     */
+    Scoreboard getScoreboard();
+
+    /**
+     * This puts the specified player onto this team for the scoreboard.
+     * <p>
+     * This will remove the player from any other team on the scoreboard.
+     *
+     * @param player the player to add
+     * @throws IllegalArgumentException if player is null
+     * @throws IllegalStateException if this team has been unregistered
+     */
+    void addPlayer(OfflinePlayer player) throws IllegalStateException, IllegalArgumentException;
+
+    /**
+     * Removes the player from this team.
+     *
+     * @param player the player to remove
+     * @return if the player was on this team
+     * @throws IllegalArgumentException if player is null
+     * @throws IllegalStateException if this team has been unregistered
+     */
+    boolean removePlayer(OfflinePlayer player) throws IllegalStateException, IllegalArgumentException;
+
+    /**
+     * Unregisters this team from the Scoreboard
+     *
+     * @param team Team to unregister
+     * @throws IllegalStateException if this team has been unregistered
+     */
+    void unregister() throws IllegalStateException;
+
+    /**
+     * Checks to see if the specified player is a member of this team.
+     *
+     * @param player the player to search for
+     * @return true if the player is a member of this team
+     * @throws IllegalArgumentException if player is null
+     * @throws IllegalStateException if this team has been unregistered
+     */
+    boolean hasPlayer(OfflinePlayer player) throws IllegalArgumentException, IllegalStateException;
+}

--- a/src/main/java/org/bukkit/scoreboard/Team.java
+++ b/src/main/java/org/bukkit/scoreboard/Team.java
@@ -158,7 +158,6 @@ public interface Team {
     /**
      * Unregisters this team from the Scoreboard
      *
-     * @param team Team to unregister
      * @throws IllegalStateException if this team has been unregistered
      */
     void unregister() throws IllegalStateException;

--- a/src/main/java/org/bukkit/util/Vector.java
+++ b/src/main/java/org/bukkit/util/Vector.java
@@ -279,7 +279,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
     /**
      * Calculates the cross product of this vector with another. The cross
      * product is defined as:
-     * <p />
+     * <p>
      * x = y1 * z2 - y2 * z1<br/>
      * y = z1 * x2 - z2 * x1<br/>
      * z = x1 * y2 - x2 * y1
@@ -507,7 +507,7 @@ public class Vector implements Cloneable, ConfigurationSerializable {
 
     /**
      * Checks to see if two objects are equal.
-     * <p />
+     * <p>
      * Only two Vectors can ever return true. This method uses a fuzzy match
      * to account for floating point errors. The epsilon can be retrieved
      * with epsilon.

--- a/src/main/java/org/bukkit/util/noise/OctaveGenerator.java
+++ b/src/main/java/org/bukkit/util/noise/OctaveGenerator.java
@@ -15,7 +15,7 @@ public abstract class OctaveGenerator {
 
     /**
      * Sets the scale used for all coordinates passed to this generator.
-     * <p />
+     * <p>
      * This is the equivalent to setting each coordinate to the specified value.
      *
      * @param scale New value to scale each coordinate by

--- a/src/main/java/org/bukkit/util/noise/SimplexNoiseGenerator.java
+++ b/src/main/java/org/bukkit/util/noise/SimplexNoiseGenerator.java
@@ -5,7 +5,7 @@ import org.bukkit.World;
 
 /**
  * Generates simplex-based noise.
- * <p />
+ * <p>
  * This is a modified version of the freely published version in the paper by
  * Stefan Gustavson at http://staffwww.itn.liu.se/~stegu/simplexnoise/simplexnoise.pdf
  */

--- a/src/main/java/org/bukkit/util/permissions/CommandPermissions.java
+++ b/src/main/java/org/bukkit/util/permissions/CommandPermissions.java
@@ -108,7 +108,7 @@ public final class CommandPermissions {
         DefaultPermissions.registerPermission(PREFIX + "toggledownfall", "Allows the user to toggle rain on/off for a given world", PermissionDefault.OP, commands);
         DefaultPermissions.registerPermission(PREFIX + "defaultgamemode", "Allows the user to change the default gamemode of the server", PermissionDefault.OP, commands);
         DefaultPermissions.registerPermission(PREFIX + "seed", "Allows the user to view the seed of the world", PermissionDefault.OP, commands);
-
+        DefaultPermissions.registerPermission(PREFIX + "effect", "Allows the user to add/remove effects on players", PermissionDefault.OP, commands);
 
         commands.recalculatePermissibles();
 

--- a/src/main/javadoc/org/bukkit/plugin/doc-files/permissions-example_plugin.yml
+++ b/src/main/javadoc/org/bukkit/plugin/doc-files/permissions-example_plugin.yml
@@ -1,0 +1,64 @@
+name: ScrapBukkit
+main: com.dinnerbone.bukkit.scrap.ScrapBukkit
+version: 1.0.0
+website: http://www.bukkit.org
+author: The Bukkit Team
+description: >
+             Miscellaneous administrative commands for Bukkit.
+             This plugin is one of the default plugins shipped with Bukkit.
+# commands: snipped
+
+permissions:
+  scrapbukkit.*:
+    description: Gives all permissions for Scrapbukkit
+    default: op
+    children:
+      scrapbukkit.remove:
+        description: Allows the player to remove items from anyones inventory
+        children:
+          scrapbukkit.remove.self:
+            description: Allows the player to remove items from their own inventory
+          scrapbukkit.remove.other:
+            description: Allows the player to remove items from other peoples inventory
+
+      scrapbukkit.time:
+        description: Allows the player to view and change the time
+        children:
+          scrapbukkit.time.view:
+            description: Allows the player to view the time
+            default: true
+          scrapbukkit.time.change:
+            description: Allows the player to change the time
+
+      scrapbukkit.tp:
+        description: Allows the player to teleport anyone to anyone else
+        children:
+          scrapbukkit.tp.here:
+            description: Allows the player to teleport other players to themselves
+          scrapbukkit.tp.self:
+            description: Allows the player to teleport themselves to another player
+          scrapbukkit.tp.other:
+            description: Allows the player to teleport anyone to another player
+
+      scrapbukkit.give:
+        description: Allows the player to give items
+        children:
+          scrapbukkit.give.self:
+            description: Allows the player to give themselves items
+          scrapbukkit.give.other:
+            description: Allows the player to give other players items
+
+      scrapbukkit.clear:
+        description: Allows the player to clear inventories
+        children:
+          scrapbukkit.clear.self:
+            description: Allows the player to clear their own inventory
+          scrapbukkit.clear.other:
+            description: Allows the player to clear other players inventory
+
+      scrapbukkit.some.standard.perm: {}
+      scrapbukkit.some.other.perm: true
+      scrapbukkit.some.bad.perm: false
+  # This is defined here individually, as simply giving it an association will not cause it to exist at runtime
+  scrapbukkit.some.bad.perm: {}
+  scrapbukkit.some.other.perm: {}

--- a/src/main/javadoc/org/bukkit/scoreboard/package-info.java
+++ b/src/main/javadoc/org/bukkit/scoreboard/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Interfaces used to manage the client side score display system.
+ * <p>
+ */
+package org.bukkit.scoreboard;
+

--- a/src/test/java/org/bukkit/metadata/FixedMetadataValueTest.java
+++ b/src/test/java/org/bukkit/metadata/FixedMetadataValueTest.java
@@ -1,6 +1,7 @@
 package org.bukkit.metadata;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.TestPlugin;
@@ -10,21 +11,32 @@ public class FixedMetadataValueTest {
     private Plugin plugin = new TestPlugin("X");
     private FixedMetadataValue subject;
 
-    private void valueEquals(Object value) {
-        subject = new FixedMetadataValue(plugin, value);
-        assertEquals(value, subject.value());
+    @Test
+    public void testBasic() {
+        subject = new FixedMetadataValue(plugin, new Integer(50));
+        assertSame(plugin, subject.getOwningPlugin());
+        assertEquals(new Integer(50), subject.value());
     }
 
     @Test
-    public void testTypes() {
-        valueEquals(10);
-        valueEquals(0.1);
-        valueEquals("TEN");
-        valueEquals(true);
-        valueEquals(null);
-        valueEquals((float) 10.5);
-        valueEquals((long) 10);
-        valueEquals((short) 10);
-        valueEquals((byte) 10);
+    public void testNumberTypes() {
+        subject = new FixedMetadataValue(plugin, new Integer(5));
+        assertEquals(new Integer(5), subject.value());
+        assertEquals(5, subject.asInt());
+        assertEquals(true, subject.asBoolean());
+        assertEquals(5, subject.asByte());
+        assertEquals(5.0, subject.asFloat(), 0.1e-8);
+        assertEquals(5.0D, subject.asDouble(), 0.1e-8D);
+        assertEquals(5L, subject.asLong());
+        assertEquals(5, subject.asShort());
+        assertEquals("5", subject.asString());
+    }
+
+    @Test
+    public void testInvalidateDoesNothing() {
+        Object o = new Object();
+        subject = new FixedMetadataValue(plugin, o);
+        subject.invalidate();
+        assertSame(o, subject.value());
     }
 }

--- a/src/test/java/org/bukkit/metadata/MetadataValueAdapterTest.java
+++ b/src/test/java/org/bukkit/metadata/MetadataValueAdapterTest.java
@@ -1,0 +1,97 @@
+package org.bukkit.metadata;
+
+import static org.junit.Assert.assertEquals;
+
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.TestPlugin;
+import org.junit.Test;
+
+public class MetadataValueAdapterTest {
+    private TestPlugin plugin = new TestPlugin("x");
+
+    @Test
+    public void testAdapterBasics() {
+        IncrementingMetaValue mv = new IncrementingMetaValue(plugin);
+        // check getOwningPlugin
+        assertEquals(mv.getOwningPlugin(), this.plugin);
+
+        // Check value-getting and invalidation.
+        assertEquals(new Integer(1), mv.value());
+        assertEquals(new Integer(2), mv.value());
+        mv.invalidate();
+        assertEquals(new Integer(1), mv.value());
+    }
+
+    @Test
+    public void testAdapterConversions() {
+        IncrementingMetaValue mv = new IncrementingMetaValue(plugin);
+
+        assertEquals(1, mv.asInt());
+        assertEquals(2L, mv.asLong());
+        assertEquals(3.0, mv.asFloat(), 0.001);
+        assertEquals(4, mv.asByte());
+        assertEquals(5.0, mv.asDouble(), 0.001);
+        assertEquals(6, mv.asShort());
+        assertEquals("7", mv.asString());
+    }
+
+    /** Boolean conversion is non-trivial, we want to test it thoroughly. */
+    @Test
+    public void testBooleanConversion() {
+        // null is False.
+        assertEquals(false, simpleValue(null).asBoolean());
+
+        // String to boolean.
+        assertEquals(true, simpleValue("True").asBoolean());
+        assertEquals(true, simpleValue("TRUE").asBoolean());
+        assertEquals(false, simpleValue("false").asBoolean());
+
+        // Number to boolean.
+        assertEquals(true, simpleValue(1).asBoolean());
+        assertEquals(true, simpleValue(5.0).asBoolean());
+        assertEquals(false, simpleValue(0).asBoolean());
+        assertEquals(false, simpleValue(0.1).asBoolean());
+
+        // Boolean as boolean, of course.
+        assertEquals(true, simpleValue(Boolean.TRUE).asBoolean());
+        assertEquals(false, simpleValue(Boolean.FALSE).asBoolean());
+
+        // any object that is not null and not a Boolean, String, or Number is true.
+        assertEquals(true, simpleValue(new Object()).asBoolean());
+    }
+
+    /** Test String conversions return an empty string when given null. */
+    @Test
+    public void testStringConversionNull() {
+        assertEquals("", simpleValue(null).asString());
+    }
+
+    /** Get a fixed value MetadataValue. */
+    private MetadataValue simpleValue(Object value) {
+        return new FixedMetadataValue(plugin, value);
+    }
+
+    /**
+     * A sample non-trivial MetadataValueAdapter implementation.
+     *
+     * The rationale for implementing an incrementing value is to have a value
+     * which changes with every call to value(). This is important for testing
+     * because we want to make sure all the tested conversions are calling the
+     * value() method exactly once and no caching is going on.
+     */
+    class IncrementingMetaValue extends MetadataValueAdapter {
+        private int internalValue = 0;
+
+        protected IncrementingMetaValue(Plugin owningPlugin) {
+            super(owningPlugin);
+        }
+
+        public Object value() {
+            return ++internalValue;
+        }
+
+        public void invalidate() {
+            internalValue = 0;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds two new functions to the CraftWorld class, broadcast and broadcastMessage. They exactly mimic CraftServer's broadcast and broadcastMessage except CraftWorld's version will only broadcast the message to players in that world.

I added it because I use lots of plugins that iterate through every single player, check the world they are in and then send them a message. It is a lot easier and less time consuming to use something like `player.getWorld().broadcastMessage("Hello people in my world!");`

CraftBukkit and Bukkit both compile successfully using Maven with this awesome addition.

To demonstrate this I have made a plugin that just has one command

> /test [worldName] [permission]  

If you want to see this in action for yourself you can download the plugin [here](https://www.dropbox.com/s/mgwgxzw6r44b4xv/WBT.jar?dl=1) and the modified CraftBukkit [here](https://www.dropbox.com/s/snb87sdiqxydp73/craftbukkit-1.4.7-R1.1-SNAPSHOT.jar?dl=1).

See https://github.com/Bukkit/CraftBukkit/pull/1033
See https://bukkit.atlassian.net/browse/BUKKIT-3638
