### PR TITLE
[B] Fix missing closing brackets in ItemStack.addEnchantment error message. Fixes Bukkit-4126

### DIFF
--- a/src/main/java/org/bukkit/inventory/ItemStack.java
+++ b/src/main/java/org/bukkit/inventory/ItemStack.java
@@ -411,7 +411,7 @@ public class ItemStack implements Cloneable, ConfigurationSerializable {
     public void addEnchantment(Enchantment ench, int level) {
         Validate.notNull(ench, "Enchantment cannot be null");
         if ((level < ench.getStartLevel()) || (level > ench.getMaxLevel())) {
-            throw new IllegalArgumentException("Enchantment level is either too low or too high (given " + level + ", bounds are " + ench.getStartLevel() + " to " + ench.getMaxLevel());
+            throw new IllegalArgumentException("Enchantment level is either too low or too high (given " + level + ", bounds are " + ench.getStartLevel() + " to " + ench.getMaxLevel() + ")");
         } else if (!ench.canEnchantItem(this)) {
             throw new IllegalArgumentException("Specified enchantment cannot be applied to this itemstack");
         }


### PR DESCRIPTION
**The issue:**

The error message is missing a closing braket.

**Justification for this PR:**

The error message looks like being incomplete, although it is complete.
There should not be any bracket issues in the messages.

**PR Breakdown:**

Adds the missing closing bracket to the error message's text.
current: "Enchantment level is either too low or too high (given 100, bounds are 1 to 5"
fixed: "Enchantment level is either too low or too high (given 100, bounds are 1 to 5)"
Although this is just a minor mistake, but error message should be correctly too.

**Testing Results and Materials:**

None

**JIRA-Ticket:**

https://bukkit.atlassian.net/browse/BUKKIT-4126
