### PR TITLE
[B+C] Add MetadataProvider for on-demand metadata. Fixes BUKKIT-3625.

### DIFF
--- a/src/main/java/org/bukkit/Bukkit.java
+++ b/src/main/java/org/bukkit/Bukkit.java
@@ -24,6 +24,7 @@ import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemFactory;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.map.MapView;
+import org.bukkit.metadata.MetadataManager;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.ServicesManager;
 import org.bukkit.plugin.messaging.Messenger;
@@ -746,5 +747,9 @@ public final class Bukkit {
     @Deprecated
     public static UnsafeValues getUnsafe() {
         return server.getUnsafe();
+    }
+
+    public static MetadataManager getMetadataManager() {
+        return server.getMetadataManager();
     }
 }

--- a/src/main/java/org/bukkit/OfflinePlayer.java
+++ b/src/main/java/org/bukkit/OfflinePlayer.java
@@ -6,10 +6,11 @@ import java.util.UUID;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.entity.AnimalTamer;
 import org.bukkit.entity.Player;
+import org.bukkit.metadata.Metadatable;
 import org.bukkit.permissions.ServerOperator;
 
-public interface OfflinePlayer extends ServerOperator, AnimalTamer, ConfigurationSerializable {
 
+public interface OfflinePlayer extends ServerOperator, Metadatable, AnimalTamer, ConfigurationSerializable {
     /**
      * Checks if this player is currently online
      *

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -28,6 +28,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.map.MapView;
 import org.bukkit.permissions.Permissible;
+import org.bukkit.metadata.MetadataManager;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.ServicesManager;
 import org.bukkit.plugin.messaging.Messenger;
@@ -916,4 +917,10 @@ public interface Server extends PluginMessageRecipient {
      */
     @Deprecated
     UnsafeValues getUnsafe();
+
+    /**
+     * Get the metadata manager, used for managing metadata and registering providers.
+     * @return The metadata manager.
+     */
+    public MetadataManager getMetadataManager();
 }

--- a/src/main/java/org/bukkit/metadata/MetadataManager.java
+++ b/src/main/java/org/bukkit/metadata/MetadataManager.java
@@ -1,0 +1,33 @@
+package org.bukkit.metadata;
+
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Provide a way to register metadata providers and manage the metadata system.
+ */
+public interface MetadataManager {
+    /**
+     * Register a metadata provider.
+     * @param clazz The implementation class (scope) of this provider.
+     * @param plugin the plugin managing this.
+     * @param provider An appropriate generic provider.
+     */
+    public <T extends Metadatable> void registerProvider(Class<T> clazz, Plugin plugin, MetadataProvider<T> provider);
+
+    /**
+     * Unregister a metadata provider.
+     * @param clazz The implementation class(scope).
+     * @param plugin the plugin unregistering this provider.
+     */
+    public <T extends Metadatable> void unregisterProvider(Class<T> clazz, Plugin plugin);
+
+    /**
+     * Clear all data belonging to a plugin.
+     * <p>
+     * This includes removing any registered providers as well as any metadata
+     * associated with this plugin.
+     *
+     * @param plugin the plugin whose data which we want to remove.
+     */
+    public void clearPluginData(Plugin plugin);
+}

--- a/src/main/java/org/bukkit/metadata/MetadataProvider.java
+++ b/src/main/java/org/bukkit/metadata/MetadataProvider.java
@@ -1,0 +1,21 @@
+package org.bukkit.metadata;
+
+
+/**
+ * Provide "On-Demand" Metadata lookup.
+ *
+ * The purpose of this is to allow plugin authors to define a way for
+ * Metadata to be generated on request for a key, rather than having to
+ * predefine it.
+ *
+ * @param <T> A supplied class which can receive Metadata.
+ */
+public interface MetadataProvider<T extends Metadatable> {
+    /**
+     * Get a Metadata value for a subject.
+     * @param subject The object for which we're requesting metadata
+     * @param key The key on which metadata is being requested.
+     * @return A MetadataValue, or null
+     */
+    public MetadataValue getValue(T subject, String key);
+}

--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -449,6 +449,12 @@ public final class SimplePluginManager implements PluginManager {
             } catch(Throwable ex) {
                 server.getLogger().log(Level.SEVERE, "Error occurred (in the plugin loader) while unregistering plugin channels for " + plugin.getDescription().getFullName() + " (Is it up to date?)", ex);
             }
+
+            try {
+                server.getMetadataManager().clearPluginData(plugin);
+            } catch(Throwable ex) {
+                server.getLogger().log(Level.SEVERE, "Error occurred (in the plugin loader) while unregistering metadata providers for " + plugin.getDescription().getFullName() + " (Is it up to date?)", ex);
+            }
         }
     }
 

