### PR TITLE
[B+C] Allow plugins to catch Thorns damage

### DIFF
--- a/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
@@ -189,6 +189,12 @@ public class EntityDamageEvent extends EntityEvent implements Cancellable {
          */
         FALLING_BLOCK,
         /**
+         * Damage caused in retaliation to another attack by the Thorns enchantment.
+         * <p />
+         * Damage: 1-4 (Thorns)
+         */
+        THORNS,
+        /**
          * Custom damage.
          * <p />
          * Damage: variable


### PR DESCRIPTION
## Problem

When damage is done by Thorns, an EntityDamageEvent is called with the attacker as the one wearing the Thorns armor and the defender being the one swinging / shooting. This causes problems for plugins like NoCheatPlus, as it has to add an exception for far-away damage done by a player with Thorns armor (in reaction to a bow shot) - theoretically, a malicious player could wear Thorns armor and send false hit-swings.
## What this PR does

Adds a new DamageCause to EntityDamageEvent named "THORNS". Plugins are recommended to check for this source when they are examining the distance between attacker and defender.
## Links

Implementation A: https://github.com/Bukkit/CraftBukkit/pull/1035
Implementation B: https://github.com/Bukkit/CraftBukkit/pull/1036
Leaky: https://bukkit.atlassian.net/browse/BUKKIT-3505
