### PR TITLE
[B+C] Adds BUKKIT-4014. Add API for removing scores per player per objective.

### DIFF
--- a/src/main/java/org/bukkit/scoreboard/Score.java
+++ b/src/main/java/org/bukkit/scoreboard/Score.java
@@ -42,6 +42,25 @@ public interface Score {
     void setScore(int score) throws IllegalStateException;
 
     /**
+     * Checks if this score is set.
+     * 
+     * @return true if this score is set.
+     * @throws IllegalStateException if the associated objective has been
+     *     unregistered
+     */
+    boolean isSet() throws IllegalStateException;
+
+    /**
+     * Resets this score.
+     * <p>
+     * After calling this, Score.isSet() will return false.
+     * 
+     * @throws IllegalStateException if the associated objective has been
+     *     unregistered
+     */
+    void reset() throws IllegalStateException;
+
+    /**
      * Gets the scoreboard for the associated objective.
      *
      * @return the owning objective's scoreboard, or null if it has been


### PR DESCRIPTION
Justification:
Scoreboard scores should be removable by any combination of player & objective.

Breakdown:
Add `isSet()`, `reset()` to Score.

Testing:
Interface additions only.

Related PRs:
https://github.com/Bukkit/CraftBukkit/pull/1131

Ticket:
https://bukkit.atlassian.net/browse/BUKKIT-4014
