### PR TITLE
BUKKIT-3738 Remove commands when disabling plugins

### DIFF
--- a/src/main/java/org/bukkit/command/CommandMap.java
+++ b/src/main/java/org/bukkit/command/CommandMap.java
@@ -1,6 +1,7 @@
 package org.bukkit.command;
 
 import java.util.List;
+import org.bukkit.plugin.Plugin;
 
 public interface CommandMap {
 
@@ -54,6 +55,13 @@ public interface CommandMap {
      * Clears all registered commands.
      */
     public void clearCommands();
+    
+    /**
+     * Removes registered commands for only a specific plugin
+     * 
+     * @param plugin The Plugin to clear commands for.
+     */
+    public void clearCommands(Plugin plugin);
 
     /**
      * Gets the command registered to the specified name

--- a/src/main/java/org/bukkit/command/SimpleCommandMap.java
+++ b/src/main/java/org/bukkit/command/SimpleCommandMap.java
@@ -16,6 +16,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Server;
 import org.bukkit.command.defaults.*;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.util.StringUtil;
 
 public class SimpleCommandMap implements CommandMap {
@@ -202,6 +203,23 @@ public class SimpleCommandMap implements CommandMap {
         aliases.clear();
         setDefaultCommands(server);
     }
+    
+    public synchronized void clearCommands(Plugin plugin) {
+        Validate.notNull(plugin, "Plugin cannot be null");
+        Iterator<Map.Entry<String,Command>> i = knownCommands.entrySet().iterator();
+        while (i.hasNext()) {
+            Map.Entry<String,Command> e = i.next();
+            Command command = e.getValue();
+            if (command instanceof PluginCommand) {
+                PluginCommand pluginCommand = (PluginCommand) command;
+                if (plugin.equals(pluginCommand.getPlugin())) {
+                    i.remove();
+                    pluginCommand.unregister(this);
+                    aliases.remove(e.getKey());
+                }
+            }
+        }
+    }
 
     public Command getCommand(String name) {
         Command target = knownCommands.get(name.toLowerCase());
@@ -281,7 +299,7 @@ public class SimpleCommandMap implements CommandMap {
     }
 
     public Collection<Command> getCommands() {
-        return knownCommands.values();
+        return Collections.unmodifiableCollection(knownCommands.values());
     }
 
     public void registerServerAliases() {

--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -419,6 +419,12 @@ public final class SimplePluginManager implements PluginManager {
             } catch (Throwable ex) {
                 server.getLogger().log(Level.SEVERE, "Error occurred (in the plugin loader) while unregistering events for " + plugin.getDescription().getFullName() + " (Is it up to date?)", ex);
             }
+            
+            try {
+                commandMap.clearCommands(plugin);
+            } catch (Throwable ex) {
+                server.getLogger().log(Level.SEVERE, "Error occurred (in the plugin loader) while unregistering commands for " + plugin.getDescription().getFullName() + " (Is it up to date?)", ex);
+            }
 
             try {
                 server.getMessenger().unregisterIncomingPluginChannel(plugin);


### PR DESCRIPTION
Disable a plugin's commands when disabling a plugin.

Calling PluginManager.disablePlugin(myPlugin) followed by PluginManager.enablePlugin(myPlugin) causes duplicate commands to be added, this fix addresses that.

Example plugin that requires this: http://dev.bukkit.org/server-mods/easyscript/ (it requires the ability to reload itself)

I'm not particularly happy with this code, but I can't think of a way of fixing it without exposing server.getCommandMap() in bukkit, or rewriting the entire *.command.* to be more plugin aware.
