### PR TITLE
[B + C] Adds a villager trading API. Adds BUKKIT-2138, BUKKIT-3935

### DIFF
--- a/src/main/java/org/bukkit/entity/Merchant.java
+++ b/src/main/java/org/bukkit/entity/Merchant.java
@@ -1,0 +1,127 @@
+package org.bukkit.entity;
+
+import java.util.List;
+
+import org.apache.commons.lang.Validate;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Represents a Entity that can trade with other HumanEntities
+ */
+public interface Merchant extends Entity {
+
+
+    /**
+     * Get a list of trades that the villages trades
+     * 
+     * @return all the trades the villager can perform
+     */
+    public List<MerchantTrade> getTrades();
+
+    /**
+     * Get a list of trades that the villages trades for a specific player
+     * 
+     * @return all the trades the villager can perform to a specific player
+     */
+    public List<MerchantTrade> getTrades(Player player);
+
+    /**
+     * Add a trade to the merchants trades
+     * 
+     * @param trade a new trade for the villager to perform
+     */
+    public void addTrade(MerchantTrade trade);
+    
+    /**
+     * Remove a trade from the merchants trades
+     * 
+     * @param trade the trade to remove
+     */
+    public void removeTrade(MerchantTrade trade);
+    
+    /**
+     * Set the list of trades for this merchant
+     * 
+     * @param trades the new trade list
+     */
+    public void setTrades(List<MerchantTrade> trades);
+    
+    /**
+     * Represents a trade a villager can make
+     */
+    public class MerchantTrade {
+
+    	private ItemStack product;
+    	private ItemStack[] price;
+		private int tradesLeft;
+    	
+    	/**
+    	 * Create a new villager trade defining the product and price for that product
+    	 * 
+    	 * @param product the item that the villager sells
+    	 * @param price the item(s) that the villager defines as the price for the product
+    	 */
+    	public MerchantTrade(ItemStack product, ItemStack...  price) {
+    		Validate.isTrue(price.length <= 2, "The price can only be a maximum of two items");
+    		
+    		this.product = product;
+    		this.price = price;
+    	}
+    	
+    	/**
+    	 * Get the price of this trade
+    	 * 
+    	 * @return the price of this trade, either one or two item stacks in array
+    	 */
+    	public ItemStack[] getPrice() {
+    		return price;
+    	}
+    	
+    	/**
+    	 * Get the product this villager trades for
+    	 * 
+    	 * @return the product that this villager trades
+    	 */
+    	public ItemStack getProduct() {
+    		return product;
+    	}
+    	
+    	/**
+    	 * Set the price of this trade
+    	 * 
+    	 * @param price the price of the trade, a maximum of two items
+    	 */
+    	public void setPrice(ItemStack... price) {
+    		Validate.isTrue(price.length <= 2, "The price can only be a maximum of two items");
+    		
+    		this.price = price;
+    	}
+    	
+    	/**
+    	 * Set the product that this villager trades
+    	 * 
+    	 * @param product the product the villager trades
+    	 */
+    	public void setProduct(ItemStack product) {
+    		this.product = product;
+    	}
+    	
+    	/**
+    	 * Gets the amount of trades this specific trade has left
+    	 * 
+    	 * @return the amount of trades left
+    	 */
+    	public int getTradesLeft() {
+    		return tradesLeft;
+    	}
+    	
+    	/**
+    	 * Sets the number of trades left for this trade
+    	 * 
+    	 * @param left the number of trades left
+    	 */
+    	public void setTradesLeft(int left) { 
+    		this.tradesLeft = left;
+    	}
+    }
+}

