### PR TITLE
[B] Rename Fish to FishHook - Add BUKKIT-3856

### DIFF
--- a/src/main/java/org/bukkit/entity/Fish.java
+++ b/src/main/java/org/bukkit/entity/Fish.java
@@ -2,8 +2,9 @@ package org.bukkit.entity;
 
 /**
  * Represents a fishing hook.
+ * @deprecated in favor of {@link FishHook}
  */
-public interface Fish extends Projectile {
+public interface Fish extends FishHook {
 
     /**
      * Gets the chance of a fish biting.

--- a/src/main/java/org/bukkit/entity/FishHook.java
+++ b/src/main/java/org/bukkit/entity/FishHook.java
@@ -1,0 +1,7 @@
+package org.bukkit.entity;
+
+/**
+ * Represents a fishing hook.
+ */
+public interface FishHook extends Projectile {
+}


### PR DESCRIPTION
### Problem

Fish is a badly named class.
### Justification

Future-proofing against Mojang eventually adding actual fish to the game.
Additionally, all other classes in the entity package are very clear in their names, such as `Pig`, while Fish is actually misleading in its name.
### PR Description

This change creates the FishHook class for current use and future transitioning to.
This is a **non-breaking change**.

https://bukkit.atlassian.net/browse/BUKKIT-3856
