### PR TITLE
[C+B] Implement command tab completion in the console. Adds BUKKIT-4168

### DIFF
--- a/src/main/java/org/bukkit/command/Command.java
+++ b/src/main/java/org/bukkit/command/Command.java
@@ -80,12 +80,11 @@ public abstract class Command {
 
         String lastWord = args[args.length - 1];
 
-        Player senderPlayer = (Player) sender;
-
         ArrayList<String> matchedPlayers = new ArrayList<String>();
+        final boolean noPlayer = !(sender instanceof Player);
         for (Player player : sender.getServer().getOnlinePlayers()) {
             String name = player.getName();
-            if (senderPlayer.canSee(player) && StringUtil.startsWithIgnoreCase(name, lastWord)) {
+            if (noPlayer || ((Player) sender).canSee(player) && StringUtil.startsWithIgnoreCase(name, lastWord)) {
                 matchedPlayers.add(name);
             }
         }

--- a/src/main/java/org/bukkit/command/Command.java
+++ b/src/main/java/org/bukkit/command/Command.java
@@ -78,10 +78,6 @@ public abstract class Command {
         Validate.notNull(args, "Arguments cannot be null");
         Validate.notNull(alias, "Alias cannot be null");
 
-        if (!(sender instanceof Player) || args.length == 0) {
-            return ImmutableList.of();
-        }
-
         String lastWord = args[args.length - 1];
 
         Player senderPlayer = (Player) sender;

--- a/src/main/java/org/bukkit/command/SimpleCommandMap.java
+++ b/src/main/java/org/bukkit/command/SimpleCommandMap.java
@@ -16,6 +16,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Server;
 import org.bukkit.command.defaults.*;
+import org.bukkit.entity.Player;
 import org.bukkit.util.StringUtil;
 
 public class SimpleCommandMap implements CommandMap {
@@ -226,6 +227,8 @@ public class SimpleCommandMap implements CommandMap {
             ArrayList<String> completions = new ArrayList<String>();
             Map<String, Command> knownCommands = this.knownCommands;
 
+            final String prefix = (sender instanceof Player ? "/" : "");
+
             for (VanillaCommand command : fallbackCommands) {
                 String name = command.getName();
 
@@ -241,7 +244,7 @@ public class SimpleCommandMap implements CommandMap {
                     continue;
                 }
 
-                completions.add('/' + name);
+                completions.add(prefix + name);
             }
 
             for (Map.Entry<String, Command> commandEntry : knownCommands.entrySet()) {
@@ -254,7 +257,7 @@ public class SimpleCommandMap implements CommandMap {
                 String name = commandEntry.getKey(); // Use the alias, not command name
 
                 if (StringUtil.startsWithIgnoreCase(name, cmdLine)) {
-                    completions.add('/' + name);
+                    completions.add(prefix + name);
                 }
             }
 


### PR DESCRIPTION
##### The Issue:

The default implementation of Command.tabComplete() didn't allow anything but Players to tab complete.
Also the SimpleCommandMap.tabComplete() always prepended "/" to commands, which is not needed in the console.
##### Justification for this PR:

This PR is required for the feature to work
##### PR Breakdown:
- removes the Player check from Command.tabComplete()
- prepends the "/" only for Players
##### Testing Results and Materials:

Testing this is straight forward: Enter something (or nothing) into the console and press tab, it works pretty much exactly like ingame

B-868 - https://github.com/Bukkit/Bukkit/pull/868 - Command(Map) changes to allow console tab completion
CB-1151 - https://github.com/Bukkit/CraftBukkit/pull/1151 - Completer implementation
##### JIRA Ticket:

BUKKIT-4168- https://bukkit.atlassian.net/browse/BUKKIT-4168
