### PR TITLE
Add Hopper interface, adds BUKKIT-3749

### DIFF
--- a/src/main/java/org/bukkit/block/Hopper.java
+++ b/src/main/java/org/bukkit/block/Hopper.java
@@ -1,0 +1,8 @@
+package org.bukkit.block;
+
+/**
+ * Represents a hopper.
+ */
+public interface Hopper extends BlockState, ContainerBlock {
+
+}

--- a/src/main/java/org/bukkit/event/inventory/InventoryType.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryType.java
@@ -56,6 +56,10 @@ public enum InventoryType {
      * A beacon inventory, with 1 CRAFTING slot
      */
     BEACON(1, "container.beacon"),
+    /**
+     * A hopper inventory, with 5 slots of type CONTAINER.
+     */
+    HOPPER(5, "Item Hopper"),
     ;
 
     private final int size;


### PR DESCRIPTION
Implementation for Hopper: https://github.com/Bukkit/CraftBukkit/pull/1056
Currently there is no TileEntityDropper in CraftBukkit or in mc-dev, otherwise I would implement that too.
