### PR TITLE
[B+C] Set/get player count for client's multiplayer connect server list. Adds BUKKIT-2465

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -646,4 +646,20 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      *     yet or has logged out
      */
     public void setScoreboard(Scoreboard scoreboard) throws IllegalArgumentException, IllegalStateException;
+
+    /**
+     * 
+     * Get if this player is counted in the online players count
+     * 
+     * @return boolean, true if the player count
+     */
+    public boolean isCounted();
+
+    /**
+     * 
+     * Set if this player is counted in the online players count
+     * 
+     * @param boolean, true if the player count
+     */
+    public void setCounted(boolean isCounted);
 }


### PR DESCRIPTION
The Issue:

Actually , there is no way to set if a player is counted in the player online counts

Justification for this PR:

This PR allow a true vanish option and remove a player from the count list

PR Breakdown:

This PR implement the set and get values for counted method in the Player entity type

Relevant PR:

CraftBukkit: Bukkit/CraftBukkit#1153

Jira Ticket :
Leaky: https://bukkit.atlassian.net/browse/BUKKIT-2465
