### PR TITLE
Added PlayerGridMoveEvent for a less frequently called move event.

### DIFF
--- a/src/main/java/org/bukkit/event/player/PlayerGridMoveEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerGridMoveEvent.java
@@ -6,7 +6,9 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
 /**
- * Holds information for player movement events that occur only when a player has changed which block they are on.
+ * This event is called whenever the Location of a Player crosses a block boundary.
+ * <p>
+ * It is recommended that plugins listen to this event in most cases, as it is called less frequently than {@link PlayerMoveEvent}.
  */
 public class PlayerGridMoveEvent extends PlayerEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
@@ -22,11 +24,11 @@ public class PlayerGridMoveEvent extends PlayerEvent implements Cancellable {
 
     /**
      * Gets the cancellation state of this event. A cancelled event will not
-     * be executed in the server, but will still pass to other plugins
+     * be executed in the server, but will still pass to other plugins.
      * <p>
      * If a move or teleport event is cancelled, the player will be moved or
      * teleported back to the Location as defined by getFrom(). This will not
-     * fire an event
+     * fire an event.
      *
      * @return true if this event is cancelled
      */
@@ -36,11 +38,11 @@ public class PlayerGridMoveEvent extends PlayerEvent implements Cancellable {
 
     /**
      * Sets the cancellation state of this event. A cancelled event will not
-     * be executed in the server, but will still pass to other plugins
+     * be executed in the server, but will still pass to other plugins.
      * <p>
      * If a move or teleport event is cancelled, the player will be moved or
      * teleported back to the Location as defined by getFrom(). This will not
-     * fire an event
+     * fire an event.
      *
      * @param cancel true if you wish to cancel this event
      */
@@ -49,7 +51,8 @@ public class PlayerGridMoveEvent extends PlayerEvent implements Cancellable {
     }
 
     /**
-     * Gets the location this player moved from
+     * Get the location of the player before they crossed a block boundary.
+     * If this event cancelled, the player will return to this location.
      *
      * @return Location the player moved from
      */
@@ -58,7 +61,8 @@ public class PlayerGridMoveEvent extends PlayerEvent implements Cancellable {
     }
 
     /**
-     * Sets the location to mark as where the player moved from
+     * Sets the location to mark as where the player moved from.
+     * If this event is cancelled, the player will return to this location.
      *
      * @param from New location to mark as the players previous location
      */
@@ -67,7 +71,7 @@ public class PlayerGridMoveEvent extends PlayerEvent implements Cancellable {
     }
 
     /**
-     * Gets the location this player moved to
+     * Gets the location this player moved to.
      *
      * @return Location the player moved to
      */
@@ -76,7 +80,7 @@ public class PlayerGridMoveEvent extends PlayerEvent implements Cancellable {
     }
 
     /**
-     * Sets the location that this player will move to
+     * Sets the location that this player will move to.
      *
      * @param to New Location this player will move to
      */

--- a/src/main/java/org/bukkit/event/player/PlayerGridMoveEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerGridMoveEvent.java
@@ -1,0 +1,95 @@
+package org.bukkit.event.player;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Holds information for player movement events that occur only when a player has changed which block they are on.
+ */
+public class PlayerGridMoveEvent extends PlayerEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancel = false;
+    private Location from;
+    private Location to;
+
+    public PlayerGridMoveEvent(final Player player, final Location from, final Location to) {
+        super(player);
+        this.from = from;
+        this.to = to;
+    }
+
+    /**
+     * Gets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     * <p>
+     * If a move or teleport event is cancelled, the player will be moved or
+     * teleported back to the Location as defined by getFrom(). This will not
+     * fire an event
+     *
+     * @return true if this event is cancelled
+     */
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    /**
+     * Sets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     * <p>
+     * If a move or teleport event is cancelled, the player will be moved or
+     * teleported back to the Location as defined by getFrom(). This will not
+     * fire an event
+     *
+     * @param cancel true if you wish to cancel this event
+     */
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+
+    /**
+     * Gets the location this player moved from
+     *
+     * @return Location the player moved from
+     */
+    public Location getFrom() {
+        return from;
+    }
+
+    /**
+     * Sets the location to mark as where the player moved from
+     *
+     * @param from New location to mark as the players previous location
+     */
+    public void setFrom(Location from) {
+        this.from = from;
+    }
+
+    /**
+     * Gets the location this player moved to
+     *
+     * @return Location the player moved to
+     */
+    public Location getTo() {
+        return to;
+    }
+
+    /**
+     * Sets the location that this player will move to
+     *
+     * @param to New Location this player will move to
+     */
+    public void setTo(Location to) {
+        this.to = to;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
@@ -6,82 +6,13 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
 /**
- * Holds information for player movement events
+ * Holds information for player movement events that occur any time the player makes any kind of movement including looking about.
  */
-public class PlayerMoveEvent extends PlayerEvent implements Cancellable {
+public class PlayerMoveEvent extends PlayerGridMoveEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
-    private boolean cancel = false;
-    private Location from;
-    private Location to;
 
     public PlayerMoveEvent(final Player player, final Location from, final Location to) {
-        super(player);
-        this.from = from;
-        this.to = to;
-    }
-
-    /**
-     * Gets the cancellation state of this event. A cancelled event will not
-     * be executed in the server, but will still pass to other plugins
-     * <p>
-     * If a move or teleport event is cancelled, the player will be moved or
-     * teleported back to the Location as defined by getFrom(). This will not
-     * fire an event
-     *
-     * @return true if this event is cancelled
-     */
-    public boolean isCancelled() {
-        return cancel;
-    }
-
-    /**
-     * Sets the cancellation state of this event. A cancelled event will not
-     * be executed in the server, but will still pass to other plugins
-     * <p>
-     * If a move or teleport event is cancelled, the player will be moved or
-     * teleported back to the Location as defined by getFrom(). This will not
-     * fire an event
-     *
-     * @param cancel true if you wish to cancel this event
-     */
-    public void setCancelled(boolean cancel) {
-        this.cancel = cancel;
-    }
-
-    /**
-     * Gets the location this player moved from
-     *
-     * @return Location the player moved from
-     */
-    public Location getFrom() {
-        return from;
-    }
-
-    /**
-     * Sets the location to mark as where the player moved from
-     *
-     * @param from New location to mark as the players previous location
-     */
-    public void setFrom(Location from) {
-        this.from = from;
-    }
-
-    /**
-     * Gets the location this player moved to
-     *
-     * @return Location the player moved to
-     */
-    public Location getTo() {
-        return to;
-    }
-
-    /**
-     * Sets the location that this player will move to
-     *
-     * @param to New Location this player will move to
-     */
-    public void setTo(Location to) {
-        this.to = to;
+        super(player, from, to);
     }
 
     @Override

--- a/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
@@ -6,7 +6,9 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
 /**
- * Holds information for player movement events that occur any time the player makes any kind of movement including looking about.
+ * This event is called whenever the Location of a Player changes.
+ * Most plugins do not need the fine-grained control this event provides, and should listen to
+ * {@link PlayerGridMoveEvent} instead.
  */
 public class PlayerMoveEvent extends PlayerGridMoveEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
@@ -22,5 +24,16 @@ public class PlayerMoveEvent extends PlayerGridMoveEvent implements Cancellable 
 
     public static HandlerList getHandlerList() {
         return handlers;
+    }
+
+    /**
+     * Get the location of the player before this event.
+     * If this event cancelled, the player will return to this location.
+     *
+     * @return Location the player moved from
+     */
+    @Override
+    public Location getFrom() {
+        return super.getFrom();
     }
 }


### PR DESCRIPTION
In contrast to PlayerMoveEvent, this event is only called when a player's new location represents a different block than their old location.

Resolves: https://bukkit.atlassian.net/browse/BUKKIT-4031
CraftBukkit implementation PR: https://github.com/Bukkit/CraftBukkit/pull/1134
### Status
- [x] Waiting for author
- [ ] Waiting for PRH
- [ ] Waiting for core
