### PR TITLE
[B] Fixes the Duration-Value in /effect command, Fixes BUKKIT-3967

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/EffectCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/EffectCommand.java
@@ -62,6 +62,7 @@ public class EffectCommand extends VanillaCommand {
         }
 
         int duration = 600;
+        int duration_sek;
         int duration_temp = 30;
         int amplification = 0;
 
@@ -92,7 +93,8 @@ public class EffectCommand extends VanillaCommand {
             final PotionEffect applyEffect = new PotionEffect(effect, duration, amplification);
 
             player.addPotionEffect(applyEffect, true);
-            broadcastCommandMessage(sender, String.format("Given %s (ID %d) * %d to %s for %d seconds", effect.getName(), effect.getId(), amplification, args[0], duration));
+            duration_sek = duration / 20;
+            broadcastCommandMessage(sender, String.format("Given %s (ID %d) * %d to %s for %d seconds", effect.getName(), effect.getId(), amplification, args[0], duration_sek));
         }
 
         return true;

--- a/src/main/java/org/bukkit/command/defaults/EffectCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/EffectCommand.java
@@ -62,7 +62,7 @@ public class EffectCommand extends VanillaCommand {
         }
 
         int duration = 600;
-        int duration_sek;
+        int duration_sec;
         int duration_temp = 30;
         int amplification = 0;
 
@@ -93,8 +93,8 @@ public class EffectCommand extends VanillaCommand {
             final PotionEffect applyEffect = new PotionEffect(effect, duration, amplification);
 
             player.addPotionEffect(applyEffect, true);
-            duration_sek = duration / 20;
-            broadcastCommandMessage(sender, String.format("Given %s (ID %d) * %d to %s for %d seconds", effect.getName(), effect.getId(), amplification, args[0], duration_sek));
+            duration_sec = duration / 20;
+            broadcastCommandMessage(sender, String.format("Given %s (ID %d) * %d to %s for %d seconds", effect.getName(), effect.getId(), amplification, args[0], duration_sec));
         }
 
         return true;


### PR DESCRIPTION
The Issue:
When Using the /effect command. The Time is outputted in Ticks not in seconds.

PR Breakdown:
during the /effect command a variabnle (duration_sec) will be declared and initalized with duration / 20

JIRA-Ticket:
BUKKIT-3967 - https://bukkit.atlassian.net/browse/BUKKIT-3967
