### PR TITLE
[B+C] Define EntitySpawnEvent and SpawnerSpawnEvent. Adds BUKKIT-267 and BUKKIT-1559

### DIFF
--- a/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
+++ b/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
@@ -4,17 +4,13 @@ import org.bukkit.Location;
 import org.bukkit.entity.CreatureType;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.event.Cancellable;
-import org.bukkit.event.HandlerList;
 
 /**
  * Called when a creature is spawned into a world.
  * <p>
  * If a Creature Spawn event is cancelled, the creature will not spawn.
  */
-public class CreatureSpawnEvent extends EntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-    private boolean canceled;
+public class CreatureSpawnEvent extends EntitySpawnEvent {
     private final SpawnReason spawnReason;
 
     public CreatureSpawnEvent(final LivingEntity spawnee, final SpawnReason spawnReason) {
@@ -28,26 +24,9 @@ public class CreatureSpawnEvent extends EntityEvent implements Cancellable {
         spawnReason = reason;
     }
 
-    public boolean isCancelled() {
-        return canceled;
-    }
-
-    public void setCancelled(boolean cancel) {
-        canceled = cancel;
-    }
-
     @Override
     public LivingEntity getEntity() {
         return (LivingEntity) entity;
-    }
-
-    /**
-     * Gets the location at which the creature is spawning.
-     *
-     * @return The location at which the creature is spawning
-     */
-    public Location getLocation() {
-        return getEntity().getLocation();
     }
 
     /**
@@ -68,15 +47,6 @@ public class CreatureSpawnEvent extends EntityEvent implements Cancellable {
      */
     public SpawnReason getSpawnReason() {
         return spawnReason;
-    }
-
-    @Override
-    public HandlerList getHandlers() {
-        return handlers;
-    }
-
-    public static HandlerList getHandlerList() {
-        return handlers;
     }
 
     /**

--- a/src/main/java/org/bukkit/event/entity/EntitySpawnEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntitySpawnEvent.java
@@ -1,0 +1,45 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Called when an entity is spawned into a world.
+ * <p>
+ * If cancelled, the entity will not spawn.
+ */
+public class EntitySpawnEvent extends EntityEvent implements org.bukkit.event.Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean canceled;
+
+    public EntitySpawnEvent(final Entity spawnee) {
+        super(spawnee);
+    }
+
+    public boolean isCancelled() {
+        return canceled;
+    }
+
+    public void setCancelled(boolean cancel) {
+        canceled = cancel;
+    }
+
+    /**
+     * Gets the location at which the entity is spawning.
+     *
+     * @return The location at which the entity is spawning
+     */
+    public Location getLocation() {
+        return getEntity().getLocation();
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/org/bukkit/event/entity/ItemSpawnEvent.java
+++ b/src/main/java/org/bukkit/event/entity/ItemSpawnEvent.java
@@ -1,51 +1,23 @@
 package org.bukkit.event.entity;
 
-import org.bukkit.entity.Item;
 import org.bukkit.Location;
-import org.bukkit.event.Cancellable;
-import org.bukkit.event.HandlerList;
+import org.bukkit.entity.Item;
 
 /**
  * Called when an item is spawned into a world
  */
-public class ItemSpawnEvent extends EntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-    private final Location location;
-    private boolean canceled;
-
+public class ItemSpawnEvent extends EntitySpawnEvent {
+    @Deprecated
     public ItemSpawnEvent(final Item spawnee, final Location loc) {
+        this(spawnee);
+    }
+
+    public ItemSpawnEvent(final Item spawnee) {
         super(spawnee);
-        this.location = loc;
-    }
-
-    public boolean isCancelled() {
-        return canceled;
-    }
-
-    public void setCancelled(boolean cancel) {
-        canceled = cancel;
     }
 
     @Override
     public Item getEntity() {
         return (Item) entity;
-    }
-
-    /**
-     * Gets the location at which the item is spawning.
-     *
-     * @return The location at which the item is spawning
-     */
-    public Location getLocation() {
-        return location;
-    }
-
-    @Override
-    public HandlerList getHandlers() {
-        return handlers;
-    }
-
-    public static HandlerList getHandlerList() {
-        return handlers;
     }
 }

--- a/src/main/java/org/bukkit/event/entity/SpawnerSpawnEvent.java
+++ b/src/main/java/org/bukkit/event/entity/SpawnerSpawnEvent.java
@@ -1,0 +1,27 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.block.CreatureSpawner;
+import org.bukkit.entity.Entity;
+
+/**
+ * Called when an entity is spawned into a world by a spawner.
+ * <p>
+ * If cancelled, the entity will not spawn.
+ */
+public class SpawnerSpawnEvent extends EntitySpawnEvent {
+    private final CreatureSpawner spawner;
+
+    public SpawnerSpawnEvent(final Entity spawnee, final CreatureSpawner spawner) {
+        super(spawnee);
+        this.spawner = spawner;
+    }
+
+    /**
+     * Returns the CreatureSpawner involved in this event
+     *
+     * @return CreatureSpawner which is involved in this event
+     */
+    public CreatureSpawner getSpawner() {
+        return spawner;
+    }
+}


### PR DESCRIPTION
**The Issue:**
When a spawner creates an entity, it is difficult to determine the location of the spawner. With the addition of this commit, it is even more difficult to listen to all entity creation events (there are now three).

**Justification for this PR:**
My primary motivation in submitting this is to allow plugins to easily locate the spawner which spawned a given entity. Doing a brute force search on every CreatureSpawnEvent whose reason is SPAWNER is extremely impractical, especially on a large server. Additionally, if there are two identical spawners next to each other, a search will not necessarily return the correct spawner. However, I took the opportunity (at the request of @EdGruberman) to refactor entity-spawning events.

**PR Breakdown:**
Bukkit: Creates EntitySpawnEvent. Refactors ItemSpawnEvent and CreatureSpawnEvent such that they inherit from EntitySpawnEvent. Creates SpawnerSpawnEvent, also inherits from EntitySpawnEvent.
CraftBukkit: Creates central method for calling SpawnerSpawnEvent. Modifies spawner-related code such that the event is called and subsequent spawner activity does not happen if the event is cancelled.

**Testing Results and Materials:**
CreatureSpawnEvent and ItemSpawnEvent continue to work as normal, without any changes. SpawnerSpawnEvent works on both living and non-living entities.
Testing plugin: http://www.multiupload.nl/VIVPRINPEU
Source: http://www.multiupload.nl/IUD28UP8O8
Helpful schematics for testing spawners: http://www.mediafire.com/?6h6pj89ph1rdb5r

**Relevant PRs:**
CB-1137 - https://github.com/Bukkit/CraftBukkit/pull/1137
B-783 - https://github.com/Bukkit/Bukkit/pull/783 - Does not include any common entity spawn event class.
CB-1046 - https://github.com/Bukkit/CraftBukkit/pull/1046 - Builds against 1.4.x code.

**JIRA Tickets:**
BUKKIT-267 - https://bukkit.atlassian.net/browse/BUKKIT-267
BUKKIT-1559 - https://bukkit.atlassian.net/browse/BUKKIT-1559
