### PR TITLE
[B+C] Add broadcast function that sends to a player list

### DIFF
--- a/src/main/java/org/bukkit/Bukkit.java
+++ b/src/main/java/org/bukkit/Bukkit.java
@@ -255,6 +255,10 @@ public final class Bukkit {
     public static int broadcast(String message, String permission) {
         return server.broadcast(message, permission);
     }
+    
+    public static int broadcast(String message, List<Player> players) {
+        return server.broadcast(message, players);
+    }
 
     public static OfflinePlayer getOfflinePlayer(String name) {
         return server.getOfflinePlayer(name);

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -509,6 +509,15 @@ public interface Server extends PluginMessageRecipient {
     public int broadcast(String message, String permission);
 
     /**
+     * Broadcasts the specified message to every user in the list
+     * 
+     * @param message Message to broadcast
+     * @param players List of players to broadcast to
+     * @return Amount of users who received the message
+     */
+    public int broadcast(String message, List<Player> players);
+
+    /**
      * Gets the player by the given name, regardless if they are offline or online.
      * <p />
      * This will return an object even if the player does not exist. To this method, all players will exist.


### PR DESCRIPTION
**The Issue:**
Currently, the only way that you can send a message to a select group of players is with your own for loop or permissions, which can be redundant at times.

**Justification of this PR:**
This PR includes a method for broadcasting a message to a list of players, which is included in the Bukkit.java and Server.java classes.

**PR Breakdown:**
This PR adds one new method to the Bukkit.java and Server.java classes,

``` java
ArrayList<Player> players = new ArrayList<>();
players.add(Bukkit.getServer().getPlayer("KeybordPiano459"));
Bukkit.broadcast("Hello world!", players);
```

**Testing Material and Results:**
I created some sample code on how you would use this method here:
https://gist.github.com/keybordpiano459/7b77760f74b39aeb8006

**Relevant PR(s):**
https://github.com/Bukkit/CraftBukkit/pull/1085

**JIRA Ticket:**
https://bukkit.atlassian.net/browse/BUKKIT-3857