--- a/src/test/java/org/bukkit/metadata/MetadataStoreTest.java
+++ b/src/test/java/org/bukkit/metadata/MetadataStoreTest.java
@@ -4,7 +4,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 
 import org.bukkit.plugin.Plugin;
@@ -15,21 +18,21 @@ public class MetadataStoreTest {
     private Plugin pluginX = new TestPlugin("x");
     private Plugin pluginY = new TestPlugin("y");
 
-    StringMetadataStore subject = new StringMetadataStore();
+    TValueStore store = new TValueStore();
 
     @Test
     public void testMetadataStore() {
-        subject.setMetadata("subject", "key", new FixedMetadataValue(pluginX, 10));
+        store.setMetadata(new TValue("subject"), "key", new FixedMetadataValue(pluginX, 10));
 
-        assertTrue(subject.hasMetadata("subject", "key"));
-        List<MetadataValue> values = subject.getMetadata("subject", "key");
+        assertTrue(store.hasMetadata(new TValue("subject"), "key"));
+        List<MetadataValue> values = store.getMetadata(new TValue("subject"), "key");
         assertEquals(10, values.get(0).value());
     }
 
     @Test
     public void testMetadataNotPresent() {
-        assertFalse(subject.hasMetadata("subject", "key"));
-        List<MetadataValue> values = subject.getMetadata("subject", "key");
+        assertFalse(store.hasMetadata(new TValue("subject"), "key"));
+        List<MetadataValue> values = store.getMetadata(new TValue("subject"), "key");
         assertTrue(values.isEmpty());
     }
 
@@ -37,17 +40,17 @@ public class MetadataStoreTest {
     public void testInvalidateAll() {
         final Counter counter = new Counter();
 
-        subject.setMetadata("subject", "key", new LazyMetadataValue(pluginX, new Callable<Object>() {
+        store.setMetadata(new TValue("subject"), "key", new LazyMetadataValue(pluginX, new Callable<Object>() {
             public Object call() throws Exception {
                 counter.increment();
                 return 10;
             }
         }));
 
-        assertTrue(subject.hasMetadata("subject", "key"));
-        subject.getMetadata("subject", "key").get(0).value();
-        subject.invalidateAll(pluginX);
-        subject.getMetadata("subject", "key").get(0).value();
+        assertTrue(store.hasMetadata(new TValue("subject"), "key"));
+        store.getMetadata(new TValue("subject"), "key").get(0).value();
+        store.invalidateAll(pluginX);
+        store.getMetadata(new TValue("subject"), "key").get(0).value();
         assertEquals(2, counter.value());
     }
 
@@ -55,27 +58,27 @@ public class MetadataStoreTest {
     public void testInvalidateAllButActuallyNothing() {
         final Counter counter = new Counter();
 
-        subject.setMetadata("subject", "key", new LazyMetadataValue(pluginX, new Callable<Object>() {
+        store.setMetadata(new TValue("subject"), "key", new LazyMetadataValue(pluginX, new Callable<Object>() {
             public Object call() throws Exception {
                 counter.increment();
                 return 10;
             }
         }));
 
-        assertTrue(subject.hasMetadata("subject", "key"));
-        subject.getMetadata("subject", "key").get(0).value();
-        subject.invalidateAll(pluginY);
-        subject.getMetadata("subject", "key").get(0).value();
+        assertTrue(store.hasMetadata(new TValue("subject"), "key"));
+        store.getMetadata(new TValue("subject"), "key").get(0).value();
+        store.invalidateAll(pluginY);
+        store.getMetadata(new TValue("subject"), "key").get(0).value();
         assertEquals(1, counter.value());
     }
 
     @Test
     public void testMetadataReplace() {
-        subject.setMetadata("subject", "key", new FixedMetadataValue(pluginX, 10));
-        subject.setMetadata("subject", "key", new FixedMetadataValue(pluginY, 10));
-        subject.setMetadata("subject", "key", new FixedMetadataValue(pluginX, 20));
+        store.setMetadata(new TValue("subject"), "key", new FixedMetadataValue(pluginX, 10));
+        store.setMetadata(new TValue("subject"), "key", new FixedMetadataValue(pluginY, 10));
+        store.setMetadata(new TValue("subject"), "key", new FixedMetadataValue(pluginX, 20));
 
-        for (MetadataValue mv : subject.getMetadata("subject", "key")) {
+        for (MetadataValue mv : store.getMetadata(new TValue("subject"), "key")) {
             if (mv.getOwningPlugin().equals(pluginX)) {
                 assertEquals(20, mv.value());
             }
@@ -87,46 +90,137 @@ public class MetadataStoreTest {
 
     @Test
     public void testMetadataRemove() {
-        subject.setMetadata("subject", "key", new FixedMetadataValue(pluginX, 10));
-        subject.setMetadata("subject", "key", new FixedMetadataValue(pluginY, 20));
-        subject.removeMetadata("subject", "key", pluginX);
+        store.setMetadata(new TValue("subject"), "key", new FixedMetadataValue(pluginX, 10));
+        store.setMetadata(new TValue("subject"), "key", new FixedMetadataValue(pluginY, 20));
+        store.removeMetadata(new TValue("subject"), "key", pluginX);
 
-        assertTrue(subject.hasMetadata("subject", "key"));
-        assertEquals(1, subject.getMetadata("subject", "key").size());
-        assertEquals(20, subject.getMetadata("subject", "key").get(0).value());
+        assertTrue(store.hasMetadata(new TValue("subject"), "key"));
+        assertEquals(1, store.getMetadata(new TValue("subject"), "key").size());
+        assertEquals(20, store.getMetadata(new TValue("subject"), "key").get(0).value());
     }
 
     @Test
     public void testMetadataRemoveLast() {
-        subject.setMetadata("subject", "key", new FixedMetadataValue(pluginX, 10));
-        subject.removeMetadata("subject", "key", pluginX);
+        store.setMetadata(new TValue("subject"), "key", new FixedMetadataValue(pluginX, 10));
+        store.removeMetadata(new TValue("subject"), "key", pluginX);
 
-        assertFalse(subject.hasMetadata("subject", "key"));
-        assertEquals(0, subject.getMetadata("subject", "key").size());
+        assertFalse(store.hasMetadata(new TValue("subject"), "key"));
+        assertEquals(0, store.getMetadata(new TValue("subject"), "key").size());
     }
 
     @Test
     public void testMetadataRemoveForNonExistingPlugin() {
-        subject.setMetadata("subject", "key", new FixedMetadataValue(pluginX, 10));
-        subject.removeMetadata("subject", "key", pluginY);
+        store.setMetadata(new TValue("subject"), "key", new FixedMetadataValue(pluginX, 10));
+        store.removeMetadata(new TValue("subject"), "key", pluginY);
 
-        assertTrue(subject.hasMetadata("subject", "key"));
-        assertEquals(1, subject.getMetadata("subject", "key").size());
-        assertEquals(10, subject.getMetadata("subject", "key").get(0).value());
+        assertTrue(store.hasMetadata(new TValue("subject"), "key"));
+        assertEquals(1, store.getMetadata(new TValue("subject"), "key").size());
+        assertEquals(10, store.getMetadata(new TValue("subject"), "key").get(0).value());
     }
-    
+
     @Test
     public void testHasMetadata() {
-        subject.setMetadata("subject", "key", new FixedMetadataValue(pluginX, 10));
-        assertTrue(subject.hasMetadata("subject", "key"));
-        assertFalse(subject.hasMetadata("subject", "otherKey"));
+        store.setMetadata(new TValue("subject"), "key", new FixedMetadataValue(pluginX, 10));
+        assertTrue(store.hasMetadata(new TValue("subject"), "key"));
+        assertFalse(store.hasMetadata(new TValue("subject"), "otherKey"));
     }
 
-    private class StringMetadataStore extends MetadataStoreBase<String> implements MetadataStore<String> {
-        @Override
-        protected String disambiguate(String subject, String metadataKey) {
-            return subject + ":" + metadataKey;
+    @Test
+    public void testProviderUsage() {
+        List<MetadataProvider<TValue>> mapping = new ArrayList<MetadataProvider<TValue>>();
+        TValueStore store = new TValueStore(mapping);
+        assertEquals(store.getMetadata(new TValue("foobar"), "uppercased").size(), 0);
+        TValueProvider p = new TValueProvider();
+        mapping.add(p);
+        assertEquals(0, p.counter.value());
+        List<MetadataValue> values = store.getMetadata(new TValue("foobar"), "uppercased");
+        assertEquals(1, values.size());
+        assertEquals("FOOBAR", values.get(0).asString());
+        assertEquals(1, p.counter.value());
+        // Check we still get a single value only
+        values = store.getMetadata(new TValue("foobar"), "uppercased");
+        assertEquals(1, values.size());
+        assertEquals("FOOBAR", values.get(0).asString());
+        // Check the provider wasn't called twice.
+        assertEquals(1, p.counter.value());
+        // Try a new previously un-seen value through the provider.
+        assertEquals(1, store.getMetadata(new TValue("hello"), "uppercased").size());
+        assertEquals(2, p.counter.value());
+        mapping.clear();
+    }
+
+    private static class TValue implements Metadatable {
+        public String value;
+
+        public TValue(String value) {
+            this.value = value;
         }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other instanceof TValue) {
+                return value.equals(((TValue) other).value);
+            } else if (other instanceof String) {
+                return value.equals(other);
+            } else {
+                return false;
+            }
+        }
+        
+        @Override
+        public int hashCode() {
+            return value.hashCode();
+        }
+
+        public void setMetadata(String metadataKey, MetadataValue newMetadataValue) {
+        }
+
+        public List<MetadataValue> getMetadata(String metadataKey) {
+            return null;
+        }
+
+        public boolean hasMetadata(String metadataKey) {
+            return false;
+        }
+
+        public void removeMetadata(String metadataKey, Plugin owningPlugin) {
+        }
+
+    }
+
+    private static class TValueStore extends MetadataStoreBase<TValue> implements MetadataStore<TValue> {
+        public TValueStore() {
+            this(new ArrayList<MetadataProvider<TValue>>());
+        }
+
+        public TValueStore(List<MetadataProvider<TValue>> mapping) {
+            super(convertMap(mapping));
+        }
+
+        private static Map<Class<? extends Metadatable>, List<MetadataProvider<TValue>>> convertMap(List<MetadataProvider<TValue>> mapping) {
+            Map<Class<? extends Metadatable>, List<MetadataProvider<TValue>>> lookup = new HashMap<Class<? extends Metadatable>, List<MetadataProvider<TValue>>>();
+            lookup.put(TValue.class, mapping);
+            return lookup;
+        }
+
+        @Override
+        protected String disambiguate(TValue subject, String metadataKey) {
+            return subject.value + ":" + metadataKey;
+        }
+    }
+
+    private class TValueProvider implements MetadataProvider<TValue> {
+        public final Counter counter = new Counter();
+
+        public MetadataValue getValue(TValue subject, String key) {
+            counter.increment();
+            if (subject.equals("nodata")) {
+                return null;
+            } else {
+                return new FixedMetadataValue(pluginX, subject.value.toUpperCase());
+            }
+        }
+
     }
 
     private class Counter {


### PR DESCRIPTION
**The Issue/Justification**
At the very core of the metadata system is the idea of asking a question. A plugin asks a question, like “What is this player’s chat prefix?” and some other plugin is able to provide an answer. 

The way it’s currently designed, for some plugin (say a chat plugin) to ask what a prefix is, some other plugin (say a permissions plugin or user manager) would have to set the "chatPrefix" key on every user before it's asked. (say when they log in.) This isn’t very effective, and it isn’t quite as “lazy” as one would hope, what if the value is never asked for? Then we've done all that work for nothing.

What would be useful, instead, if the metadata system provided a way for a plugin to register a metadata ‘provider’ for a key. Calling <object>.getMetadata(key) would query the provider if no value is set, passing it the object, for an appropriate metadata value.

To use the chatPrefix example from before, MyAwesomePermissions would register a provider on a class target (say, Player or OfflinePlayer). Then at some point, BobsChatPlugin calls player.getMetadata("chatPrefix") which asks the provider for the chatPrefix. This also means if the chatPrefix is never requested (say you don't have a chat plugin to use it), there's no work done or memory used in creating the values.

For a full dissertation on issues with Metadata as a whole see: http://goo.gl/jRsX9

**PR Breakdown:**
Metadata Providers are a new "dispatch" type system for allowing metadata to
be done truly on-demand, via calling into a contextual "provider" when metadata
is requested. Through use of generics providers can be registered for a large
range of bukkit types and they will be dispatched to the providers which respond
for those specific types.
- Created provider interface
- Added unit tests for provider usage
- Updated bukkit.Server interface with methods for registering /unregistering providers 
- Updated bukkit.Bukkit with static implementations
- Update generic type requirements of MetadataStore
- Make OfflinePlayer Metadatable for consistency and generic guarantees.

Using the interface would require the user to do something like 

``` java
server.getMetadataManager().registerProvider(Sheep.class, plugin, new MetadataProvider<Sheep> { 
    public MetadataValue getValue(Sheep subject, String key) {
        if (key.equals("name")) {
             // using isSheared mostly to demonstrate that we don't need to cast types here
            String name = createRandomName(subject.isSheared())
            return new FixedMetadataValue(plugin, name)
        }
        return null; // We're not interested in this request
    }
});
```

**Testing Results and Materials:**
Wrote extensive new unit tests that provides full coverage on the Metadata Provider interface/implementation, including writing some sample implementations and testing how providers receive data. This is in addition to some new full-stack unit tests in the craftbukkit companion to this ticket: https://github.com/Bukkit/CraftBukkit/pull/1124

**Relevant PR(s):**
CB-1124 https://github.com/Bukkit/CraftBukkit/pull/1124 - Implement MetadataProvider backend inside craftbukkit

**JIRA Ticket:**
BUKKIT-3625 - https://bukkit.atlassian.net/browse/BUKKIT-3625
