### PR TITLE
Added EntityEquipEvent

### DIFF
--- a/src/main/java/org/bukkit/event/entity/EntityEquipEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityEquipEvent.java
@@ -1,0 +1,46 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.Item;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Thrown when an entity picks up and equips an item from the ground
+ */
+public class EntityEquipEvent extends EntityPickupItemEvent {
+    private static final HandlerList handlers = new HandlerList();
+    private final int equipSlot;
+
+    public EntityEquipEvent(final LivingEntity entity, final Item item, final int equipSlot) {
+        super(entity, item, item.getPickupDelay());
+        this.equipSlot = equipSlot;
+    }
+
+    /**
+     * Gets the living entity involved in this event.
+     *
+     * @return LivingEntity
+     */
+    @Override
+    public LivingEntity getEntity() {
+        return (LivingEntity) entity;
+    }
+
+    /**
+     * Gets the raw slot to equip the item.
+     *
+     * @return raw slot to equip the item.
+     */
+    public int getEquipSlot() {
+        return equipSlot;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/org/bukkit/event/entity/EntityPickupItemEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityPickupItemEvent.java
@@ -1,0 +1,57 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Thrown when an entity picks an item up from the ground
+ */
+public class EntityPickupItemEvent extends EntityEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private final Item item;
+    private boolean cancel = false;
+    private final int remaining;
+
+    public EntityPickupItemEvent(final Entity entity, final Item item, final int remaining) {
+        super(entity);
+        this.item = item;
+        this.remaining = remaining;
+    }
+
+    /**
+     * Gets the ItemDrop the entity picked up
+     *
+     * @return Item
+     */
+    public Item getItem() {
+        return item;
+    }
+
+    /**
+     * Gets the amount remaining on the ground, if any
+     *
+     * @return amount remaining on the ground
+     */
+    public int getRemaining() {
+        return remaining;
+    }
+
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}


### PR DESCRIPTION
When mobs pick up items they can equip it, for example Zombies and Skeletons.
This event is cancellable, and is called before the item is picked up and equipped.

Through this event plugin developers can know the entity involved, the item being picked up and the raw slot index for the entity's inventory the item will be equipped to.

CraftBukkit PR: https://github.com/Bukkit/CraftBukkit/pull/1038
Leaky: https://bukkit.atlassian.net/browse/BUKKIT-3655
