### PR TITLE
[C+B] Add in sendSignChange(), fixes BUKKIT-2300

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -269,6 +269,22 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
     public void sendBlockChange(Location loc, int material, byte data);
 
     /**
+     * Send a sign change. This fakes a sign change packet for a user at
+     * a certain location. This will not actually change the world in any way.
+     * This method will use a sign at the location's block or a faked sign
+     * sent via {@link #sendBlockChange(org.bukkit.Location, int, byte)} or
+     * {@link #sendBlockChange(org.bukkit.Location, org.bukkit.Material, byte)}.
+     * This method fails, notifying the client of an unknown sign if neither
+     * of these exist.
+     *
+     * @param loc The location of the sign
+     * @param lines The new text on the sign, each line trimmed to 15 characters
+     * @throws IllegalArgumentException if the location is not a sign
+     * @throws IllegalArgumentException if location is null
+     */
+    public void sendSignChange(Location loc, String[] lines);
+
+    /**
      * Render a map and send it to the player in its entirety. This may be used
      * when streaming the map in the normal manner is not desirbale.
      *

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -274,12 +274,11 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      * This method will use a sign at the location's block or a faked sign
      * sent via {@link #sendBlockChange(org.bukkit.Location, int, byte)} or
      * {@link #sendBlockChange(org.bukkit.Location, org.bukkit.Material, byte)}.
-     * This method fails, notifying the client of an unknown sign if neither
-     * of these exist.
+     * This method notifies the client of an unknown sign if neither of
+     * these exist.
      *
      * @param loc The location of the sign
-     * @param lines The new text on the sign, each line trimmed to 15 characters
-     * @throws IllegalArgumentException if the location is not a sign
+     * @param lines The new text on the sign
      * @throws IllegalArgumentException if location is null
      */
     public void sendSignChange(Location loc, String[] lines);


### PR DESCRIPTION
##### The Issue:

In Bukkit, there exists a player.sendBlockChange() that is able to send signs to clients, but the signs are blank due to the lack of a method to set them. Sign text is send via the SignUpdate packet, so the method will need to use this packet for the faked signs.
##### Justification for this PR:

With player.sendBlockChange(), you can send a block with a specific data value, such as a sign with a specific rotation. What you can not send with this is the text on said signs, or even have per player signs without some modification to CraftBukkit, probably using this same method.
##### PR Breakdown:

This PR implements a way to fake a sign update packet. It takes a location and an array of Strings. Before the packet is created, it does some validation to the array, making sure each line is not null and less than 16 characters (the text limit on a sign in nms). Afterwards, it sends the SignUpdate packet with the x, y, and z coordinates of the location and the validated array to the client.

The reason that I don't validate that the location given is a sign or not is that we don't know what the client thinks. A previous valid call to player.sendBlockChange() creating a sign client side would be unknown to the server, so it doesn't matter if the location server side is a sign or not.
##### Testing Results and Materials:

In order to test this, I created a plugin that used the newly created sendSignChange() method with the player's "target" block as the location parameter. The args were then directly handed over to the method, allowing me to create nulls and arrays too short. I also created a second command that uses the existing sendBlockChange() methods to send a sign to the client at their target location. This allowed me to test the sendSignChange() method on clientside signs.

The results of the testing were good. Calling sendSignChange() with a sign as the player's target block changes the lines as expected, trimming any lines longer than 15 and setting nulls to blank strings. Calling sendSignChange() with a sendBlockChange() sign as the target also works as expected. However, calling sendSignChange() with a location that does not show a sign on the client side ends with the client saying "Unable to locate sign at x, y, z" in chat. The client can not crash out of the game using the sendSignChange() method.

Test plugin jar: https://dl.dropbox.com/u/59767756/SendSignChangeTest-1.0-SNAPSHOT.jar
Test plugin source: https://github.com/psycowithespn/SendSignChangeTest
Test plugin usage:
/testchange [lines] - lines to change the target "sign" to  using sendSignChange().
/testfake - creates a fake sign using player.sendBlockChange().
##### Relevant PR(s):

CB- https://github.com/Bukkit/CraftBukkit/pull/1094
##### JIRA Ticket:

BUKKIT-2300 - https://bukkit.atlassian.net/browse/BUKKIT-2300
