### PR TITLE
[B+C] Implemented mass block change API. Adds BUKKIT-4114

### DIFF
--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -1064,6 +1064,80 @@ public interface World extends PluginMessageRecipient, Metadatable {
     public boolean isGameRule(String rule);
 
     /**
+     * Sets the type-id of the block at the given location without sending client changes
+     * @param x X coordinate of the block
+     * @param y Y coordinate of the block
+     * @param z Z coordinate of the block
+     * @param type Type-Id to change this block to
+     * @param data The data value to change this block to
+     * @return whether the block was changed
+     */
+    public boolean setBlockTypeIdAndDataFast(int x, int y, int z, int type, byte data);
+
+    /**
+     * Sets the type-id of the block at the given location without sending client changes
+     * @param x Z coordinate of the block
+     * @param y Y coordinate of the block
+     * @param z Z coordinate of the block
+     * @param type Type-Id to change this block to
+     * @return whether the block was changed
+     */
+    public boolean setBlockTypeIdFast(int x, int y, int z, int type);
+
+    /**
+     * Sets the type of the block at the given location without sending client changes
+     * @param x Z coordinate of the block
+     * @param y Y coordinate of the block
+     * @param z Z coordinate of the block
+     * @param type Material to change this block to
+     * @return whether the block was changed
+     */
+    public boolean setBlockTypeFast(int x, int y, int z, Material type);
+
+    /**
+     * Sets the type-id of the block at the given location without sending client changes
+     * @param location The location of the block
+     * @param type Type-Id to change this block to
+     * @param data The data value to change this block to
+     * @return whether the block was changed
+     */
+    public boolean setBlockTypeIdAndDataFast(Location location, int type, byte data);
+
+    /**
+     * Sets the type-id of the block at the given location without sending client changes
+     * @param location The location of the block
+     * @param type Type-Id to change this block to
+     * @return whether the block was changed
+     */
+    public boolean setBlockTypeIdFast(Location location, int type);
+
+    /**
+     * Sets the type of the block at the given location without sending client changes
+     * @param location The location of the block
+     * @param type Material to change this block to
+     * @return whether the block was changed
+     */
+    public boolean setBlockTypeFast(Location location, Material type);
+
+    /**
+     * Sets the metadata of the block at the given location without sending client changes
+     * @param x X coordinate of the block
+     * @param y Y coordinate of the block
+     * @param z Z coordinate of the block
+     * @param data New block specific metadata
+     * @return whether the block was changed
+     */
+    public boolean setBlockDataFast(int x, int y, int z, byte data);
+
+    /**
+     * Sets the metadata of the block at the given location without sending client changes
+     * @param location The location of the block
+     * @param data New block specific metadata
+     * @return whether the block was changed
+     */
+    public boolean setBlockDataFast(Location location, byte data);
+
+    /**
      * Represents various map environment types that a world may be
      */
     public enum Environment {

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -4,6 +4,7 @@ import java.net.InetSocketAddress;
 
 import org.bukkit.Achievement;
 import org.bukkit.ChatColor;
+import org.bukkit.Chunk;
 import org.bukkit.Effect;
 import org.bukkit.Instrument;
 import org.bukkit.Location;
@@ -646,4 +647,17 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      *     yet or has logged out
      */
     public void setScoreboard(Scoreboard scoreboard) throws IllegalArgumentException, IllegalStateException;
+
+    /**
+     * Updates a chunk for this player
+     * @param chunk The chunk to update
+     */
+    public void updateChunk(Chunk chunk);
+
+    /**
+     * Updates a chunk for this player
+     * @param x X coordinate of the chunk to update
+     * @param z Z coordinate of the chunk to update
+     */
+    public void updateChunk(int x, int z);
 }


### PR DESCRIPTION
**The Issue:**
Internally, Bukkit's Block.setType\* and Block.setData calls end up sending a packet to update player clients. When updating large amounts of blocks, this causes a flood of packets which most clients have trouble dealing with.

It is possible to queue block changes and send them in bulk, per chunk to desired players. This would result in one chunk update packet against possible thousands of block change packets, effectively drastically reducing block modification lag.

**Justification for this PR:**
I created this API because there is a dire need for a robust block API in Bukkit. Many popular plugins (WorldEdit comes to mind) would benefit from fast block changes without the hassle of NMS.

**PR Breakdown:**
Bukkit: Adds set(Block|Data)*Fast interface methods & JavaDocs.
CraftBukkit: Implements said methods. All methods are self contained.

**Testing Results and Materials:**
Using this method, an entire chunk can be set to glass in an average of 300ms (Tested on Windows 7 localhost server, 2GB RAM).

BulkBlockTest: https://dl.dropboxusercontent.com/u/67341745/test/BulkBlockTest.jar
Source for BulkBlockTest (sans plugin.yml): https://gist.github.com/Icyene/5417528

**Relevant PRs:**
CraftBukkit: https://github.com/Bukkit/CraftBukkit/pull/1142

**JIRA Tickets:**
BUKKIT-4114 - https://bukkit.atlassian.net/browse/BUKKIT-4114
