### PR TITLE
Add a way to get the source of a primed TNT entity

### DIFF
--- a/src/main/java/org/bukkit/entity/TNTPrimed.java
+++ b/src/main/java/org/bukkit/entity/TNTPrimed.java
@@ -29,7 +29,9 @@ public interface TNTPrimed extends Explosive {
      * The source will become null if the chunk this primed TNT is in
      * is unloaded then reloaded. If the source is a player that logs
      * out, this will actually not become null until the chunk this
-     * primed TNT is in unloads and then reloads.
+     * primed TNT is in unloads and then reloads. It will also be
+     * null if the source entity is no longer valid. (Dead or some
+     * other reason it is invalid.)
      *
      * @return the source of this primed TNT
      */

--- a/src/main/java/org/bukkit/entity/TNTPrimed.java
+++ b/src/main/java/org/bukkit/entity/TNTPrimed.java
@@ -17,4 +17,21 @@ public interface TNTPrimed extends Explosive {
      * @return the number of ticks until this TNTPrimed explodes
      */
     public int getFuseTicks();
+
+    /**
+     * Gets the source of this primed TNT. The source is the entity
+     * responsible for the creation of this primed TNT.
+     * (I.E. player ignites TNT with flint and steel.) Take note
+     * that this can be null if there is no suitable source.
+     * (created by the {@link org.bukkit.World#spawn(Location, Class)}
+     * method, for example.)
+     *
+     * The source will become null if the chunk this primed TNT is in
+     * is unloaded then reloaded. If the source is a player that logs
+     * out, this will actually not become null until the chunk this
+     * primed TNT is in unloads and then reloads.
+     *
+     * @return the source of this primed TNT
+     */
+    public Entity getSource();
 }


### PR DESCRIPTION
Since Minecraft 1.5, we can now get the source of a primed TNT entity, so
we just reflect those changes in bukkit

CB PR: https://github.com/Bukkit/CraftBukkit/pull/1065

JIRA: https://bukkit.atlassian.net/browse/BUKKIT-3815