--- a/src/main/java/org/bukkit/entity/Merchant.java
+++ b/src/main/java/org/bukkit/entity/Merchant.java
@@ -10,118 +10,101 @@ import org.bukkit.inventory.ItemStack;
  */
 public interface Merchant extends Entity {
 
-
     /**
      * Get a list of trades that the villages trades
-     * 
+     *
      * @return all the trades the villager can perform
      */
     public List<MerchantTrade> getTrades();
 
     /**
      * Get a list of trades that the villages trades for a specific player
-     * 
+     *
      * @return all the trades the villager can perform to a specific player
      */
     public List<MerchantTrade> getTrades(Player player);
 
     /**
      * Add a trade to the merchants trades
-     * 
+     *
      * @param trade a new trade for the villager to perform
      */
     public void addTrade(MerchantTrade trade);
-    
+
     /**
      * Remove a trade from the merchants trades
-     * 
+     *
      * @param trade the trade to remove
      */
     public void removeTrade(MerchantTrade trade);
-    
+
     /**
      * Set the list of trades for this merchant
-     * 
+     *
      * @param trades the new trade list
      */
     public void setTrades(List<MerchantTrade> trades);
-    
+
     /**
      * Represents a trade a villager can make
      */
     public class MerchantTrade {
 
-    	private ItemStack product;
-    	private ItemStack[] price;
-		private int tradesLeft;
-    	
-    	/**
-    	 * Create a new villager trade defining the product and price for that product
-    	 * 
-    	 * @param product the item that the villager sells
-    	 * @param price the item(s) that the villager defines as the price for the product
-    	 */
-    	public MerchantTrade(ItemStack product, ItemStack...  price) {
-    		Validate.isTrue(price.length <= 2, "The price can only be a maximum of two items");
-    		
-    		this.product = product;
-    		this.price = price;
-    	}
-    	
-    	/**
-    	 * Get the price of this trade
-    	 * 
-    	 * @return the price of this trade, either one or two item stacks in array
-    	 */
-    	public ItemStack[] getPrice() {
-    		return price;
-    	}
-    	
-    	/**
-    	 * Get the product this villager trades for
-    	 * 
-    	 * @return the product that this villager trades
-    	 */
-    	public ItemStack getProduct() {
-    		return product;
-    	}
-    	
-    	/**
-    	 * Set the price of this trade
-    	 * 
-    	 * @param price the price of the trade, a maximum of two items
-    	 */
-    	public void setPrice(ItemStack... price) {
-    		Validate.isTrue(price.length <= 2, "The price can only be a maximum of two items");
-    		
-    		this.price = price;
-    	}
-    	
-    	/**
-    	 * Set the product that this villager trades
-    	 * 
-    	 * @param product the product the villager trades
-    	 */
-    	public void setProduct(ItemStack product) {
-    		this.product = product;
-    	}
-    	
-    	/**
-    	 * Gets the amount of trades this specific trade has left
-    	 * 
-    	 * @return the amount of trades left
-    	 */
-    	public int getTradesLeft() {
-    		return tradesLeft;
-    	}
-    	
-    	/**
-    	 * Sets the number of trades left for this trade
-    	 * 
-    	 * @param left the number of trades left
-    	 */
-    	public void setTradesLeft(int left) { 
-    		this.tradesLeft = left;
-    	}
+        private ItemStack product;
+        private ItemStack[] price;
+        
+        /**
+         * Create a new villager trade defining the product and price for that product
+         *
+         * @param product the item that the villager sells
+         * @param price the item(s) that the villager defines as the price for the product
+         * @throws IllegalArgumentException if more than two price elements are passed in
+         */
+        public MerchantTrade(ItemStack product, ItemStack...  price) {
+            Validate.isTrue(price.length <= 2, "The price can only be a maximum of two items");
+
+            this.product = product;
+            this.price = price;
+        }
+
+        /**
+         * Get the price of this trade
+         *
+         * @return the price of this trade, either one or two item stacks in array
+         */
+        public ItemStack[] getPrice() {
+            return price;
+        }
+
+        /**
+         * Get the product this villager trades for
+         *
+         * @return the product that this villager trades
+         */
+        public ItemStack getProduct() {
+            return product;
+        }
+
+        /**
+         * Set the price of this trade
+         *
+         * @param price the price of the trade, a maximum of two items
+         * @throws IllegalArgumentException if more than two elements are passed in
+         */
+        public void setPrice(ItemStack... price) {
+            Validate.isTrue(price.length <= 2, "The price can only be a maximum of two items");
+
+            this.price = price;
+        }
+
+        /**
+         * Set the product that this villager trades
+         *
+         * @param product the product the villager trades
+         */
+        public void setProduct(ItemStack product) {
+            this.product = product;
+        }
+
     }
 }

