### PR TITLE
[B] Account for spacing in MapFont#getWidth(). Fixes BUKKIT-4089

### DIFF
--- a/src/main/java/org/bukkit/map/MapFont.java
+++ b/src/main/java/org/bukkit/map/MapFont.java
@@ -52,10 +52,16 @@ public class MapFont {
             throw new IllegalArgumentException("text contains invalid characters");
         }
 
+        if (text.length() == 0) {
+            return 0;
+        }
+
         int result = 0;
         for (int i = 0; i < text.length(); ++i) {
             result += chars.get(text.charAt(i)).getWidth();
         }
+        result += text.length() - 1; // Account for 1-px spaces between characters
+
         return result;
     }
 


### PR DESCRIPTION
(Note that [someone else did a PR for this before](https://github.com/Bukkit/Bukkit/pull/768), but that one doesn't follow the new PR conventions)
### The issue

The implementation of MapFont#getWidth(String) does not accurately reflect the width of the input, unless the input consists of 1 or less characters.

This is evident when looking at CraftBukkit's implementation of MapCanvas#drawText(), which contains [this line](https://github.com/Bukkit/CraftBukkit/blob/61e57e1196fc917d0e8f9c5f1ee48818a85fd5b9/src/main/java/org/bukkit/craftbukkit/map/CraftMapCanvas.java#L106):

```
x += sprite.getWidth() + 1;
```

This line defines a 1-px space added after each character, which is not reflected in [the current MapFont#getWidth()](https://github.com/Bukkit/Bukkit/blob/dce83b6ce48c0c8592e7912e9527080254a22553/src/main/java/org/bukkit/map/MapFont.java#L48).
### PR Breakdown

This change first checks if the String contains 0 characters (as to not inaccurately report a width of -1) and returns `0` if this is the case.

After the character widths are added together, `text.length() - 1` is added to account for the 1-px spacing between characters
### Testing results and Materials

[The original PR submitter had a compelling test case](https://github.com/Bukkit/Bukkit/pull/768#issuecomment-13403025).

In addition, see [CraftMapCanvas#drawText()](https://github.com/Bukkit/CraftBukkit/blob/61e57e1196fc917d0e8f9c5f1ee48818a85fd5b9/src/main/java/org/bukkit/craftbukkit/map/CraftMapCanvas.java#L106) to identify that there are no edge cases in regard to spacing the characters; _every character_ has a 1-px spacer appended to the end.
### JIRA Ticket

BUKKIT-4089 - https://bukkit.atlassian.net/browse/BUKKIT-4089
