### PR TITLE
[B+C] Added spawnParticle to World. Adds BUKKET-3792

### DIFF
--- a/src/main/java/org/bukkit/Particle.java
+++ b/src/main/java/org/bukkit/Particle.java
@@ -1,196 +1,184 @@
 package org.bukkit;
 
 public enum Particle {
-	/**
-	 * The biggest explosion particle effect
-	 */
-	HUGE_EXPLOSION("hugeexplosion"),
-	/**
-	 * A larger version of the explode particle
-	 */
-	LARGE_EXPLODE("largeexplode"),
-	/**
-	 * The spark that comes off a fireworks
-	 */
-	FIREWORKS_SPARK("fireworksSpark"),
-	/**
-	 * Currently shows nothing
-	 */
-	BUBBLE("bubble"),
-	/**
-	 * Currently shows nothing
-	 */
-	SUSPENDED("suspended"),
-	/**
-	 * Small gray particles
-	 */
-	DEPTH_SUSPEND("depthsuspend"),
-	/**
-	 * Small gray particles
-	 */
-	TOWNAURA("townaura"),
-	/**
-	 * Currently shows nothing
-	 */
-	CRIT("CRIT"),
-	/**
-	 * Blue crit particles
-	 */
-	MAGIC_CRIT("magicCrit"),
-	/**
-	 * Smoke particles
-	 */
-	SMOKE("smoke"),
-	/**
-	 * Multicolored potion particles
-	 */
-	MOB_SPELL("mobSpell"),
-	/**
-	 * Multicolored potion particles that are slightly transparent
-	 */
-	MOB_SPELL_AMBIENT("mobSpellAmbient"),
-	/**
-	 * A puff of white particles
-	 */
-	SPELL("spell"),
-	/**
-	 * A puff of white starts
-	 */
-	INSTANT_SPELL("instantSpell"),
-	/**
-	 * A puff of purple particles
-	 */
-	WITCH_MAGIC("witchMagic"),
-	/**
-	 * The note that appears above note blocks
-	 */
-	NOTE("note"),
-	/**
-	 * The particles shown at nether portals
-	 */
-	PORTAL("portal"),
-	/**
-	 * The symbols that fly towards the enchantment table
-	 */
-	ENCHANTMENT_TABLE("enchantmenttable"),
-	/**
-	 * Explosion particles
-	 */
-	EXPLODE("explode"),
-	/**
-	 * Fire particles
-	 */
-	FLAME("flame"),
-	/**
-	 * The particles that pop out of lava
-	 */
-	LAVA("lava"),
-	/**
-	 * A small gray square
-	 */
-	FOOTSTEP("footstep"),
-	/**
-	 * Water particles
-	 */
-	SPLASH("splash"),
-	/**
-	 * Currently shows nothing
-	 */
-	LARGE_SMOKE("largeSmoke"),
-	/**
-	 * A puff of smoke
-	 */
-	CLOUD("cloud"),
-	/**
-	 * Multicolored dust particles
-	 */
-	REDDUST("reddust"),
-	/**
-	 * Snowball breaking
-	 */
-	SNOWBALL_POOF("snowballpoof"),
-	/**
-	 * The water drip particle that appears on blocks under water
-	 */
-	DRIP_WATER("dripWater"),
-	/**
-	 * The lava drip particle that appears on blocks under lava
-	 */
-	DRIP_LAVA("dripLava"),
-	/**
-	 * White particles
-	 */
-	SNOW_SHOVEL("snowshovel"),
-	/**
-	 * The particle shown when a slime jumps
-	 */
-	SLIME("slime"),
-	/**
-	 * The particle that appears when breading animals
-	 */
-	HEART("heart"),
-	/**
-	 * The particle that appears when hitting a villager
-	 */
-	ANGRY_VILLAGER("angryVillager"),
-	/**
-	 * The particle that appears when trading with a villager
-	 */
-	HAPPY_VILLAGER("happyVillager"),
-	/**
-	 * The item's icon breaking.
-	 * This needs an ID
-	 */
-	ICON_CRACK("iconcrack", true),
-	/**
-	 * The block breaking particles.
-	 * This needs an ID and data value.
-	 */
-	TILE_CRACK("tilecrack", true, true);
-
-	private final String particleName;
-	private final boolean hasID;
-	private final boolean hasData;
-	
-	Particle(String particleName) {
-		this.particleName = particleName;
-		hasID = false;
-		hasData = false;
-	}
-	
-	Particle(String particleName, boolean hasID) {
-		this.particleName = particleName;
-		this.hasID = hasID;
-		hasData = false;
-	}
-	
-	Particle(String particleName, boolean hasID, boolean hasData) {
-		this.particleName = particleName;
-		this.hasID = true;
-		this.hasData = true;
-	}
-	
-	/**
-	 * Gets the name of the particle as used internally by minecraft
-	 * @return The particle's name
-	 */
-	public String getParticleName() {
-		return particleName;
-	}
-
-	/**
-	 * Returns whether the particle needs the extra ID information
-	 * @return Whether the particle needs extra ID information 
-	 */
-	public boolean hasID() {
-		return hasID;
-	}
-
-	/**
-	 * Returns whether the particle needs the extra data information
-	 * @return Whether the particle needs extra data information 
-	 */
-	public boolean hasData() {
-		return hasData;
-	}	
+    /**
+     * The biggest explosion particle effect
+     */
+    HUGE_EXPLOSION(),
+    /**
+     * A larger version of the explode particle
+     */
+    LARGE_EXPLODE(),
+    /**
+     * The spark that comes off a fireworks
+     */
+    FIREWORKS_SPARK(),
+    /**
+     * Currently shows nothing
+     */
+    BUBBLE(),
+    /**
+     * Currently shows nothing
+     */
+    SUSPENDED(),
+    /**
+     * Small gray particles
+     */
+    DEPTH_SUSPEND(),
+    /**
+     * Small gray particles
+     */
+    TOWNAURA(),
+    /**
+     * Crit particles
+     */
+    CRIT(),
+    /**
+     * Blue crit particles
+     */
+    MAGIC_CRIT(),
+    /**
+     * Smoke particles
+     */
+    SMOKE(),
+    /**
+     * Multicolored potion particles
+     */
+    MOB_SPELL(),
+    /**
+     * Multicolored potion particles that are slightly transparent
+     */
+    MOB_SPELL_AMBIENT(),
+    /**
+     * A puff of white particles
+     */
+    SPELL(),
+    /**
+     * A puff of white starts
+     */
+    INSTANT_SPELL(),
+    /**
+     * A puff of purple particles
+     */
+    WITCH_MAGIC(),
+    /**
+     * The note that appears above note blocks
+     */
+    NOTE(),
+    /**
+     * The particles shown at nether portals
+     */
+    PORTAL(),
+    /**
+     * The symbols that fly towards the enchantment table
+     */
+    ENCHANTMENT_TABLE(),
+    /**
+     * Explosion particles
+     */
+    EXPLODE(),
+    /**
+     * Fire particles
+     */
+    FLAME(),
+    /**
+     * The particles that pop out of lava
+     */
+    LAVA(),
+    /**
+     * A small gray square
+     */
+    FOOTSTEP(),
+    /**
+     * Water particles
+     */
+    SPLASH(),
+    /**
+     * Currently shows nothing
+     */
+    LARGE_SMOKE(),
+    /**
+     * A puff of smoke
+     */
+    CLOUD(),
+    /**
+     * Multicolored dust particles
+     */
+    REDDUST(),
+    /**
+     * Snowball breaking
+     */
+    SNOWBALL_POOF(),
+    /**
+     * The water drip particle that appears on blocks under water
+     */
+    DRIP_WATER(),
+    /**
+     * The lava drip particle that appears on blocks under lava
+     */
+    DRIP_LAVA(),
+    /**
+     * White particles
+     */
+    SNOW_SHOVEL(),
+    /**
+     * The particle shown when a slime jumps
+     */
+    SLIME(),
+    /**
+     * The particle that appears when breading animals
+     */
+    HEART(),
+    /**
+     * The particle that appears when hitting a villager
+     */
+    ANGRY_VILLAGER(),
+    /**
+     * The particle that appears when trading with a villager
+     */
+    HAPPY_VILLAGER(),
+    /**
+     * The item's icon breaking. This needs an ID
+     */
+    ICON_CRACK(true),
+    /**
+     * The block breaking particles. This needs an ID and data value.
+     */
+    TILE_CRACK(true, true);
+    
+    private final boolean hasID;
+    private final boolean hasData;
+    
+    Particle() {
+        hasID = false;
+        hasData = false;
+    }
+    
+    Particle(boolean hasID) {
+        this.hasID = hasID;
+        hasData = false;
+    }
+    
+    Particle(boolean hasID, boolean hasData) {
+        this.hasID = true;
+        this.hasData = true;
+    }
+    
+    /**
+     * Returns whether the particle needs the extra ID information
+     * 
+     * @return Whether the particle needs extra ID information
+     */
+    public boolean hasID() {
+        return hasID;
+    }
+    
+    /**
+     * Returns whether the particle needs the extra data information
+     * 
+     * @return Whether the particle needs extra data information
+     */
+    public boolean hasData() {
+        return hasData;
+    }
 }

