### PR TITLE
BlockBurnEvent, BlockIgniteEvent knows exactly what caused the ignition.

### DIFF
--- a/src/main/java/org/bukkit/event/block/BlockBurnEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockBurnEvent.java
@@ -11,11 +11,27 @@ import org.bukkit.event.HandlerList;
  */
 public class BlockBurnEvent extends BlockEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
+    private final Block sourceBlock;
     private boolean cancelled;
 
     public BlockBurnEvent(final Block block) {
         super(block);
+        this.sourceBlock = null;
         this.cancelled = false;
+    }
+
+    public BlockBurnEvent(final Block block, final Block sourceBlock) {
+        super(block);
+        this.sourceBlock = sourceBlock;
+        this.cancelled = false;
+    }
+
+    /**
+     * Gets the block that caused the burning.
+     * @return The block
+     */
+    public Block getSourceBlock() {
+        return this.sourceBlock;
     }
 
     public boolean isCancelled() {


### PR DESCRIPTION
## Fire Related Events Enhancement
### This is awesome because:
1. BlockBurnEvent and BlockIgniteEvent can know exactly what caused the ignition, wether its another block or an entity for ANY event that's raised.
2. BlockIgniteEvent is properly called for EnderCrystal environmental flame.
3. BlockIgniteEvent is properly called for blocks ignited due to explosion.
4. BlockIgniteEvent is properly called for new dispenser flint and steel behaviour.
5. Uses CraftEventFactory to get rid of imports, reduce dependencies and centralize logic for raising the events.
6. 100% compatibility. This does not break anything.
### Links:

CraftBukkit PR: https://github.com/Bukkit/CraftBukkit/pull/1040
https://bukkit.atlassian.net/browse/BUKKIT-3657
**Status**
- [ ] Waiting on author (@YLivay)
- [ ] Waiting on PRH (@riking)
- [x] Waiting on core (idea approval)
