### PR TITLE
Change the hashset of getLineOfSight(), getTargetBlock() and ...

### DIFF
--- a/src/main/java/org/bukkit/entity/LivingEntity.java
+++ b/src/main/java/org/bukkit/entity/LivingEntity.java
@@ -44,7 +44,7 @@ public interface LivingEntity extends Entity, Damageable {
      * @param maxDistance This is the maximum distance to scan. This may be further limited by the server, but never to less than 100 blocks.
      * @return List containing all blocks along the player's line of sight
      */
-    public List<Block> getLineOfSight(HashSet<Byte> transparent, int maxDistance);
+    public List<Block> getLineOfSight(HashSet<Short> transparent, int maxDistance);
 
     /**
      * Gets the block that the player has targeted
@@ -53,7 +53,7 @@ public interface LivingEntity extends Entity, Damageable {
      * @param maxDistance This is the maximum distance to scan. This may be further limited by the server, but never to less than 100 blocks.
      * @return Block that the player has targeted
      */
-    public Block getTargetBlock(HashSet<Byte> transparent, int maxDistance);
+    public Block getTargetBlock(HashSet<Short> transparent, int maxDistance);
 
     /**
      * Gets the last two blocks along the player's line of sight.
@@ -63,7 +63,7 @@ public interface LivingEntity extends Entity, Damageable {
      * @param maxDistance This is the maximum distance to scan. This may be further limited by the server, but never to less than 100 blocks
      * @return List containing the last 2 blocks along the player's line of sight
      */
-    public List<Block> getLastTwoTargetBlocks(HashSet<Byte> transparent, int maxDistance);
+    public List<Block> getLastTwoTargetBlocks(HashSet<Short> transparent, int maxDistance);
 
     /**
      * Throws an egg from the entity.


### PR DESCRIPTION
...getLastTwoTargetBlocks() to short

As all three of these methods currently use a HashSet that takes a Byte, it
is not possible to include block IDs greater than 127, as they would have
negative values, and thus be ignored by direct comparison, so we use a Short instead.

JIRA: https://bukkit.atlassian.net/browse/BUKKIT-3888
