### PR TITLE
[B+C] Create InventoryPickupItemEvent. Adds BUKKIT-3798

### DIFF
--- a/src/main/java/org/bukkit/entity/minecart/HopperMinecart.java
+++ b/src/main/java/org/bukkit/entity/minecart/HopperMinecart.java
@@ -1,9 +1,10 @@
 package org.bukkit.entity.minecart;
 
 import org.bukkit.entity.Minecart;
+import org.bukkit.inventory.InventoryHolder;
 
 /**
  * Represents a Minecart with a Hopper inside it
  */
-public interface HopperMinecart extends Minecart {
+public interface HopperMinecart extends Minecart, InventoryHolder {
 }

--- a/src/main/java/org/bukkit/event/inventory/InventoryPickupItemEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryPickupItemEvent.java
@@ -1,0 +1,59 @@
+package org.bukkit.event.inventory;
+
+import org.bukkit.entity.Item;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.Inventory;
+
+/**
+ * Called when a hopper or hopper minecart picks up a dropped item.
+ */
+public class InventoryPickupItemEvent extends Event implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancelled;
+    private final Inventory inventory;
+    private final Item item;
+
+    public InventoryPickupItemEvent(final Inventory inventory, final Item item) {
+        super();
+        this.inventory = inventory;
+        this.item = item;
+    }
+
+
+    /**
+     * Gets the Inventory that picked up the item
+     *
+     * @return Inventory
+     */
+    public Inventory getInventory() {
+        return inventory;
+    }
+
+    /**
+     * Gets the Item entity that was picked up
+     *
+     * @return Item
+     */
+    public Item getItem() {
+        return item;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}


### PR DESCRIPTION
This event is called when a hopper or hopper minecart picks up a dropped item.

CraftBukkit: https://github.com/Bukkit/CraftBukkit/pull/1063
Leaky: https://bukkit.atlassian.net/browse/BUKKIT-3798

This depends on Bukkit#797: https://github.com/Bukkit/Bukkit/pull/797
and on CraftBukkit#1061: https://github.com/Bukkit/CraftBukkit/pull/1061
