### PR TITLE
[B+C] Add heal() method to entities - BUKKIT-3641

### DIFF
--- a/src/main/java/org/bukkit/entity/Damageable.java
+++ b/src/main/java/org/bukkit/entity/Damageable.java
@@ -20,6 +20,20 @@ public interface Damageable extends Entity {
     void damage(int amount, Entity source);
 
     /**
+     * Heals the given amount of damage on this entity. If the amount given
+     * would overheal the entity, the health will be capped at maximum.
+     *
+     * <p />
+     * This method will, as a side effect, call a
+     * {@link org.bukkit.event.entity.EntityRegainHealthEvent} with a reason
+     * of CUSTOM.
+     *
+     * @param amount Amount of damage to heal
+     * @throws IllegalArgumentException on negative values
+     */
+    void heal(int amount);
+
+    /**
      * Gets the entity's health from 0 to {@link #getMaxHealth()}, where 0 is dead.
      *
      * @return Health represented from 0 to max


### PR DESCRIPTION
#### The Issue:

Given a plugin where players (or any other entities) are given extra health (Let's say it's some kind of PVP) there are five main tasks to do that I can think of:
- Instant kill (`setHealth(0)`)
- Constant damage (`damage(3, DamageSource.FOO`)
- Full Heal (`setHealth(getMaxHealth())`)
- Constant Heal

Absolute & Percent healing, right now, don't have an available API method - you have to use setHealth().
However, setHealth() throws an error if you give it a health higher than the current max health, necessitating a conditional branch.
#### Justification for this PR:

Current method to heal an entity requires the following:

``` java
// Given: int healAmount, Damageable entity
// One-line version
//  Note that this runs off of the PR screen
entity.setHealth((entity.getHealth() + healAmount > entity.getMaxHealth()) ? (entity.getHealth() + healAmount) : (entity.getMaxHealth()));
// Multi-line version
int newhealth = entity.getHealth() + healAmount;
if (newhealth > entity.getMaxHealth()) {
    entity.setHealth(entity.getMaxHealth()
} else {
    entity.setHealth(newhealth);
}
// Or some variation thereof.
```
#### PR Breakdown:
- Adds heal(int) to Damageable.
- Adds heal(int, EntityHealEvent.HealReason) to Damageable, for when plugins want a specific heal reason for other processing.
- Adds HealReason.PLUGIN to HealReason, to provide a sane default.
##### Relevant PR(s) and other discussions:

https://github.com/Bukkit/CraftBukkit/pull/1034
https://github.com/Bukkit/CraftBukkit/commit/2f68cb8b50d87a7f34fde84bae125c69bd920cdc#comments
##### JIRA Ticket:

BUKKIT-3641 - https://bukkit.atlassian.net/browse/BUKKIT-3641
