### PR TITLE
[B+C] Stores mob spawn reason inside the mob. Adds BUKKIT-2598

### DIFF
--- a/src/main/java/org/bukkit/entity/LivingEntity.java
+++ b/src/main/java/org/bukkit/entity/LivingEntity.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.bukkit.Location;
 import org.bukkit.block.Block;
+import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -391,4 +392,11 @@ public interface LivingEntity extends Entity, Damageable, ProjectileSource {
      * @return whether the operation was successful
      */
     public boolean setLeashHolder(Entity holder);
+
+    /**
+     * Gets the reason the living entity spawned into the world.
+     * 
+     * @return spawn reason of the living entity
+     */
+    public SpawnReason getSpawnReason();
 }


### PR DESCRIPTION
**The Issue**:

Currently, mob spawn reason is only available inside of a CreatureSpawnEvent.

**Justification for this PR**:

Multiple plugins save this data in maps for various reasons, which is usually lost after a server restart.  This request centralizes the data to one location, and is persistent over restarts.

**PR Breakdown**:

On creature spawn, the reason is stored in an internal variable inside the living entity.  On map save/load it is stored inside the mob's NBT tag Bukkit.SpawnReason.

**Testing Results and Materials**:

On mob damage, their spawn reason is messaged to the damager.  Plugin source is inside jar.
CraftBukkit: http://dropbox.meiskam.shininet.org/minecraft/bukkit/test/MobSpawnReason/craftbukkit-b3006-MobSpawnReason.jar
Plugin: http://dropbox.meiskam.shininet.org/minecraft/bukkit/test/MobSpawnReason/MobSpawnReasonTest-1.2.jar

**Relevant PR**:

CB-1152 - https://github.com/Bukkit/CraftBukkit/pull/1152

**JIRA Ticket**:

BUKKIT-2598 - https://bukkit.atlassian.net/browse/BUKKIT-2598
