### PR TITLE
[B+C] Add ItemDeathEvent for more coverage of Item removal. Adds BUKKIT-1900

### DIFF
--- a/src/main/java/org/bukkit/event/entity/ItemDeathEvent.java
+++ b/src/main/java/org/bukkit/event/entity/ItemDeathEvent.java
@@ -1,0 +1,55 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Item;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+
+/**
+ * This event is called when a {@link org.bukkit.entity.Item} receives damage
+ * and is about to be removed.
+ * <p>
+ * This event will never be called when a Item of
+ * {@link org.bukkit.Material#NETHER_STAR} is hurt by an explosion.
+ */
+public class ItemDeathEvent extends EntityEvent {
+    private static final HandlerList handlers = new HandlerList();
+    private final Location location;
+    private final DamageCause cause;
+
+    public ItemDeathEvent(final Item despawnee, final Location loc, final DamageCause cause) {
+        super(despawnee);
+        location = loc;
+        this.cause = cause;
+    }
+
+    @Override
+    public Item getEntity() {
+        return (Item) entity;
+    }
+
+    /**
+     * Gets the location at which the item is dying.
+     *
+     * @return The location at which the item is dying
+     */
+    public Location getLocation() {
+        return location;
+    }
+
+    /**
+     * Gets the source of the damage that killed this Item
+     */
+    public DamageCause getCause() {
+        return cause;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/org/bukkit/event/entity/ItemDeathEvent.java
+++ b/src/main/java/org/bukkit/event/entity/ItemDeathEvent.java
@@ -10,8 +10,12 @@ import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
  * This event is called when a {@link org.bukkit.entity.Item} receives damage
  * and is about to be removed.
  * <p>
- * This event will never be called when a Item of
- * {@link org.bukkit.Material#NETHER_STAR} is hurt by an explosion.
+ * Canceling this event will result in the item remaining in the world and not
+ * dying. If you cancel this event, it is advisable to examine the DamageCause
+ * and attempt to remove the Item from the "situation" by means of teleport().
+ * <p>
+ * Items whose ItemStack are of the NETHER_STAR Material have innate
+ * resistance to explosions. This may change in the future.
  */
 public class ItemDeathEvent extends EntityEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();

--- a/src/main/java/org/bukkit/event/entity/ItemDeathEvent.java
+++ b/src/main/java/org/bukkit/event/entity/ItemDeathEvent.java
@@ -2,6 +2,7 @@ package org.bukkit.event.entity;
 
 import org.bukkit.Location;
 import org.bukkit.entity.Item;
+import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 
@@ -12,10 +13,11 @@ import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
  * This event will never be called when a Item of
  * {@link org.bukkit.Material#NETHER_STAR} is hurt by an explosion.
  */
-public class ItemDeathEvent extends EntityEvent {
+public class ItemDeathEvent extends EntityEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private final Location location;
     private final DamageCause cause;
+    private boolean cancelled = false;
 
     public ItemDeathEvent(final Item despawnee, final Location loc, final DamageCause cause) {
         super(despawnee);
@@ -42,6 +44,14 @@ public class ItemDeathEvent extends EntityEvent {
      */
     public DamageCause getCause() {
         return cause;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(boolean cancel) {
+        cancelled = cancel;
     }
 
     @Override


### PR DESCRIPTION
### Problem

Currently, plugins have two events to listen to when they want to detect an Item entity being removed - `ItemDespawnEvent` and `PlayerPickupItemEvent`. However, this does not cover all possible cases.

The current best way that plugins have to track items involves use of the scheduler, a collection of Item objects from the Bukkit API (something that is discouraged), and the isValid() method. This is incredibly non-optimal, to say the least.
### Justification

Some plugins have cause to track the lifetime of Item entities. An immediately obvious example would be what happens to a player's items right after they die - for example, if a player dies standing next to a cactus or over a lava pit, several of their items are going to be dying in short order.
No EntityDamageEvent is called for Item entities, as they are not Living, so plugins are unable to track item death that way.

_Note that two methods of removal of Item entities are left untouched by this change - item merging, and plugins calling remove(). However, item merging deserves its own event and PR, and plugin action should not be calling events._
### Description

Whenever an EntityItem recieves fatal damage, the new ItemDeathEvent is called. A method in CraftEventFactory is added to do the best-guess determination of the appropriate DamageCause to use in the event.

Additionally, CraftEventFactory is imported, because it is used twice.
### Related

https://bukkit.atlassian.net/browse/BUKKIT-1900
https://github.com/Bukkit/CraftBukkit/pull/1116
