### PR TITLE
Add Fish Hook to PlayerFishEvent [#Bukkit-1025]

### DIFF
--- a/src/main/java/org/bukkit/event/player/PlayerFishEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerFishEvent.java
@@ -1,5 +1,6 @@
 package org.bukkit.event.player;
 
+import org.bukkit.entity.Fish;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.entity.Entity;
@@ -14,10 +15,24 @@ public class PlayerFishEvent extends PlayerEvent implements Cancellable {
     private boolean cancel = false;
     private int exp;
     private final State state;
+    private final Fish hookEntity;
 
+    /**
+     * @deprecated replaced by {@link #PlayerFishEvent(Player, Entity, Fish, 
+     * State)} to include the EntityFishHook.
+     * @param player
+     * @param entity
+     * @param state
+     */
+    @Deprecated
     public PlayerFishEvent(final Player player, final Entity entity, final State state) {
+    	this(player, entity, null, state);
+    }
+
+    public PlayerFishEvent(final Player player, final Entity entity, final Fish hookEntity, final State state) {
         super(player);
         this.entity = entity;
+        this.hookEntity = hookEntity;
         this.state = state;
     }
 
@@ -28,6 +43,14 @@ public class PlayerFishEvent extends PlayerEvent implements Cancellable {
      */
     public Entity getCaught() {
         return entity;
+    }
+
+    /**
+     * Gets the fishing hook.
+     * @return Fish the entity representing the fishing hook/bobber.
+     */
+    public Fish getHook() {
+        return hookEntity;
     }
 
     public boolean isCancelled() {


### PR DESCRIPTION
This patch adds a reference to the Fish entity (ie. bobber/hook) to the PlayerFishEvent.  This allows plugins to determine its location after casting as well as simulate bites.

CraftBukkit PR: 
https://github.com/Bukkit/CraftBukkit/pull/1045

Ticket:
https://bukkit.atlassian.net/browse/BUKKIT-1025
