### PR TITLE
[B] Plugin extends the interface Listener Adds BUKKIT-4123

### DIFF
--- a/src/main/java/org/bukkit/plugin/Plugin.java
+++ b/src/main/java/org/bukkit/plugin/Plugin.java
@@ -7,6 +7,7 @@ import java.util.logging.Logger;
 import org.bukkit.Server;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.event.Listener;
 import org.bukkit.generator.ChunkGenerator;
 
 import com.avaje.ebean.EbeanServer;
@@ -16,7 +17,7 @@ import com.avaje.ebean.EbeanServer;
  * <p>
  * The use of {@link PluginBase} is recommended for actual Implementation
  */
-public interface Plugin extends TabExecutor {
+public interface Plugin extends TabExecutor, Listener {
     /**
      * Returns the folder that the plugin data's files are located in. The
      * folder may not yet exist.


### PR DESCRIPTION
**The Issue:**

When registering events in the main class of your plugin (class that extends "JavaPlugin"), you need to implement Listener manually.

``` java
public class MyAwesomePlugin extends JavaPlugin implements Listener {
  @Override
  public void onEnable() {
    getServer().getPluginManager().registerEvents(this, this);
  }

  /* Events here, etc */
}
```

With this PR you no longer have to implement Listener

``` java
public class MyAwesomePlugin extends JavaPlugin {
  /* onEnable(), events, etc */
}
```

**PR Breakdown:**

Plugin interface now extends Listener

If this PR get's merged, a method in PluginManager could be created with the single argument of a Plugin

``` java
void registerEvents(Plugin plugin);
```

**JIRA Ticket:**

BUKKIT-4123 - https://bukkit.atlassian.net/browse/BUKKIT-4123