--- a/src/main/java/org/bukkit/Particle.java
+++ b/src/main/java/org/bukkit/Particle.java
@@ -1,0 +1,196 @@
+package org.bukkit;
+
+public enum Particle {
+	/**
+	 * The biggest explosion particle effect
+	 */
+	HUGE_EXPLOSION("hugeexplosion"),
+	/**
+	 * A larger version of the explode particle
+	 */
+	LARGE_EXPLODE("largeexplode"),
+	/**
+	 * The spark that comes off a fireworks
+	 */
+	FIREWORKS_SPARK("fireworksSpark"),
+	/**
+	 * Currently shows nothing
+	 */
+	BUBBLE("bubble"),
+	/**
+	 * Currently shows nothing
+	 */
+	SUSPENDED("suspended"),
+	/**
+	 * Small gray particles
+	 */
+	DEPTH_SUSPEND("depthsuspend"),
+	/**
+	 * Small gray particles
+	 */
+	TOWNAURA("townaura"),
+	/**
+	 * Currently shows nothing
+	 */
+	CRIT("CRIT"),
+	/**
+	 * Blue crit particles
+	 */
+	MAGIC_CRIT("magicCrit"),
+	/**
+	 * Smoke particles
+	 */
+	SMOKE("smoke"),
+	/**
+	 * Multicolored potion particles
+	 */
+	MOB_SPELL("mobSpell"),
+	/**
+	 * Multicolored potion particles that are slightly transparent
+	 */
+	MOB_SPELL_AMBIENT("mobSpellAmbient"),
+	/**
+	 * A puff of white particles
+	 */
+	SPELL("spell"),
+	/**
+	 * A puff of white starts
+	 */
+	INSTANT_SPELL("instantSpell"),
+	/**
+	 * A puff of purple particles
+	 */
+	WITCH_MAGIC("witchMagic"),
+	/**
+	 * The note that appears above note blocks
+	 */
+	NOTE("note"),
+	/**
+	 * The particles shown at nether portals
+	 */
+	PORTAL("portal"),
+	/**
+	 * The symbols that fly towards the enchantment table
+	 */
+	ENCHANTMENT_TABLE("enchantmenttable"),
+	/**
+	 * Explosion particles
+	 */
+	EXPLODE("explode"),
+	/**
+	 * Fire particles
+	 */
+	FLAME("flame"),
+	/**
+	 * The particles that pop out of lava
+	 */
+	LAVA("lava"),
+	/**
+	 * A small gray square
+	 */
+	FOOTSTEP("footstep"),
+	/**
+	 * Water particles
+	 */
+	SPLASH("splash"),
+	/**
+	 * Currently shows nothing
+	 */
+	LARGE_SMOKE("largeSmoke"),
+	/**
+	 * A puff of smoke
+	 */
+	CLOUD("cloud"),
+	/**
+	 * Multicolored dust particles
+	 */
+	REDDUST("reddust"),
+	/**
+	 * Snowball breaking
+	 */
+	SNOWBALL_POOF("snowballpoof"),
+	/**
+	 * The water drip particle that appears on blocks under water
+	 */
+	DRIP_WATER("dripWater"),
+	/**
+	 * The lava drip particle that appears on blocks under lava
+	 */
+	DRIP_LAVA("dripLava"),
+	/**
+	 * White particles
+	 */
+	SNOW_SHOVEL("snowshovel"),
+	/**
+	 * The particle shown when a slime jumps
+	 */
+	SLIME("slime"),
+	/**
+	 * The particle that appears when breading animals
+	 */
+	HEART("heart"),
+	/**
+	 * The particle that appears when hitting a villager
+	 */
+	ANGRY_VILLAGER("angryVillager"),
+	/**
+	 * The particle that appears when trading with a villager
+	 */
+	HAPPY_VILLAGER("happyVillager"),
+	/**
+	 * The item's icon breaking.
+	 * This needs an ID
+	 */
+	ICON_CRACK("iconcrack", true),
+	/**
+	 * The block breaking particles.
+	 * This needs an ID and data value.
+	 */
+	TILE_CRACK("tilecrack", true, true);
+
+	private final String particleName;
+	private final boolean hasID;
+	private final boolean hasData;
+	
+	Particle(String particleName) {
+		this.particleName = particleName;
+		hasID = false;
+		hasData = false;
+	}
+	
+	Particle(String particleName, boolean hasID) {
+		this.particleName = particleName;
+		this.hasID = hasID;
+		hasData = false;
+	}
+	
+	Particle(String particleName, boolean hasID, boolean hasData) {
+		this.particleName = particleName;
+		this.hasID = true;
+		this.hasData = true;
+	}
+	
+	/**
+	 * Gets the name of the particle as used internally by minecraft
+	 * @return The particle's name
+	 */
+	public String getParticleName() {
+		return particleName;
+	}
+
+	/**
+	 * Returns whether the particle needs the extra ID information
+	 * @return Whether the particle needs extra ID information 
+	 */
+	public boolean hasID() {
+		return hasID;
+	}
+
+	/**
+	 * Returns whether the particle needs the extra data information
+	 * @return Whether the particle needs extra data information 
+	 */
+	public boolean hasData() {
+		return hasData;
+	}	
+}

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -716,6 +716,64 @@ public interface World extends PluginMessageRecipient, Metadatable {
      * @param radius the radius around the location
      */
     public <T> void playEffect(Location location, Effect effect, T data, int radius);
+    
+    /**
+     * Spawns a particle to all players within a default radius around a given location.
+     * 
+     * @param location the {@link Location} around which players must be to see the particle
+     * @param particle the {@link Particle}
+     */
+    public void spawnParticle(Location location, Particle particle);
+    
+    /**
+     * Spawns a particle to all players within a default radius around a given location with
+     * the additional id and data.
+     * 
+     * @param location the {@link Location} around which players must be to see the particle
+     * @param particle the {@link Particle}
+     * @param id the id to attach
+     * @param data the data to attach
+     */
+    public void spawnParticle(Location location, Particle particle, int id, int data);
+    
+    /**
+     * Spawns a particle to all players within a default radius around a given location 
+     * with the set speed.
+     * 
+     * @param location the {@link Location} around which players must be to see the particle
+     * @param particle the {@link Particle}
+     * @param speed the speed of the particle
+     */
+    public void spawnParticle(Location location, Particle particle, float speed);
+    
+    /**
+     * Spawns a particle to all players within a default radius around a given location 
+     * with the set speed and count.
+     * 
+     * @param location the {@link Location} around which players must be to see the particle
+     * @param particle the {@link Particle}
+     * @param speed the speed of the particle
+     * @param particleCount the number of particles to spawn
+     */
+    public void spawnParticle(Location location, Particle particle, float speed, int particleCount);
+    
+    /**
+     * Spawns a particle to all players within a given radius around a given location 
+     * with the set speed, count and the additional id and data. The particle will be randomly 
+     * offset by the given offset for each client.
+     * 
+     * @param location the {@link Location} around which players must be to see the particle
+     * @param particle the {@link Particle}
+     * @param id the id to attach
+     * @param data the data to attach
+     * @param offsetX the random X offset
+     * @param offsetY the random Y offset
+     * @param offsetZ the random Z offset
+     * @param speed the speed of the particle
+     * @param particle Count the number of particles to spawn
+     * @param radius the radius around the location
+     */
+    public void spawnParticle(Location location, Particle particle, int id, int data, float offsetX, float offsetY, float offsetZ, float speed, int particleCount, int radius);
 
     /**
      * Get empty chunk snapshot (equivalent to all air blocks), optionally including valid biome

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -726,8 +726,8 @@ public interface World extends PluginMessageRecipient, Metadatable {
     public void spawnParticle(Location location, Particle particle);
     
     /**
-     * Spawns a particle to all players within a default radius around a given location with
-     * the additional id and data.
+     * Spawns a particle to all players within a default radius around a given location with the
+     * additional id and data.
      * 
      * @param location the {@link Location} around which players must be to see the particle
      * @param particle the {@link Particle}
@@ -737,8 +737,8 @@ public interface World extends PluginMessageRecipient, Metadatable {
     public void spawnParticle(Location location, Particle particle, int id, int data);
     
     /**
-     * Spawns a particle to all players within a default radius around a given location 
-     * with the set speed.
+     * Spawns a particle to all players within a default radius around a given location with the set
+     * speed.
      * 
      * @param location the {@link Location} around which players must be to see the particle
      * @param particle the {@link Particle}
@@ -747,8 +747,8 @@ public interface World extends PluginMessageRecipient, Metadatable {
     public void spawnParticle(Location location, Particle particle, float speed);
     
     /**
-     * Spawns a particle to all players within a default radius around a given location 
-     * with the set speed and count.
+     * Spawns a particle to all players within a default radius around a given location with the set
+     * speed and count.
      * 
      * @param location the {@link Location} around which players must be to see the particle
      * @param particle the {@link Particle}
@@ -758,9 +758,9 @@ public interface World extends PluginMessageRecipient, Metadatable {
     public void spawnParticle(Location location, Particle particle, float speed, int particleCount);
     
     /**
-     * Spawns a particle to all players within a given radius around a given location 
-     * with the set speed, count and the additional id and data. The particle will be randomly 
-     * offset by the given offset for each client.
+     * Spawns a particle to all players within a given radius around a given location with the set
+     * speed, count and the additional id and data. The particle will be randomly offset by the
+     * given offset for each client.
      * 
      * @param location the {@link Location} around which players must be to see the particle
      * @param particle the {@link Particle}


### PR DESCRIPTION
**Justification for this PR:**

With 1.5 a new packet was added that allowed the server to spawn particles. I thought this would be a useful feature for bukkit plugins.

**PR Breakdown:**

This adds a spawnParticle method to World.

**Relevant PR:**

CB-1064 - https://github.com/Bukkit/CraftBukkit/pull/1064 - Add the spawnParticle method to World and new constructor to Packet63WorldParticles

**JIRA Ticket:**

BUKKIT-3792 - https://bukkit.atlassian.net/browse/BUKKIT-3792
