### PR TITLE
[B] Updated .gitignore to ignore all .DS_Store files just not the one in the root directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@
 /manifest.mf
 
 # Mac filesystem dust
-/.DS_Store
+.DS_Store
 
 # intellij
 *.iml


### PR DESCRIPTION
The gitignore file currently includes /.DS_Store, but that only ignores the .DS_Store file in the project root. By removing the forward slash, all .DS_Store files can be ignored, so that people on OS X don't get a whole load of untracked .DS_Store files clogging up their git status, stopping them from using git add . or git commit -a.

This has already be implemented into the craftbukkit repo as seen on this pull request https://github.com/Bukkit/CraftBukkit/pull/1008
