### PR TITLE
Adds command tab completion control

### DIFF
--- a/src/main/java/org/bukkit/Bukkit.java
+++ b/src/main/java/org/bukkit/Bukkit.java
@@ -388,6 +388,10 @@ public final class Bukkit {
         return server.getShutdownMessage();
     }
 
+    public static boolean isCommandTabEnabled() {
+        return server.isCommandTabEnabled();
+    }
+
     public static WarningState getWarningState() {
         return server.getWarningState();
     }

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -676,6 +676,13 @@ public interface Server extends PluginMessageRecipient {
     String getShutdownMessage();
 
     /**
+     * Gets if tab completion for command names is enabled
+     *
+     * @return True if enabled
+     */
+    boolean isCommandTabEnabled();
+
+    /**
      * Gets the current warning state for the server
      *
      * @return The configured WarningState

--- a/src/main/java/org/bukkit/command/SimpleCommandMap.java
+++ b/src/main/java/org/bukkit/command/SimpleCommandMap.java
@@ -218,6 +218,10 @@ public class SimpleCommandMap implements CommandMap {
         int spaceIndex = cmdLine.indexOf(' ');
 
         if (spaceIndex == -1) {
+            if (!server.isCommandTabEnabled()) {
+                return null;
+            }
+
             ArrayList<String> completions = new ArrayList<String>();
             Map<String, Command> knownCommands = this.knownCommands;
 


### PR DESCRIPTION
## Command Tab Control

Too many plugins do not implement permission correctly, and many servers end up having malicious users snooping around the server's commands by tab-completing command names, deducing which plugins are being used and many might even find a command that wasn't protected correctly to abuse, and to top it off - it doesn't even log it.

This lets server admins control if to allow tab completion for command names using a flag "command-tab-complete" in bukkit.yml.

**CraftBukkit PR:** https://github.com/Bukkit/CraftBukkit/pull/1069
**Leaky:** https://bukkit.atlassian.net/browse/BUKKIT-3812
