### PR TITLE
[C+B] Add Entity.isOnGround() API. Fixes BUKKIT-3787

### DIFF
--- a/src/main/java/org/bukkit/entity/Entity.java
+++ b/src/main/java/org/bukkit/entity/Entity.java
@@ -47,6 +47,14 @@ public interface Entity extends Metadatable {
     public Vector getVelocity();
 
     /**
+     * Returns true if the entity is supported by a block. This value is a state
+     * updated by the server and is not recalculated unless the entity moves.
+     *
+     * @return True if entity is on ground.
+     */
+    public boolean isOnGround();
+
+    /**
      * Gets the current world this entity resides in
      *
      * @return World

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -531,6 +531,17 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
     public boolean canSee(Player player);
 
     /**
+     * Checks to see if this player is currently standing on a block. This information may
+     * not be reliable, as it is a state provided by the client, and may therefore not be accurate.
+     *
+     * @return True if the player standing on a solid block, else false.
+     * @deprecated Inconsistent with {@link org.bukkit.craftbukkit.entity.Entity#isOnGround()}
+     */
+    @Override
+    @Deprecated
+    public boolean isOnGround();
+
+    /**
      * Checks to see if this player is currently flying or not.
      *
      * @return True if the player is flying, else false.


### PR DESCRIPTION
Addresses https://bukkit.atlassian.net/browse/BUKKIT-3787

Conversation with @amaranth regarding the event and its history http://gist.github.com/authorblues/430f5972071fbb1edbe7

This is a minor API addition to allow plugins to determine if an entity is on the ground. Currently, there is no suitable proxy for this information, since players do not have access to the onGround flag and the Block interface does not expose a suitable method for determining if a block can support the weight of a player. Therefore, rather than solving the latter problem (which is typically only used to solve the former), I propose a simple API addition. This is non-breaking, incredibly valuable to plugin developers, and solves a common and tedious problem that most developers are addressing with a tedious lookup table of blocks, which is not future proof.

In the event that a future change to the physics engine changes the way this flag is calculated, I purport that the notion of whether or not an entity is supported by a block is fundamental enough to Minecraft logic that such information will be made available there as well.

CraftBukkit PR: https://github.com/Bukkit/CraftBukkit/pull/1059
