### PR TITLE
[B] Rename ExplosionPrimeEvent - Fixes BUKKIT-2610, BUKKIT-3885

### DIFF
--- a/src/main/java/org/bukkit/event/entity/EntityPreExplodeEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityPreExplodeEvent.java
@@ -1,0 +1,77 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Explosive;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+public class EntityPreExplodeEvent extends EntityEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancel;
+    private float radius;
+    private boolean fire;
+
+    public EntityPreExplodeEvent(final Entity what, final float radius, final boolean fire) {
+        super(what);
+        this.cancel = false;
+        this.radius = radius;
+        this.fire = fire;
+    }
+
+    public EntityPreExplodeEvent(final Explosive explosive) {
+        this(explosive, explosive.getYield(), explosive.isIncendiary());
+    }
+
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+
+    /**
+     * Gets the radius of the explosion
+     *
+     * @return returns the radius of the explosion
+     */
+    public float getRadius() {
+        return radius;
+    }
+
+    /**
+     * Sets the radius of the explosion
+     *
+     * @param radius the radius of the explosion
+     */
+    public void setRadius(float radius) {
+        this.radius = radius;
+    }
+
+    /**
+     * Gets whether this explosion will create fire or not
+     *
+     * @return true if this explosion will create fire
+     */
+    public boolean getFire() {
+        return fire;
+    }
+
+    /**
+     * Sets whether this explosion will create fire or not
+     *
+     * @param fire true if you want this explosion to create fire
+     */
+    public void setFire(boolean fire) {
+        this.fire = fire;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/org/bukkit/event/entity/ExplosionPrimeEvent.java
+++ b/src/main/java/org/bukkit/event/entity/ExplosionPrimeEvent.java
@@ -2,79 +2,26 @@ package org.bukkit.event.entity;
 
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Explosive;
-import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
 /**
  * Called when an entity has made a decision to explode.
+ * @deprecated in favor of {@link EntityPreExplodeEvent} due to bad name
  */
-public class ExplosionPrimeEvent extends EntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-    private boolean cancel;
-    private float radius;
-    private boolean fire;
-
+public class ExplosionPrimeEvent extends EntityPreExplodeEvent {
     public ExplosionPrimeEvent(final Entity what, final float radius, final boolean fire) {
-        super(what);
-        this.cancel = false;
-        this.radius = radius;
-        this.fire = fire;
+        super(what, radius, fire);
     }
 
     public ExplosionPrimeEvent(final Explosive explosive) {
         this(explosive, explosive.getYield(), explosive.isIncendiary());
     }
 
-    public boolean isCancelled() {
-        return cancel;
-    }
-
-    public void setCancelled(boolean cancel) {
-        this.cancel = cancel;
-    }
-
-    /**
-     * Gets the radius of the explosion
-     *
-     * @return returns the radius of the explosion
-     */
-    public float getRadius() {
-        return radius;
-    }
-
-    /**
-     * Sets the radius of the explosion
-     *
-     * @param radius the radius of the explosion
-     */
-    public void setRadius(float radius) {
-        this.radius = radius;
-    }
-
-    /**
-     * Gets whether this explosion will create fire or not
-     *
-     * @return true if this explosion will create fire
-     */
-    public boolean getFire() {
-        return fire;
-    }
-
-    /**
-     * Sets whether this explosion will create fire or not
-     *
-     * @param fire true if you want this explosion to create fire
-     */
-    public void setFire(boolean fire) {
-        this.fire = fire;
-    }
-
-    @Override
     public HandlerList getHandlers() {
-        return handlers;
+        return super.getHandlers();
     }
 
     public static HandlerList getHandlerList() {
-        return handlers;
+        return EntityPreExplodeEvent.getHandlerList();
     }
 }


### PR DESCRIPTION
This renames the ExplosionPrimeEvent to EntityPreExplodeEvent in a non-breaking way.

https://bukkit.atlassian.net/browse/BUKKIT-2610
https://bukkit.atlassian.net/browse/BUKKIT-3885

After this is pulled, BUKKIT-286, BUKKIT-770, and BUKKIT-2231 can continue.

https://bukkit.atlassian.net/browse/BUKKIT-286
https://bukkit.atlassian.net/browse/BUKKIT-770
https://bukkit.atlassian.net/browse/BUKKIT-2231
