### PR TITLE
Check null before grabbing owning plugin - fixes BUKKIT-3987

### DIFF
--- a/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
+++ b/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
@@ -25,8 +25,8 @@ public abstract class MetadataStoreBase<T> {
      * @throws IllegalArgumentException If value is null, or the owning plugin is null
      */
     public synchronized void setMetadata(T subject, String metadataKey, MetadataValue newMetadataValue) {
-        Plugin owningPlugin = newMetadataValue.getOwningPlugin();
         Validate.notNull(newMetadataValue, "Value cannot be null");
+        Plugin owningPlugin = newMetadataValue.getOwningPlugin();
         Validate.notNull(owningPlugin, "Plugin cannot be null");
         String key = disambiguate(subject, metadataKey);
         Map<Plugin, MetadataValue> entry = metadataMap.get(key);


### PR DESCRIPTION
The null validation check comes after the owning plugin is extracted from it, resulting in a possible NPE if a null value is passed to the method.

The issue:

A validation check is called to make sure that the metadata value passed in is not null. However, another call, which gets the owning plugin of the metadata value, gets called before this validation check is called, resulting in an NPE if the value passed into the method is null.

Bukkit Ticket:

BUKKIT-3987: https://bukkit.atlassian.net/browse/BUKKIT-3987
