### PR TITLE
[B+C] Add method for setting explosion range to creepers. Adds Bukkit-4171

### DIFF
--- a/src/main/java/org/bukkit/entity/Creeper.java
+++ b/src/main/java/org/bukkit/entity/Creeper.java
@@ -18,4 +18,18 @@ public interface Creeper extends Monster {
      * @param value New Powered status
      */
     public void setPowered(boolean value);
+    
+    /**
+     * Gets the explosion range of this Creeper.
+     *
+     * @return the explosion range
+     */
+    public int getExplosionRange();
+    
+    /**
+     * Sets the explosion range of this Creeper.
+     *
+     * @param value New explosion range
+     */
+    public void setExplosionRange(int value);
 }

--- a/src/main/java/org/bukkit/entity/Creeper.java
+++ b/src/main/java/org/bukkit/entity/Creeper.java
@@ -14,22 +14,25 @@ public interface Creeper extends Monster {
 
     /**
      * Sets the Powered status of this Creeper
+     * Calling this method will reset yield.
+     * Powered true -> yield = 6F
+     * Powered false -> yield = 3F
      *
      * @param value New Powered status
      */
     public void setPowered(boolean value);
     
     /**
-     * Gets the explosion range of this Creeper.
-     *
-     * @return the explosion range
-     */
-    public int getExplosionRange();
-    
+    * Set the radius affected by this explosive's explosion
+    *
+    * @param yield The explosive yield
+    */
+    public void setYield(float yield);
+
     /**
-     * Sets the explosion range of this Creeper.
-     *
-     * @param value New explosion range
-     */
-    public void setExplosionRange(int value);
+    * Return the radius or yield of this explosive's explosion
+    *
+    * @return the radius of blocks affected
+    */
+    public float getYield();
 }

--- a/src/main/java/org/bukkit/entity/Creeper.java
+++ b/src/main/java/org/bukkit/entity/Creeper.java
@@ -23,14 +23,14 @@ public interface Creeper extends Monster {
     public void setPowered(boolean value);
     
     /**
-    * Set the radius affected by this explosive's explosion
+    * Set the radius affected by this creeper's explosion
     *
     * @param yield The explosive yield
     */
     public void setYield(float yield);
 
     /**
-    * Return the radius or yield of this explosive's explosion
+    * Return the radius or yield of this creeper's explosion
     *
     * @return the radius of blocks affected
     */


### PR DESCRIPTION
**Justification for this:**

The Creeper has a field called explosionRange, but it isn't used by any Bukkit and CraftBukkit method.
In addition to that it isn't used to when the creeper explodes, this dismatches vanilla behaviour. (since updated to Minecraft 1.4(.2))
This PR adds a method to the Creeper which made this value accessible and changeable

**PR Breakdown:**

Added getExplosionRange and setExplosionRange(int) method to Creeper interface

JIRA: https://bukkit.atlassian.net/browse/BUKKIT-4171
CraftBukkit: https://github.com/Bukkit/CraftBukkit/pull/1149
