### PR TITLE
Fix ArrayIndexOOBException in DyeColor. Fixes BUKKIT-3938

### DIFF
--- a/src/main/java/org/bukkit/DyeColor.java
+++ b/src/main/java/org/bukkit/DyeColor.java
@@ -164,7 +164,7 @@ public enum DyeColor {
      */
     public static DyeColor getByWoolData(final byte data) {
         int i = 0xff & data;
-        if (i > BY_WOOL_DATA.length) {
+        if (i >= BY_WOOL_DATA.length) {
             return null;
         }
         return BY_WOOL_DATA[i];
@@ -179,7 +179,7 @@ public enum DyeColor {
      */
     public static DyeColor getByDyeData(final byte data) {
         int i = 0xff & data;
-        if (i > BY_DYE_DATA.length) {
+        if (i >= BY_DYE_DATA.length) {
             return null;
         }
         return BY_DYE_DATA[i];


### PR DESCRIPTION
For wool with data value of 16, we should return null instead of trying to access the array element which doesn't exist.

Associated JIRA ticket:
https://bukkit.atlassian.net/browse/BUKKIT-3938
