### PR TITLE
[B+C] BlockState for Command Blocks. Adds BUKKIT-3805

### DIFF
--- a/src/main/java/org/bukkit/block/CommandBlock.java
+++ b/src/main/java/org/bukkit/block/CommandBlock.java
@@ -1,0 +1,40 @@
+package org.bukkit.block;
+
+public interface CommandBlock extends BlockState {
+
+    /**
+     * Gets the command that this CommandBlock will run when powered.
+     * This will never return null.  If the CommandBlock does not have a
+     * command, an empty String will be returned instead.
+     *
+     * @return Command that this CommandBlock will run when powered.
+     */
+    public String getCommand();
+
+    /**
+     * Sets the command that this CommandBlock will run when powered.
+     * Setting the command to null is the same as setting it to an empty
+     * String.
+     *
+     * @param command Command that this CommandBlock will run when powered.
+     */
+    public void setCommand(String command);
+
+    /**
+     * Gets the name of this CommandBlock.  The name is used with commands
+     * that this CommandBlock executes.  This name will never be null, and
+     * by default is "@".
+     *
+     * @return Name of this CommandBlock.
+     */
+    public String getName();
+
+    /**
+     * Sets the name of this CommandBlock.  The name is used with commands
+     * that this CommandBlock executes.  Setting the name to null is the
+     * same as setting it to "@".
+     *
+     * @param name New name for this CommandBlock.
+     */
+    public void setName(String name);
+}


### PR DESCRIPTION
**The Issue:**

Currently in Bukkit there is no method whatsoever to modify the command or name of a Command Block. 

**Justification for this PR:**

Currently in Bukkit there is no way to modify, much less retrieve either the command or the name of Command Blocks.  This issue is particularly damaging to plugins such as WorldEdit, which attempt to copy and paste blocks, but face particular trouble with the inability to copy these values over using purely the bukkit API.  Other plugins, such as any logging plugin really, also face the issue of being unable to correctly replace blocks, which is a bit of a pain for the end user.

**PR Breakdown:**

This PR is relatively straightforward, adding a total of one new interface, with its four methods.  The first method, CommandBlock#getCommand() returns the command that the command block will execute when powered, as indicated in the javadoc.  It will never return null, as the server currently does not cope with a null value for the command.  The second method, CommandBlock#setCommand(String), is straightforward, and changes the command for the CommandBlock.  Setting it to null is the same as setting it to an empty string for the reason mentioned above: the server doesn't cope with a null value.The third method, CommandBlock#getName() simply gets the name of the Command Block.  The default name of a CommandBlock is "@", as described in the javadocs.  The final method is CommandBlock#setName(String), which changes the name of the CommandBlock.  As mentioned above, setting the name to null isn't handled well by the server, so setting it to null reverts it back to the default name, "@".

**Relevant PR(s):**

B-803 - https://github.com/Bukkit/Bukkit/pull/803 - Bukkit API addition for the BlockState for Command Blocks.
CB-1067 - https://github.com/Bukkit/CraftBukkit/pull/1067 - CraftBukkit Implementation of the new API.

**JIRA Ticket:**

BUKKIT-3805 - https://bukkit.atlassian.net/browse/BUKKIT-3805