--- a/src/main/java/org/bukkit/entity/Villager.java
+++ b/src/main/java/org/bukkit/entity/Villager.java
@@ -3,7 +3,8 @@ package org.bukkit.entity;
 /**
  * Represents a villager NPC
  */
-public interface Villager extends Ageable, NPC {
+public interface Villager extends Ageable, NPC, Merchant {
+	
     /**
      * Gets the current profession of this villager.
      *
@@ -17,7 +18,6 @@ public interface Villager extends Ageable, NPC {
      * @param profession New profession.
      */
     public void setProfession(Profession profession);
-
 
     /**
      * Represents the various different Villager professions there may be.

--- a/src/main/java/org/bukkit/entity/Villager.java
+++ b/src/main/java/org/bukkit/entity/Villager.java
@@ -4,17 +4,17 @@ package org.bukkit.entity;
  * Represents a villager NPC
  */
 public interface Villager extends Ageable, NPC, Merchant {
-	
+
     /**
      * Gets the current profession of this villager.
      *
      * @return Current profession.
      */
     public Profession getProfession();
-    
+
     /**
      * Sets the new profession of this villager.
-     * 
+     *
      * @param profession New profession.
      */
     public void setProfession(Profession profession);

--- a/src/main/java/org/bukkit/inventory/MerchantInventory.java
+++ b/src/main/java/org/bukkit/inventory/MerchantInventory.java
@@ -3,11 +3,11 @@ package org.bukkit.inventory;
 import org.bukkit.entity.Merchant;
 
 public interface MerchantInventory extends Inventory {
-	
-	/**
-	 * Get the merchant that this inventory is registered to
-	 * 
-	 * @return the merchant that this inventory is registered to
-	 */
-	public Merchant getMerchant();
+
+    /**
+     * Get the merchant that this inventory is registered to
+     *
+     * @return the merchant that this inventory is registered to
+     */
+    public Merchant getMerchant();
 }

--- a/src/main/java/org/bukkit/inventory/MerchantInventory.java
+++ b/src/main/java/org/bukkit/inventory/MerchantInventory.java
@@ -1,4 +1,13 @@
 package org.bukkit.inventory;
 
+import org.bukkit.entity.Merchant;
+
 public interface MerchantInventory extends Inventory {
+	
+	/**
+	 * Get the merchant that this inventory is registered to
+	 * 
+	 * @return the merchant that this inventory is registered to
+	 */
+	public Merchant getMerchant();
 }


### PR DESCRIPTION
The Issue:

Currently in bukkit there is no way to get or set merchant trades or get a merchant from its inventory

PR Breakdown:

This PR adds a way to get, set and add merchant trades and adds a way to get the merchant from the MerchantInventory

Testing Results and Materials:

https://github.com/thefishlive/Bukkit-test - source
https://www.dropbox.com/sh/9v7cy8c2acsuywn/mqdvl8kL3S/Bukkit-Test-0.0.1-SNAPSHOT.jar - binary

Relevant PR(s):

CB-1111 -https://github.com/Bukkit/CraftBukkit/pull/1111 - implmentation

JIRA Ticket:

https://bukkit.atlassian.net/browse/BUKKIT-2138
https://bukkit.atlassian.net/browse/BUKKIT-3935
