### PR TITLE
Added PluginExceptionHandler and method to call from SimplePluginManager

### DIFF
--- a/src/main/java/org/bukkit/plugin/PluginExceptionHandler.java
+++ b/src/main/java/org/bukkit/plugin/PluginExceptionHandler.java
@@ -1,0 +1,5 @@
+package org.bukkit.plugin;
+
+public interface PluginExceptionHandler {
+	public void uncaughtException(Throwable exception);
+}

--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -490,6 +490,15 @@ public final class SimplePluginManager implements PluginManager {
                 }
             } catch (Throwable ex) {
                 server.getLogger().log(Level.SEVERE, "Could not pass event " + event.getEventName() + " to " + registration.getPlugin().getDescription().getFullName(), ex);
+                Plugin plugin = registration.getPlugin();
+                if (plugin instanceof PluginExceptionHandler){
+                	try{
+                    	((PluginExceptionHandler)plugin).uncaughtException(ex);
+                	} catch (Exception e){
+                		/* *sigh, really you couldnt even handle your own bad exception?
+                		 * do nothing */
+                	}
+                }
             }
         }
     }


### PR DESCRIPTION
Added the ability for plugins to have a method to handle their own
uncaught exceptions during Bukkit Events. Similar to a per plugin
Thread.UncaughtExceptionHandler
