### PR TITLE
[B+C] Implement Explosive and call ExplosionPrimeEvent for ExplosiveMinecart. Adds BUKKIT-3905

### DIFF
--- a/src/main/java/org/bukkit/entity/minecart/ExplosiveMinecart.java
+++ b/src/main/java/org/bukkit/entity/minecart/ExplosiveMinecart.java
@@ -1,9 +1,10 @@
 package org.bukkit.entity.minecart;
 
+import org.bukkit.entity.Explosive;
 import org.bukkit.entity.Minecart;
 
 /**
  * Represents a Minecart with TNT inside it that can explode when triggered.
  */
-public interface ExplosiveMinecart extends Minecart {
+public interface ExplosiveMinecart extends Minecart, Explosive {
 }


### PR DESCRIPTION
The Issue:
No ExplosionPrimeEvent is called for ExplosiveMinecart, so you can't cancel the explosion, only the affected blocks. Entities still gets damaged.

PR Breakdown:
With this PR ExplosiveMinecart implements Explosive. So you can also setup the fuse time.

Testing Results and Materials:
If you have a plugin that listens to ExplosionPrimeEvent, it's easy to handle ExplosiveMinecart, too. Tests shows that no mobs or players gets hurt, if you cancel the event. If you alter the radius, the explosion will use that radius.

Relevant PR(s):
CB-1114 - https://github.com/Bukkit/CraftBukkit/pull/1114
B-819 - https://github.com/Bukkit/Bukkit/pull/819 (should be updated to trigger for all explosives)
CB-1088 - https://github.com/Bukkit/CraftBukkit/pull/1088 (should be updated to trigger for all explosives)
B-839 - https://github.com/Bukkit/Bukkit/pull/839 (FusedExplosive)
CB-1117 - https://github.com/Bukkit/CraftBukkit/pull/1117 (FusedExplosive)

JIRA Ticket:
BUKKIT-3905 - https://bukkit.atlassian.net/browse/BUKKIT-3905
