### PR TITLE
[B+C] Control spawn change through PlayerBedLeaveEvent. Adds BUKKIT-1916

### DIFF
--- a/src/main/java/org/bukkit/event/player/PlayerBedLeaveEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerBedLeaveEvent.java
@@ -10,19 +10,47 @@ import org.bukkit.event.HandlerList;
 public class PlayerBedLeaveEvent extends PlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     private final Block bed;
+    private boolean bedSpawnChange;
 
+    @Deprecated
     public PlayerBedLeaveEvent(final Player who, final Block bed) {
+        this(who, bed, true);
+    }
+
+    public PlayerBedLeaveEvent(final Player who, final Block bed, boolean bedSpawnChange) {
         super(who);
         this.bed = bed;
+        this.bedSpawnChange = bedSpawnChange;
     }
 
     /**
-     * Returns the bed block involved in this event.
+     * Returns where the player left bed.
      *
-     * @return the bed block involved in this event
+     * @return where the player left bed
      */
     public Block getBed() {
         return bed;
+    }
+
+    /**
+     * Indicates if the bed spawn location for player will change to {@link
+     * #getBed()} after this event is processed.
+     *
+     * @return true if player spawn location will change; otherwise false
+     */
+    public boolean isBedSpawnChange() {
+        return bedSpawnChange;
+    }
+
+    /**
+     * Control if the bed spawn will be changed for player to {@link
+     * #getBed()} after this event is processed.
+     *
+     * @param bedSpawnChange true to cause the bed spawn to change; false to
+     * keep the current bed spawn for Player
+     */
+    public void setBedSpawnChange(boolean bedSpawnChange) {
+        this.bedSpawnChange = bedSpawnChange;
     }
 
     @Override


### PR DESCRIPTION
##### Issue:

A player's respawn location is changed after a PlayerBedLeaveEvent completes. The way to currently revert/cancel it is to set a delayed task to run after the event and change it. This current approach is cumbersome.
##### Justification:

Providing the option to directly adjust if the spawn is changed or not within the event simplifies the API interaction.
##### Breakdown:

This PR provides methods within the PlayerBedLeaveEvent to enable or disable the spawn changing for the player after the event is processed.
##### Testing:

TBD
##### Relevant:

Bukkit/CraftBukkit#1048
##### JIRA Ticket:

BUKKIT-1916 - https://bukkit.atlassian.net/browse/BUKKIT-1916
