### PR TITLE
Update snakeyaml to 1.12; Adds BUKKIT-48, BUKKIT-3896

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.9</version>
+            <version>1.12</version>
             <type>jar</type>
             <scope>compile</scope>
         </dependency>


### PR DESCRIPTION
http://code.google.com/p/snakeyaml/wiki/changes
Issue 66 "Provide serialization with minimum layout change" is fixed in
snakeyaml 1.11 and addresses BUKKIT-48.

This commit also introduces an improved error message when a TAB is
attempted to be used for indentation.

Leaky: https://bukkit.atlassian.net/browse/BUKKIT-48
https://github.com/Bukkit/CraftBukkit/pull/1052
