### PR TITLE
[B] Add NETHER_BRICK & QUARTZ_BLOCK to Step (Fixes BUKKIT-4074)

### DIFF
--- a/src/main/java/org/bukkit/material/Step.java
+++ b/src/main/java/org/bukkit/material/Step.java
@@ -17,6 +17,8 @@ public class Step extends TexturedMaterial {
         textures.add(Material.COBBLESTONE);
         textures.add(Material.BRICK);
         textures.add(Material.SMOOTH_BRICK);
+        textures.add(Material.NETHER_BRICK);
+        textures.add(Material.QUARTZ_BLOCK);
     }
 
     public Step() {


### PR DESCRIPTION
## The Issue:

Minecraft added two new slab types. (Nether Brick in MC 1.4.6 and Quartz in MC 1.5). Bukkit's Step class had not taken these into account, so setMaterial() and getMaterial() couldn't be used to set/read the those types of slabs.
## Justification for this PR:

This pull request simply adds the two new materials to the texture array for steps.
## JIRA Ticket:

BUKKIT4074 - https://bukkit.atlassian.net/browse/BUKKIT-4074
### Other Comments

This doesn't deal with the fact that double slabs also have two additional type additions (4 total new data vales), but that can't be handled quite as nicely as there is not a clean Material type that could be used.
