### PR TITLE
Removed superfluous permissions recalculation. Fixes BUKKIT-3728

### DIFF
--- a/src/main/java/org/bukkit/permissions/PermissionAttachment.java
+++ b/src/main/java/org/bukkit/permissions/PermissionAttachment.java
@@ -90,7 +90,6 @@ public class PermissionAttachment {
      */
     public void setPermission(Permission perm, boolean value) {
         setPermission(perm.getName(), value);
-        permissible.recalculatePermissions();
     }
 
     /**
@@ -114,7 +113,6 @@ public class PermissionAttachment {
      */
     public void unsetPermission(Permission perm) {
         unsetPermission(perm.getName());
-        permissible.recalculatePermissions();
     }
 
     /**


### PR DESCRIPTION
##### The Issue:

The permission attachment interface provides two methods each for setting and
unsetting permissions. Each one also provides an extra call to the
recalculatePermissions() method on the permissible, which degrades performance.

This commit fixes that.
##### Justification for this PR:

There is no reason for the extra method calls.
##### PR Breakdown:

This PR removes the extra methods to improve performance. More explanation is likely unnecessary.
##### JIRA Ticket:

BUKKIT-3728 - https://bukkit.atlassian.net/browse/BUKKIT-3728
