### PR TITLE
[B+C] Allow inventory creation by InventoryType and title. Fixes BUKKIT-4045

### DIFF
--- a/src/main/java/org/bukkit/Bukkit.java
+++ b/src/main/java/org/bukkit/Bukkit.java
@@ -574,6 +574,13 @@ public final class Bukkit {
     }
 
     /**
+     * @see Server#createInventory(InventoryHolder owner, InventoryType type, String title)
+     */
+    public static Inventory createInventory(InventoryHolder owner, InventoryType type, String title) {
+        return server.createInventory(owner, type, title);
+    }
+
+    /**
      * @see Server#createInventory(InventoryHolder owner, int size)
      */
     public static Inventory createInventory(InventoryHolder owner, int size) {

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -650,6 +650,17 @@ public interface Server extends PluginMessageRecipient {
     Inventory createInventory(InventoryHolder owner, InventoryType type);
 
     /**
+     * Creates an empty inventory with the specified type and title. If the type
+     * is {@link InventoryType#CHEST}, the new inventory has a size of 27;
+     * otherwise the new inventory has the normal size for its type.
+     * @param owner The holder of the inventory; can be null if there's no holder.
+     * @param type The type of inventory to create.
+     * @param title The title of the inventory, to be displayed when it is viewed.
+     * @return The new inventory.
+     */
+    Inventory createInventory(InventoryHolder owner, InventoryType type, String title);
+
+    /**
      * Creates an empty inventory of type {@link InventoryType#CHEST} with the
      * specified size.
      *


### PR DESCRIPTION
**The issue**

With the current API it is possible to create an inventory with a specific type, but it is not possible to give such an inventory a title other than the default.

**Justification for this PR**

It is possible to give a chest-like inventory a specified title, and this functionality should be extended to the other inventory types.

**PR Breakdown**

On the Bukkit side, it exposes a new API for creating an inventory by InventoryType and title: `Bukkit.createInventory(InventoryHolder owner, InventoryType type, String title)`

On the CraftBukkit side, `CraftInventoryCustom` (and subsequently CraftInventoryCustom.MinecraftInventory) are given matching constructors.

**Testing Results and Materials**

I've thrown together a plugin that uses the new API call to open an inventory of a given type with a static title. To use this, type `/open` and use the tab complete from there: [InventoryTypeWithTitle.jar](https://dl.dropboxusercontent.com/u/2241170/tmp/InventoryTypeWithTitle.jar). ([source](https://github.com/eueln/InventoryTypeWithTitle))

**Relevant PRs**

CB-1136 - https://github.com/Bukkit/CraftBukkit/pull/1136 - Matching CraftBukkit PR

**JIRA Ticket**

BUKKIT-4045 https://bukkit.atlassian.net/browse/BUKKIT-4045
