### PR TITLE
[B+C] Add API for players affecting mob spawning. Adds BUKKIT-3850

### DIFF
--- a/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -160,4 +160,18 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, Permissible, Inv
      * @return Experience required to level up
      */
     public int getExpToLevel();
+
+    /**
+    * Setting this to false prevents players from activating mob spawners
+    * and allows mobs to randomly spawn and despawn near them (which
+    * normally can't happen).
+    *
+    * @param affect true to prevent this player from affecting mob spawning
+    */
+    public void setAffectsMobSpawning(boolean affect);
+
+    /**
+     * @return Whether this player affects mob spawning
+    */
+    public boolean getAffectsMobSpawning();
 }


### PR DESCRIPTION
Add an API so that players can be flagged as not affecting mob spawning.
Those that don't affect spawning will not activate mob spawners and will
be ignored by the natural spawning and despawning algorithms.

This is a update & reimplentation of the PR originally opened here: https://github.com/Bukkit/Bukkit/issues/609

CraftBukkit PR: https://github.com/Bukkit/CraftBukkit/pull/1084
