### PR TITLE
[B+C] API for new mob spawner features. Adds BUKKIT-1998

### DIFF
--- a/src/main/java/org/bukkit/SpawnerEntry.java
+++ b/src/main/java/org/bukkit/SpawnerEntry.java
@@ -57,6 +57,11 @@ public class SpawnerEntry {
         return weight;
     }
     
+    /**
+     * Gets the weight of this entry, a higher weight means this spawn will be more likely to happen.
+     *
+     * @param weight The weight
+     */
     public void setWeight(int weight) {
         this.weight = weight;
     }

--- a/src/main/java/org/bukkit/SpawnerEntry.java
+++ b/src/main/java/org/bukkit/SpawnerEntry.java
@@ -1,22 +1,63 @@
 package org.bukkit;
 
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 
 /**
  * Represents one of the possible entities that may spawn from a spawner
  */
-public interface SpawnerEntry {
+public class SpawnerEntry {
+    protected EntityType type;
+    protected boolean includePosition;
+    protected int weight;
+
+    public SpawnerEntry(EntityType type, int weight) {
+        if (type == null || type.getName() == null) {
+            throw new IllegalArgumentException("Can't spawn EntityType " + type + " from mobspawners!");
+        }
+
+        this.type = type;
+        this.includePosition = false;
+        this.weight = weight;
+    }
+
     /**
      * Gets the type of entity that would be created.
      *
      * @return The type
      */
-    public EntityType getEntityType();
+    public EntityType getEntityType() {
+        return type;
+    }
+
+    /**
+     * Gets the include position flag, if true the entity will be spawned at it's current location.
+     * 
+     * @return The flag
+     */
+    public boolean isPositionIncluded() {
+        return includePosition;
+    }
+
+    /**
+     * Sets the include position flag, if true the entity will be spawned at it's current location.
+     *
+     * @param includePosition The flag
+     */
+    public void setIncludePosition(boolean includePosition) {
+        this.includePosition = includePosition;
+    }
 
     /**
      * Gets the weight of this entry, a higher weight means this spawn will be more likely to happen.
      * 
      * @return The weight
      */
-    public int getWeight();
+    public int getWeight() {
+        return weight;
+    }
+    
+    public void setWeight(int weight) {
+        this.weight = weight;
+    }
 }

--- a/src/main/java/org/bukkit/SpawnerEntry.java
+++ b/src/main/java/org/bukkit/SpawnerEntry.java
@@ -1,0 +1,22 @@
+package org.bukkit;
+
+import org.bukkit.entity.EntityType;
+
+/**
+ * Represents one of the possible entities that may spawn from a spawner
+ */
+public interface SpawnerEntry {
+    /**
+     * Gets the type of entity that would be created.
+     *
+     * @return The type
+     */
+    public EntityType getEntityType();
+
+    /**
+     * Gets the weight of this entry, a higher weight means this spawn will be more likely to happen.
+     * 
+     * @return The weight
+     */
+    public int getWeight();
+}

--- a/src/main/java/org/bukkit/block/CreatureSpawner.java
+++ b/src/main/java/org/bukkit/block/CreatureSpawner.java
@@ -157,7 +157,8 @@ public interface CreatureSpawner extends BlockState {
     public int getRange();
 
     /**
-     * Sets the maximum distance from the spawner that entities will be spawned.
+     * Sets the maximum distance from the spawner that entities will be spawned. This uses a horizontal
+     * square centred on the spawner
      *
      * @param range The distance.
      */

--- a/src/main/java/org/bukkit/block/CreatureSpawner.java
+++ b/src/main/java/org/bukkit/block/CreatureSpawner.java
@@ -76,38 +76,30 @@ public interface CreatureSpawner extends BlockState {
     public void clearSpawnPotentials();
 
     /**
-     * Adds an entity type to the spawn list. The weight is used to control the chance
-     * of each spawn potential occurring, a higher value relative to the other list entries
-     * will result in this spawn being more frequent.
-     *
-     * @param creatureType The entity type.
-     * @param weight The weight.
-     * @throws IllegalArgumentException If the entity cannot be spawned from spawners.
-     */
-    public void addPotentialSpawnedType(EntityType creatureType, int weight);
-
-    /**
-     * Adds an entity to the spawn list. The weight is used to control the chance
-     * of each spawn potential occurring, a higher value relative to the other list entries
-     * will result in this spawn being more frequent.
+     * Creates a new {@link SpawnerEntry} from an entity, when added to a spawner all properties of the
+     * entity will be included. The position data can be removed by setting the position flag to false.
      *
      * @param entity The entity
-     * @param includePosition If true position data will be kept.
-     * @param weight The weight.
-     * @throws IllegalArgumentException If the entity cannot be spawned from spawners.
+     * @param includePosition The position flag
+     * @param weight The weight
+     * @return The entry
      */
-    public void addPotentialSpawnedEntity(Entity entity, boolean includePosition, int weight);
+    public SpawnerEntry createSpawnerEntry(Entity entity, boolean includePosition, int weight);
 
     /**
-     * Adds an entity to the spawn list. The weight is used to control the chance
-     * of each spawn potential occurring, a higher value relative to the other list entries
-     * will result in this spawn being more frequent.
+     * Creates a new {@link SpawnerEntry} from an entity, if added to a spawner all properties of the entity will be included.
      *
-     * @param entity The entity.
-     * @param weight The weight.
-     * @throws IllegalArgumentException If the entity cannot be spawned from spawners.
+     * @param entity The entity
+     * @return The entry
      */
-    public void addPotentialSpawnedEntity(Entity entity, int weight);
+    public SpawnerEntry createSpawnerEntry(Entity entity);
+
+    /**
+     * Adds a potential spawn to the spawner
+     *
+     * @param entry The entry
+     */
+    public void addSpawnerEntry(SpawnerEntry entry);
 
     /**
      * Set the spawner mob type.
@@ -225,7 +217,7 @@ public interface CreatureSpawner extends BlockState {
     public void setVerticalRange(int maxBelow, int maxAbove);
 
     /**
-     * Gets the number of other entities that need to be within the spawner's range to prevent spawning,
+     * Gets the number of other entities that need to be within the spawner's range to prevent spawning.
      *
      * @return The number.
      */

--- a/src/main/java/org/bukkit/block/CreatureSpawner.java
+++ b/src/main/java/org/bukkit/block/CreatureSpawner.java
@@ -1,6 +1,7 @@
 package org.bukkit.block;
 
 import org.bukkit.entity.CreatureType;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 
 /**
@@ -30,6 +31,21 @@ public interface CreatureSpawner extends BlockState {
      * @param creatureType The creature type.
      */
     public void setSpawnedType(EntityType creatureType);
+
+    /**
+     * Sets the entity that will be spawned.
+     * 
+     * @param entity The entity
+     */
+    public void setSpawnedEntity(Entity entity);
+
+    /**
+     * Sets the entity that will be spawned.
+     * 
+     * @param entity The entity
+     * @param includePosition If true position data will be kept
+     */
+    public void setSpawnedEntity(Entity entity, boolean includePosition);
 
     /**
      * Set the spawner creature type.
@@ -85,4 +101,88 @@ public interface CreatureSpawner extends BlockState {
      * @param delay The delay.
      */
     public void setDelay(int delay);
+
+    /**
+     * Get the spawner's minimum delay.
+     *
+     * @return The delay.
+     */
+    public int getMinDelay();
+
+    /**
+     * Set the spawner's minimum delay.
+     *
+     * @param delay The delay.
+     */
+    public void setMinDelay(int delay);
+
+    /**
+     * Get the spawner's maximum delay.
+     *
+     * @return The delay.
+     */
+    public int getMaxDelay();
+
+    /**
+     * Set the spawner's maximum delay.
+     *
+     * @param delay The delay.
+     */
+    public void setMaxDelay(int delay);
+
+    /**
+     * Gets the number of entities that the spawner will attempt to spawn.
+     * 
+     * @return The number.
+     */
+    public int getCount();
+
+    /**
+     * Sets the number of entities that the spawner will attempt to spawn.
+     * 
+     * @param count The number.
+     */
+    public void setCount(int count);
+
+    /**
+     * Gets the maximum distance from the spawner that entities will be spawned.
+     * 
+     * @return The distance.
+     */
+    public int getRange();
+
+    /**
+     * Sets the maximum distance from the spawner that entities will be spawned.
+     * 
+     * @param range The distance.
+     */
+    public void setRange(int range);
+
+    /**
+     * Gets the number of other entities that need to be within the spawner's range to prevent spawning,
+     * 
+     * @return The number.
+     */
+    public int getMaxNearbyEntities();
+
+    /**
+     * Sets the number of other entities that need to be within the spawner's range to prevent spawning.
+     * 
+     * @param maxNearbyEntities The number.
+     */
+    public void setMaxNearbyEntities(int maxNearbyEntities);
+
+    /**
+     * Gets the range that a player must be within to allow spawning.
+     * 
+     * @return The range.
+     */
+    public int getRequiredPlayerRange();
+
+    /**
+     * Sets the range that a player must be within to allow spawning.
+     * 
+     * @param requiredPlayerRange The range.
+     */
+    public void setRequiredPlayerRange(int requiredPlayerRange);
 }

--- a/src/main/java/org/bukkit/block/CreatureSpawner.java
+++ b/src/main/java/org/bukkit/block/CreatureSpawner.java
@@ -34,14 +34,14 @@ public interface CreatureSpawner extends BlockState {
 
     /**
      * Sets the entity that will be spawned.
-     * 
+     *
      * @param entity The entity
      */
     public void setSpawnedEntity(Entity entity);
 
     /**
      * Sets the entity that will be spawned.
-     * 
+     *
      * @param entity The entity
      * @param includePosition If true position data will be kept
      */
@@ -132,56 +132,66 @@ public interface CreatureSpawner extends BlockState {
 
     /**
      * Gets the number of entities that the spawner will attempt to spawn.
-     * 
+     *
      * @return The number.
      */
     public int getCount();
 
     /**
      * Sets the number of entities that the spawner will attempt to spawn.
-     * 
+     *
      * @param count The number.
      */
     public void setCount(int count);
 
     /**
      * Gets the maximum distance from the spawner that entities will be spawned.
-     * 
+     *
      * @return The distance.
      */
     public int getRange();
 
     /**
      * Sets the maximum distance from the spawner that entities will be spawned.
-     * 
+     *
      * @param range The distance.
      */
     public void setRange(int range);
 
     /**
+     * Set the vertical range of this CreatureSpawner. Spawn attempts will be uniformly distributed
+     * in the range specified. Vanilla behavior (1 below, 1 above) is equivalent to calling this with (1, 1).
+     *
+     * @param maxBelow Maximum Y-difference below this CreatureSpawner for spawning attempts
+     * @param maxAbove Maximum Y-difference above this CreatureSpawner for spawning attempts
+     * @throws IllegalArgumentException when no Y-values would be possible (e.g. setVerticalRange(1, -2))
+     */
+    public void setVerticalRange(int maxBelow, int maxAbove);
+
+    /**
      * Gets the number of other entities that need to be within the spawner's range to prevent spawning,
-     * 
+     *
      * @return The number.
      */
     public int getMaxNearbyEntities();
 
     /**
      * Sets the number of other entities that need to be within the spawner's range to prevent spawning.
-     * 
+     *
      * @param maxNearbyEntities The number.
      */
     public void setMaxNearbyEntities(int maxNearbyEntities);
 
     /**
      * Gets the range that a player must be within to allow spawning.
-     * 
+     *
      * @return The range.
      */
     public int getRequiredPlayerRange();
 
     /**
      * Sets the range that a player must be within to allow spawning.
-     * 
+     *
      * @param requiredPlayerRange The range.
      */
     public void setRequiredPlayerRange(int requiredPlayerRange);

--- a/src/main/java/org/bukkit/block/CreatureSpawner.java
+++ b/src/main/java/org/bukkit/block/CreatureSpawner.java
@@ -1,5 +1,8 @@
 package org.bukkit.block;
 
+import java.util.List;
+
+import org.bukkit.SpawnerEntry;
 import org.bukkit.entity.CreatureType;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
@@ -17,6 +20,15 @@ public interface CreatureSpawner extends BlockState {
      */
     @Deprecated
     public CreatureType getCreatureType();
+
+    /**
+     * Set the spawner creature type.
+     *
+     * @param creatureType The creature type.
+     * @deprecated In favour of {@link #setSpawnedType(EntityType)}.
+     */
+    @Deprecated
+    public void setCreatureType(CreatureType creatureType);
 
     /**
      * Get the spawner's creature type.
@@ -51,22 +63,51 @@ public interface CreatureSpawner extends BlockState {
     public void setSpawnedEntity(Entity entity, boolean includePosition);
 
     /**
-     * Set the spawner creature type.
+     * Gets a list of the entity types that this spawner could create. Note that modifying
+     * this list will not affect the behviour of the spawner.
      *
-     * @param creatureType The creature type.
-     * @deprecated In favour of {@link #setSpawnedType(EntityType)}.
+     * @return The list of types.
      */
-    @Deprecated
-    public void setCreatureType(CreatureType creatureType);
+    public List<SpawnerEntry> getSpawnPotentials();
 
     /**
-     * Get the spawner's creature type.
-     *
-     * @return The creature type's name.
-     * @deprecated Use {@link #getCreatureTypeName()}.
+     * Removes all spawn possibilities from the spawner.
      */
-    @Deprecated
-    public String getCreatureTypeId();
+    public void clearSpawnPotentials();
+
+    /**
+     * Adds an entity type to the spawn list. The weight is used to control the chance
+     * of each spawn potential occurring, a higher value relative to the other list entries
+     * will result in this spawn being more frequent.
+     *
+     * @param creatureType The entity type.
+     * @param weight The weight.
+     * @throws IllegalArgumentException If the entity cannot be spawned from spawners.
+     */
+    public void addPotentialSpawnedType(EntityType creatureType, int weight);
+
+    /**
+     * Adds an entity to the spawn list. The weight is used to control the chance
+     * of each spawn potential occurring, a higher value relative to the other list entries
+     * will result in this spawn being more frequent.
+     *
+     * @param entity The entity
+     * @param includePosition If true position data will be kept.
+     * @param weight The weight.
+     * @throws IllegalArgumentException If the entity cannot be spawned from spawners.
+     */
+    public void addPotentialSpawnedEntity(Entity entity, boolean includePosition, int weight);
+
+    /**
+     * Adds an entity to the spawn list. The weight is used to control the chance
+     * of each spawn potential occurring, a higher value relative to the other list entries
+     * will result in this spawn being more frequent.
+     *
+     * @param entity The entity.
+     * @param weight The weight.
+     * @throws IllegalArgumentException If the entity cannot be spawned from spawners.
+     */
+    public void addPotentialSpawnedEntity(Entity entity, int weight);
 
     /**
      * Set the spawner mob type.
@@ -81,6 +122,15 @@ public interface CreatureSpawner extends BlockState {
      * @return The creature type's name.
      */
     public String getCreatureTypeName();
+
+    /**
+     * Get the spawner's creature type.
+     *
+     * @return The creature type's name.
+     * @deprecated Use {@link #getCreatureTypeName()}.
+     */
+    @Deprecated
+    public String getCreatureTypeId();
 
     /**
      * Set the spawner mob type.

--- a/src/main/java/org/bukkit/block/CreatureSpawner.java
+++ b/src/main/java/org/bukkit/block/CreatureSpawner.java
@@ -29,6 +29,7 @@ public interface CreatureSpawner extends BlockState {
      * Set the spawner's creature type.
      *
      * @param creatureType The creature type.
+     * @throws IllegalArgumentException If the entity cannot be spawned from spawners.
      */
     public void setSpawnedType(EntityType creatureType);
 
@@ -36,14 +37,16 @@ public interface CreatureSpawner extends BlockState {
      * Sets the entity that will be spawned.
      *
      * @param entity The entity
+     * @throws IllegalArgumentException If the entity cannot be spawned from spawners.
      */
     public void setSpawnedEntity(Entity entity);
 
     /**
      * Sets the entity that will be spawned.
      *
-     * @param entity The entity
-     * @param includePosition If true position data will be kept
+     * @param entity The entity.
+     * @param includePosition If true position data will be kept.
+     * @throws IllegalArgumentException If the entity cannot be spawned from spawners.
      */
     public void setSpawnedEntity(Entity entity, boolean includePosition);
 
@@ -113,6 +116,7 @@ public interface CreatureSpawner extends BlockState {
      * Set the spawner's minimum delay.
      *
      * @param delay The delay.
+     * @throws IllegalArgumentException if delay is less than or equal to 0
      */
     public void setMinDelay(int delay);
 
@@ -145,7 +149,8 @@ public interface CreatureSpawner extends BlockState {
     public void setCount(int count);
 
     /**
-     * Gets the maximum distance from the spawner that entities will be spawned.
+     * Gets the maximum distance from the spawner that entities will be spawned. This uses a horizontal
+     * square centred on the spawner.
      *
      * @return The distance.
      */
@@ -179,20 +184,22 @@ public interface CreatureSpawner extends BlockState {
      * Sets the number of other entities that need to be within the spawner's range to prevent spawning.
      *
      * @param maxNearbyEntities The number.
+     * @throws IllegalArgumentException If maxNearbyEntities is less than 0.
      */
     public void setMaxNearbyEntities(int maxNearbyEntities);
 
     /**
-     * Gets the range that a player must be within to allow spawning.
+     * Gets the radius of the sphere that a player must be within to allow spawning.
      *
      * @return The range.
      */
     public int getRequiredPlayerRange();
 
     /**
-     * Sets the range that a player must be within to allow spawning.
+     * Sets the radius of the sphere that a player must be within to allow spawning.
      *
      * @param requiredPlayerRange The range.
+     * @throws IllegalArgumentException If requiredPlayerRange is less than or equal to 0.
      */
     public void setRequiredPlayerRange(int requiredPlayerRange);
 }


### PR DESCRIPTION
##### The Issue:

There is no way for plugins to make use of the new spawner customisation that was introduced.
##### Justification for this PR:

Plugins may want to create custom spawners or modify the parameters of existing ones. I personally want to use this for dungeon generation.
##### PR Breakdown:
- Adds new methods to the CreatureSpawner interface to get and set the various fields.
- Adds support for all entity types that can be created using spawners to CreatureSpawner.setSpawnedType(EntityType entityType);
- Adds a method to set the properties of the spawned entity to those of an existing one, CreatureSpawner.setSpawnedEntity(Entity entity, boolean includePosition);
##### Testing Results and Materials:

Source - https://github.com/betterphp/SpawnerTest
Binary - http://ubuntuone.com/5bMZ7n3xCLxuw84on8sHDV

Provides 4 commands:
/gsp - Lists the current spawner properties
/ssp - Sets the spawner properties
/tnt - Makes a spawner than shoots TNT into the air
/fw - Makes a spawner that shoots fireworks into the air

All work on the spawner in the line of sight. A number of variations of spawner were created and their properties and behaviour checked before and after a server restart.
##### Relevant PR(s):

CB-1133 - https://github.com/Bukkit/CraftBukkit/pull/1133
##### JIRA Ticket:

BUKKIT-1998 - https://bukkit.atlassian.net/browse/BUKKIT-1998
