### PR TITLE
[B+C] InventoryClickEvent now can return if the click was a double click

### DIFF
--- a/src/main/java/org/bukkit/event/inventory/CraftItemEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/CraftItemEvent.java
@@ -9,7 +9,7 @@ public class CraftItemEvent extends InventoryClickEvent {
     private Recipe recipe;
 
     public CraftItemEvent(Recipe recipe, InventoryView what, SlotType type, int slot, boolean right, boolean shift) {
-        super(what, type, slot, right, shift);
+        super(what, type, slot, right, shift, false);
         this.recipe = recipe;
     }
 

--- a/src/main/java/org/bukkit/event/inventory/InventoryClickEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryClickEvent.java
@@ -11,20 +11,26 @@ import org.bukkit.inventory.ItemStack;
 public class InventoryClickEvent extends InventoryEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private SlotType slot_type;
-    private boolean rightClick, shiftClick;
+    private boolean rightClick, shiftClick, doubleClick;
     private Result result;
     private int whichSlot;
     private int rawSlot;
     private ItemStack current = null;
 
-    public InventoryClickEvent(InventoryView what, SlotType type, int slot, boolean right, boolean shift) {
+    public InventoryClickEvent(InventoryView what, SlotType type, int slot, boolean right, boolean shift, boolean doubleClick) {
         super(what);
         this.slot_type = type;
         this.rightClick = right;
         this.shiftClick = shift;
+        this.doubleClick = doubleClick;
         this.result = Result.DEFAULT;
         this.rawSlot = slot;
         this.whichSlot = what.convertSlot(slot);
+    }
+
+    @Deprecated
+    public InventoryClickEvent(InventoryView what, SlotType type, int slot, boolean right, boolean shift) {
+        this(what, type, slot, right, shift, false);
     }
 
     /**
@@ -64,6 +70,14 @@ public class InventoryClickEvent extends InventoryEvent implements Cancellable {
      */
     public boolean isLeftClick() {
         return !rightClick;
+    }
+
+    /**
+     * A double click will group up all items from the container of the same type onto the cursor.
+     * @return True if the click is a double click.
+     */
+    public boolean isDoubleClick() {
+        return doubleClick;
     }
 
     /**


### PR DESCRIPTION
**The Issue:**

A new feature was added in Minecraft 1.5 that allows you to double click inside of an inventory while you have an item on the cursor. When you double click it will stack all like-items (same type as your cursor) from the container onto your cursor.

The current API provides no way to distinguish this from a normal inventory interaction event. This circumvents normal ways to block usage of an inventory because you can simply get an item that is inside of the inventory already and then double click yours and it will bring all of the ones in the inventory onto your cursor.

**Justification for this PR:**

Plugins that want to prevent a player from using an inventory (e.g. looking at it but not removing/placing items) are made useless because any item can be removed if you have the same item type that you wish to remove.

**PR Breakdown:**

It amends `InventoryClickEvent` by exposing the double click state that is only known internally

**Testing Results and Materials:**

LWC, a single-block protection plugin, has a feature which allows you to create a "donation" chest. This allows you to place items into the chest but not take items out.

Before this PR anyone could arbitrarily take items out of the donation chests by using their own item and double clicking it to gather up the ones inside of the chest.

I have fully tested the PR with LWC by implementing `isDoubleClick()`. This can be seen in [LWC/e5e7ae1c7](https://github.com/Hidendra/LWC/commit/e5e7ae1c77dd30cdd6a17b7ddee9c027fb746061) and a working build can be found [here](http://ci.griefcraft.com/job/LWC/865/)

**JIRA Ticket:**

BUKKIT-4035 - https://bukkit.atlassian.net/browse/BUKKIT-4035

CraftBukkit PR: Bukkit/CraftBukkit#1135
