### PR TITLE
[C+B] Adds BUKKIT-3859, InventoryPaintEvent

### DIFF
--- a/src/main/java/org/bukkit/event/inventory/InventoryPaintEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryPaintEvent.java
@@ -1,0 +1,172 @@
+package org.bukkit.event.inventory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryView;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.inventory.InventoryType.SlotType;
+import org.bukkit.inventory.ItemStack;
+
+public class InventoryPaintEvent extends InventoryEvent implements Cancellable {
+
+    public class PaintedSlot {
+        private ItemStack item;
+        private ItemStack result;
+        private SlotType slotType;
+        private int whichSlot;
+        private int rawSlot;
+
+        private PaintedSlot(int rawSlot, int amount) {
+            InventoryView view = getView();
+            item = view.getItem(rawSlot);
+            result = view.getCursor();
+            if (result != null) {
+                result = result.clone();
+                result.setAmount(item.getAmount() + amount);
+            }
+            slotType = view.getSlotType(rawSlot);
+            whichSlot = view.convertSlot(rawSlot);
+            this.rawSlot = rawSlot;
+        }
+
+        /**
+         * <p>Gets the item in the painted slot.</p>
+         * @return The item
+         */
+        public ItemStack getItem() {
+            return item.clone();
+        }
+
+        /**
+         * <p>Gets the result item in the painted slot after the painting is done.</p>
+         *
+         * <p>Changes to this item stack will be reflected in the inventory.</p>
+         * @return The result item
+         */
+        public ItemStack getResult() {
+            return result;
+        }
+
+        /**
+         * <p>Sets the result item in the painted slot.</p>
+         * @param result The result item
+         */
+        public void setResult(ItemStack result) {
+            this.result = result;
+        }
+
+        /**
+         * <p>Gets the painted slot's type.</p>
+         * @return The slot type
+         */
+        public SlotType getSlotType() {
+            return slotType;
+        }
+
+        /**
+         * <p>The slot number that was clicked, ready for passing to {@link Inventory#getItem(int)}.</p>
+         *
+         * <p>Note that there may be two slots with the same slot number, since a view links two different inventories.</p>
+         * @return The slot number.
+         */
+        public int getSlot() {
+            return whichSlot;
+        }
+
+        /**
+         * <p>The raw slot number, which is unique for the view.</p>
+         * @return The slot number.
+         */
+        public int getRawSlot() {
+            return rawSlot;
+        }
+    }
+
+    private static final HandlerList handlers = new HandlerList();
+    private ItemStack cursor;
+    private boolean rightClick;
+    private List<PaintedSlot> slots;
+    private boolean cancelled;
+
+    public InventoryPaintEvent(InventoryView what, ItemStack cursor, boolean right, Map<Integer, Integer> slots) {
+        super(what);
+        this.cursor = cursor;
+        this.rightClick = right;
+        this.slots = new ArrayList<PaintedSlot>();
+        for (Map.Entry<Integer, Integer> slot : slots.entrySet()) {
+            this.slots.add(new PaintedSlot(slot.getKey(), slot.getValue()));
+        }
+    }
+
+    /**
+     * <p>Get the result cursor after the painting is done.</p>
+     *
+     * <p>Changing this item stack changes the cursor item. Note that changing the affected "painted" slots does not update this item stack to reflect the changes you've made.</p>
+     *
+     * <p>To get the cursor item before the painting begins, use {@link #getView()} and then {@link InventoryView#getCursor()}</p>
+     * @return The cursor item
+     */
+    public ItemStack getCursor() {
+        return this.cursor;
+    }
+
+    /**
+     * <p>Sets the result cursor after the painting is done.</p>
+     * @param cursor The new cursor item
+     */
+    public void setCursor(ItemStack cursor) {
+        this.cursor = cursor;
+    }
+
+    /**
+     * @return True if the click is a right-click.
+     */
+    public boolean isRightClick() {
+        return rightClick;
+    }
+
+    /**
+     * @return True if the click is a left-click.
+     */
+    public boolean isLeftClick() {
+        return !rightClick;
+    }
+
+    /**
+     * <p>Get the player who performed the click.</p>
+     * @return The clicking player.
+     */
+    public HumanEntity getWhoClicked() {
+        return getView().getPlayer();
+    }
+
+    /**
+     * <p>Gets a list of painted slots.</p>
+     * @return The list of painted slots.
+     */
+    public List<PaintedSlot> getPaintedSlots() {
+        return slots;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(boolean toCancel) {
+        cancelled = toCancel;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/org/bukkit/inventory/InventoryView.java
+++ b/src/main/java/org/bukkit/inventory/InventoryView.java
@@ -2,6 +2,7 @@ package org.bukkit.inventory;
 
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.inventory.InventoryType.SlotType;
 
 /**
  * Represents a view linking two inventories and a single player
@@ -85,6 +86,13 @@ public abstract class InventoryView {
      * @return the inventory type
      */
     public abstract InventoryType getType();
+
+    /**
+     * Gets the slot type by its raw slot ID in this inventory view.
+     * @param slot The raw slot ID
+     * @return The slot type
+     */
+    public abstract SlotType getSlotType(int slot);
 
     /**
      * Sets one item in this inventory view by its raw slot ID.


### PR DESCRIPTION
## Added InventoryPaintEvent

Since 1.5 there's two new inventory operations:
- **Painting mode** - where you can drag a stack of items onto slots to "paint" with it. If you left click, you split the items evenly across the painted slots, and if you right click you put 1 in each slot.
- **Stacking mode** - where a double click on an item attempts to stack at the cursor all items that are equal to the double clicked item.
### What's happening

When the client paints is that when the client releases the mouse button, it goes through 3 steps:
- Send a signal packet with raw slot ID -999 and action modifier 5 (Called Packet102WindowClick.shift for some reason) with a null ItemStack. This tells the server to start painting.
- A batch of  windows click packets (Packet102WindowClick) for every slot. The server accumulates these clicks and then...
- Send another signal packet indicating the end of painting operation. At this point the server runs the logic for all the slots and distributes the item stack in the cursor to the selected slots depending on which mouse button the client held.

To make everything worse, there's also a bug that sometimes makes normal click operations act like painting operations for a single item.
### The problem

As it is now, Bukkit is not equipped to deal with these operations.
Bukkit does not detect the signal packets and filter them out, and send InventoryClickEvent for them anyways, which causes problems to plugins monitoring it, and for the rest of the packets, it doesn't detect the items put in the slots or the cursor state because the logic is done only when the end signal packet arrives.
### The solution

InventoryPaintEvent handles this problem by filtering out all painting mode packets, and throwing a flexible, cancellable event for all the accumulated packet changes.
The event saves the changes to the slots and allows plugin developers to react to each slot individually by modifying the list of slots. After the event finishes, any changes made to the operation will be applied to the slots.

Using this implementation you can:
- Cancel the event completely.
- Cancel changes to individual slots.
- Get the itemstacks for each slot before the painting operation.
- Get the cursor itemstack before the painting operation.
- Change each slot's result item stack individually.
- Get the result cursor itemstack after the painting operation (Changes to slot itemstacks after the event is raised are not reflected in the result cursor itemstack).
- Change the result cursor itemstack.

**Note:** I chose not to extend InventoryClickEvent since it is not a click, it's a hold operation, and also not to check type/damage/amount for result items (going by the decision in my EntityEquipEvent PR).

**CraftBukkit PR:** https://github.com/Bukkit/CraftBukkit/pull/1090
**Leaky:** https://bukkit.atlassian.net/browse/BUKKIT-3859
