### PR TITLE
[B+C] Add conflictsWith method to ItemMeta. Adds BUKKIT-3830.

### DIFF
--- a/src/main/java/org/bukkit/inventory/meta/EnchantmentStorageMeta.java
+++ b/src/main/java/org/bukkit/inventory/meta/EnchantmentStorageMeta.java
@@ -61,5 +61,13 @@ public interface EnchantmentStorageMeta extends ItemMeta {
      */
     boolean removeStoredEnchant(Enchantment ench) throws IllegalArgumentException;
 
+    /**
+     * Checks if the specified enchantment conflicts with any enchantments in this ItemMeta.
+     *
+     * @param ench enchantment to test
+     * @return true if the enchantment conflicts, false otherwise
+     */
+    boolean hasConflictingStoredEnchant(Enchantment ench);
+
     EnchantmentStorageMeta clone();
 }

--- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
+++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
@@ -107,6 +107,14 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable {
      */
     boolean removeEnchant(Enchantment ench);
 
+   /**
+    * Checks if the specified enchantment conflicts with any enchantments in this ItemMeta.
+    *
+    * @param ench enchantment to test
+    * @return true if the enchantment conflicts, false otherwise
+    */
+    boolean hasConflictingEnchant(Enchantment ench);
+
     @SuppressWarnings("javadoc")
     ItemMeta clone();
 }


### PR DESCRIPTION
The Issue:

Currently, there is no way to check if a given enchantment conflicts with the enchantments already existing on an item. This adds an easy method to check this.

Relevant PR(s):
https://github.com/Bukkit/CraftBukkit/pull/1072

JIRA Ticket: BUKKIT-3830 - https://bukkit.atlassian.net/browse/BUKKIT-3830
