### PR TITLE
[B] Fix incorrect effect duration. Fixes BUKKIT-3967

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/EffectCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/EffectCommand.java
@@ -8,6 +8,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import org.bukkit.util.NumberConversions;
 import org.bukkit.util.StringUtil;
 
 public class EffectCommand extends VanillaCommand {
@@ -92,7 +93,7 @@ public class EffectCommand extends VanillaCommand {
             final PotionEffect applyEffect = new PotionEffect(effect, duration, amplification);
 
             player.addPotionEffect(applyEffect, true);
-            broadcastCommandMessage(sender, String.format("Given %s (ID %d) * %d to %s for %d seconds", effect.getName(), effect.getId(), amplification, args[0], duration));
+            broadcastCommandMessage(sender, String.format("Given %s (ID %d) * %d to %s for %d seconds", effect.getName(), effect.getId(), amplification, args[0], NumberConversions.floor(duration / 20D)));
         }
 
         return true;

--- a/src/main/java/org/bukkit/command/defaults/EffectCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/EffectCommand.java
@@ -92,7 +92,7 @@ public class EffectCommand extends VanillaCommand {
             final PotionEffect applyEffect = new PotionEffect(effect, duration, amplification);
 
             player.addPotionEffect(applyEffect, true);
-            broadcastCommandMessage(sender, String.format("Given %s (ID %d) * %d to %s for %d seconds", effect.getName(), effect.getId(), amplification, args[0], Double.toString(duration / 20D)));
+            broadcastCommandMessage(sender, String.format("Given %s (ID %d) * %d to %s for %s seconds", effect.getName(), effect.getId(), amplification, args[0], Double.toString(duration / 20D)));
         }
 
         return true;

--- a/src/main/java/org/bukkit/command/defaults/EffectCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/EffectCommand.java
@@ -93,7 +93,7 @@ public class EffectCommand extends VanillaCommand {
             final PotionEffect applyEffect = new PotionEffect(effect, duration, amplification);
 
             player.addPotionEffect(applyEffect, true);
-            broadcastCommandMessage(sender, String.format("Given %s (ID %d) * %d to %s for %d seconds", effect.getName(), effect.getId(), amplification, args[0], NumberConversions.floor(duration / 20D)));
+            broadcastCommandMessage(sender, String.format("Given %s (ID %d) * %d to %s for %d " + (effect.isInstant() ? "ticks" : "seconds"), effect.getName(), effect.getId(), amplification, args[0], effect.isInstant() ? duration : NumberConversions.floor(duration / 20D)));
         }
 
         return true;

--- a/src/main/java/org/bukkit/command/defaults/EffectCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/EffectCommand.java
@@ -8,7 +8,6 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-import org.bukkit.util.NumberConversions;
 import org.bukkit.util.StringUtil;
 
 public class EffectCommand extends VanillaCommand {
@@ -93,7 +92,7 @@ public class EffectCommand extends VanillaCommand {
             final PotionEffect applyEffect = new PotionEffect(effect, duration, amplification);
 
             player.addPotionEffect(applyEffect, true);
-            broadcastCommandMessage(sender, String.format("Given %s (ID %d) * %d to %s for %d " + (effect.isInstant() ? "ticks" : "seconds"), effect.getName(), effect.getId(), amplification, args[0], effect.isInstant() ? duration : NumberConversions.floor(duration / 20D)));
+            broadcastCommandMessage(sender, String.format("Given %s (ID %d) * %d to %s for %d seconds", effect.getName(), effect.getId(), amplification, args[0], Double.toString(duration / 20D)));
         }
 
         return true;


### PR DESCRIPTION
The Issue:

Using the /effect command displays an incorrect duration. The displayed duration is in ticks.

PR Breakdown:

I changed the output from 'duration' for the seconds to 'NumberConversions.floor(duration / 20D)' in order to produce the correct time in seconds to the user.

Testing Results:

As expected, this fixed the incorrect effect duration. (Pictures) http://imgur.com/SS5zlx7,jCcF8yL,9Nc7pMw#0

Bukkit Ticket:

BUKKIT-3967: https://bukkit.atlassian.net/browse/BUKKIT-3967
