### PR TITLE
MaterialData#toItemStack without amount should make 1 item by default

### DIFF
--- a/src/main/java/org/bukkit/material/MaterialData.java
+++ b/src/main/java/org/bukkit/material/MaterialData.java
@@ -69,7 +69,7 @@ public class MaterialData implements Cloneable {
      * @return New ItemStack containing a copy of this MaterialData
      */
     public ItemStack toItemStack() {
-        return new ItemStack(type, 0, data);
+        return new ItemStack(type, 1, data);
     }
 
     /**


### PR DESCRIPTION
https://bukkit.atlassian.net/browse/BUKKIT-3673

An Item entity with 0 amount in its ItemStack causes a trouble in Minecraft world; players can pick up the item but cannot do anything with it. Current implementation of MaterialData#toItemStack with no amount argument doesn't make sense, so this commit changes the default value to let it have a meaning.

Another solution: just remove toItemStack without amount but keep toItemStack with amount.
