### PR TITLE
[C+B] Make fishing success rate adjustable, and allow forcing a bite at any time. Adds BUKKIT-3837

### DIFF
--- a/src/main/java/org/bukkit/entity/Fish.java
+++ b/src/main/java/org/bukkit/entity/Fish.java
@@ -3,4 +3,9 @@ package org.bukkit.entity;
 /**
  * Represents a fishing hook.
  */
-public interface Fish extends Projectile {}
+public interface Fish extends Projectile {
+    /**
+     * causes a fish to bite the hook. 
+     */
+    public void bite();
+}

--- a/src/main/java/org/bukkit/entity/Fish.java
+++ b/src/main/java/org/bukkit/entity/Fish.java
@@ -7,8 +7,8 @@ public interface Fish extends Projectile {
 
     /**
      * Gets the chance of a fish biting.
-     *
-     * 0.0 = No Chance.
+     * <p>
+     * 0.0 = No Chance.<br>
      * 1.0 = Instant catch.
      *
      * @return chance
@@ -17,8 +17,8 @@ public interface Fish extends Projectile {
 
     /**
      * Sets the chance of a fish biting.
-     *
-     * 0.0 = No Chance.
+     * <p>
+     * 0.0 = No Chance.<br>
      * 1.0 = Instant catch.
      *
      * @param chance

--- a/src/main/java/org/bukkit/entity/Fish.java
+++ b/src/main/java/org/bukkit/entity/Fish.java
@@ -8,6 +8,10 @@ public interface Fish extends Projectile {
     /**
      * Gets the chance of a fish biting.
      *
+     * -1.0 = Use vanilla odds.
+     * 0.0 = No Chance.
+     * 1.0 = Instant catch.
+     *
      * @return chance
      */
     public double getBiteChance();
@@ -15,7 +19,11 @@ public interface Fish extends Projectile {
     /**
      * Sets the chance of a fish biting.
      *
-     * @param chance where 0.0 is never, 1.0 is very frequent
+     * -1.0 = Use vanilla odds.
+     * 0.0 = No Chance.
+     * 1.0 = Instant catch.
+     *
+     * @param chance
      */
     public void setBiteChance(double chance);
 

--- a/src/main/java/org/bukkit/entity/Fish.java
+++ b/src/main/java/org/bukkit/entity/Fish.java
@@ -8,4 +8,8 @@ public interface Fish extends Projectile {
      * causes a fish to bite the hook. 
      */
     public void bite();
+    public short getBiteChance();
+    public void setBiteChance(short chance);
+    public short getRainyBiteChance();
+    public void setRainyBiteChance(short chance);
 }

--- a/src/main/java/org/bukkit/entity/Fish.java
+++ b/src/main/java/org/bukkit/entity/Fish.java
@@ -6,35 +6,17 @@ package org.bukkit.entity;
 public interface Fish extends Projectile {
 
     /**
-     * Causes a fish to bite the hook.
-     */
-    public void bite();
-
-    /**
-     * Gets the chance of a fish biting during normal weather.
+     * Gets the chance of a fish biting.
      *
      * @return chance
      */
-    public short getBiteChance();
+    public double getBiteChance();
 
     /**
-     * Sets the chance of a fish biting during normal weather.
+     * Sets the chance of a fish biting.
      *
-     * @param chance "1-in-chance" chance of triggering a bite each tick
+     * @param chance where 0.0 is never, 1.0 is very frequent
      */
-    public void setBiteChance(short chance);
+    public void setBiteChance(double chance);
 
-    /**
-     * Gets the chance of a fish biting outdoors during rain.
-     *
-     * @return chance
-     */
-    public short getRainyBiteChance();
-
-    /**
-     * Sets the chance of a fish biting outdoors during rain.
-     *
-     * @param chance "1-in-chance" chance of triggering a bite each tick
-     */
-    public void setRainyBiteChance(short chance);
 }

--- a/src/main/java/org/bukkit/entity/Fish.java
+++ b/src/main/java/org/bukkit/entity/Fish.java
@@ -8,7 +8,6 @@ public interface Fish extends Projectile {
     /**
      * Gets the chance of a fish biting.
      *
-     * -1.0 = Use vanilla odds.
      * 0.0 = No Chance.
      * 1.0 = Instant catch.
      *
@@ -19,7 +18,6 @@ public interface Fish extends Projectile {
     /**
      * Sets the chance of a fish biting.
      *
-     * -1.0 = Use vanilla odds.
      * 0.0 = No Chance.
      * 1.0 = Instant catch.
      *

--- a/src/main/java/org/bukkit/entity/Fish.java
+++ b/src/main/java/org/bukkit/entity/Fish.java
@@ -6,7 +6,7 @@ package org.bukkit.entity;
 public interface Fish extends Projectile {
 
     /**
-     * causes a fish to bite the hook.
+     * Causes a fish to bite the hook.
      */
     public void bite();
 
@@ -34,7 +34,7 @@ public interface Fish extends Projectile {
     /**
      * Sets the chance of a fish biting outdoors during rain.
      *
-     * @param chance - "1-in-chance" chance chance of triggering a bite each tick
+     * @param chance "1-in-chance" chance of triggering a bite each tick
      */
     public void setRainyBiteChance(short chance);
 }

--- a/src/main/java/org/bukkit/entity/Fish.java
+++ b/src/main/java/org/bukkit/entity/Fish.java
@@ -4,12 +4,37 @@ package org.bukkit.entity;
  * Represents a fishing hook.
  */
 public interface Fish extends Projectile {
+
     /**
-     * causes a fish to bite the hook. 
+     * causes a fish to bite the hook.
      */
     public void bite();
+
+    /**
+     * Gets the chance of a fish biting during normal weather.
+     *
+     * @return chance
+     */
     public short getBiteChance();
+
+    /**
+     * Sets the chance of a fish biting during normal weather.
+     *
+     * @param chance "1-in-chance" chance of triggering a bite each tick
+     */
     public void setBiteChance(short chance);
+
+    /**
+     * Gets the chance of a fish biting outdoors during rain.
+     *
+     * @return chance
+     */
     public short getRainyBiteChance();
+
+    /**
+     * Sets the chance of a fish biting outdoors during rain.
+     *
+     * @param chance - "1-in-chance" chance chance of triggering a bite each tick
+     */
     public void setRainyBiteChance(short chance);
 }


### PR DESCRIPTION
This code adds two ways for plugins to enhance fishing. It changes the constant values that represent fishing success rate to be variable and exposes them through the Fish entity. It also adds a .bite() method to the Fish to directly force a bite on the next tick.

both features rely on https://github.com/Bukkit/Bukkit/pull/781 to allow plugins to access the hook in the first place.

Leaky Ticket: https://bukkit.atlassian.net/browse/BUKKIT-3837

CraftBukkit PR: https://github.com/Bukkit/CraftBukkit/pull/1077
