### PR TITLE
[B+C] Add getter/setter for command block redstone level, adds BUKKIT-3833

### DIFF
--- a/src/main/java/org/bukkit/block/CommandBlock.java
+++ b/src/main/java/org/bukkit/block/CommandBlock.java
@@ -37,7 +37,7 @@ public interface CommandBlock extends BlockState {
      * @param name New name for this CommandBlock.
      */
     public void setName(String name);
-    
+
     /**
      * Sets the redstone level for this CommandBlock. This redstone level
      * is used by comparators when placed against the CommandBlock facing 

--- a/src/main/java/org/bukkit/block/CommandBlock.java
+++ b/src/main/java/org/bukkit/block/CommandBlock.java
@@ -37,4 +37,18 @@ public interface CommandBlock extends BlockState {
      * @param name New name for this CommandBlock.
      */
     public void setName(String name);
+    
+    /**
+     * Sets the redstone level for this CommandBlock. This redstone level
+     * is used by comparators when placed against the CommandBlock facing 
+     * away from it
+     * @param level redstone level, 0-15
+     */
+	public void setRedstoneLevel(int level);
+
+	/**
+	 * Gets the redstone level of this CommandBlock.
+	 * @return redstone level, 0-15
+	 */
+	public int getRedstoneLevel();
 }


### PR DESCRIPTION
**The issue:**
Currently there is no way for a plugin (either via event or command) to set or get the redstone output level of a command block.

**Justification of this PR:**
This PR implements an interface for getting and setting the redstone output level of a command block via the BlockState interface. This can be be accessed inside commands via `BlockCommandSender.getBlock().getState()`

**PR Breakdown:**
This PR adds two new methods to CommandBlock, 

```
void setRedstoneLevel(int level) 
int getRedstoneLevel()
```

The related CB PR implements these.

**Testing Material and Results:**
A sample plugin code can be found here: https://gist.github.com/tehbeard/5208456 
This implements a command that when executed by a command block will take the first parameter, convert it to an int and then set the command block's redstone output to that value.

**Relevant PR(s):**
Bukkit/CraftBukkit#1075

**JIRA Ticket:**
https://bukkit.atlassian.net/browse/BUKKIT-3833
