### PR TITLE
[B] Give plugins a chance to modify Avaje ServerConfig. Adds BUKKIT-3919

### DIFF
--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
@@ -283,8 +283,7 @@ public abstract class JavaPlugin extends PluginBase {
      *
      * @param config ServerConfig to populate
      */
-    protected void configureDbConfig(ServerConfig config) {
-    }
+    protected void configureDbConfig(ServerConfig config) {}
 
     private String replaceDatabaseString(String input) {
         input = input.replaceAll("\\{DIR\\}", dataFolder.getPath().replaceAll("\\\\", "/") + "/");

--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
@@ -248,6 +248,7 @@ public abstract class JavaPlugin extends PluginBase {
             if (description.isDatabaseEnabled()) {
                 ServerConfig db = new ServerConfig();
 
+                configureDbConfig(db);
                 db.setDefaultServer(false);
                 db.setRegister(false);
                 db.setClasses(getDatabaseClasses());
@@ -275,6 +276,14 @@ public abstract class JavaPlugin extends PluginBase {
      */
     public List<Class<?>> getDatabaseClasses() {
         return new ArrayList<Class<?>>();
+    }
+
+    /**
+     * Populates a given {@link ServerConfig} with plugin-specific attributes.
+     *
+     * @param config ServerConfig to populate
+     */
+    protected void configureDbConfig(ServerConfig config) {
     }
 
     private String replaceDatabaseString(String input) {


### PR DESCRIPTION
##### The Issue:

Plugins that use Avaje Ebeans have no visibility on the ServerConfig before EbeanServerFactory.create() is called. Of the ServerConfig properties that are not explicitly set by Bukkit, the `NamingConvention` property is probably the most interesting &mdash; it would allow a plugin to dynamically alter the names of its tables. (Otherwise the names of the tables are fixed at compile-time &mdash; using either the name of the class or a class-level annotation.)
##### Justification for this PR:

Allows plugins to change NamingConvention, Avaje logging options (e.g. debug SQL logging), or other options.
##### PR Breakdown:

This PR adds a protected, non-final method named `configureDbConfig` to JavaPlugin. The default implementation does nothing. (The name and signature mirrors the method in the Server interface, which conceptually does the same thing.)

This new method is called shortly after the creation of the ServerConfig but before Bukkit explicitly sets its own values for the plugin.
##### Testing Results and Materials:

Available upon request. I have a proof-of-concept of one of my plugins (zPermissions) which overrides JavaPlugin's `configureDbConfig` and installs its own `NamingConvention` implementation which adds a prefix to all of the plugin's tables.
##### JIRA Ticket:

https://bukkit.atlassian.net/browse/BUKKIT-3919
