### PR TITLE
[B+C] Added BrewEndEvent. Added getPotions method to Brew(End)Event. Adds BUKKIT-2441

### DIFF
--- a/src/main/java/org/bukkit/event/inventory/BrewEndEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/BrewEndEvent.java
@@ -4,15 +4,13 @@ import org.bukkit.block.Block;
 import org.bukkit.inventory.BrewerInventory;
 import org.bukkit.inventory.ItemStack;
 
+
+/**
+ * This event is called after an ingredient is consumed in a brewing stand.
+ */
 public class BrewEndEvent extends BrewEvent {
     private ItemStack ingredient;
 
-    /**
-     * This event is called after an ingredient is consumed in a brewing stand.
-     * @param brewer 
-     * @param contents
-     * @param ingredient
-     */
     public BrewEndEvent(Block brewer, BrewerInventory contents, ItemStack ingredient) {
         super(brewer, contents);
         this.ingredient = ingredient;

--- a/src/main/java/org/bukkit/event/inventory/BrewEndEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/BrewEndEvent.java
@@ -26,12 +26,11 @@ public class BrewEndEvent extends BlockEvent implements Cancellable {
 
     public Potion[] getPotions() {
         Potion[] potions = new Potion[3];
-        if(contents.getContents()[0] != null)
-            potions[0] = Potion.fromItemStack(contents.getContents()[0]);
-        if(contents.getContents()[1] != null)
-            potions[1] = Potion.fromItemStack(contents.getContents()[1]);
-        if(contents.getContents()[2] != null)
-            potions[2] = Potion.fromItemStack(contents.getContents()[2]);
+        for (int i = 0; i < 3; i++) {
+            if (contents.getContents()[i] != null) {
+                potions[0] = Potion.fromItemStack(contents.getContents()[i]);
+            }
+        }
         return potions;
     }
 

--- a/src/main/java/org/bukkit/event/inventory/BrewEndEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/BrewEndEvent.java
@@ -28,7 +28,7 @@ public class BrewEndEvent extends BlockEvent implements Cancellable {
         Potion[] potions = new Potion[3];
         for (int i = 0; i < 3; i++) {
             if (contents.getContents()[i] != null) {
-                potions[0] = Potion.fromItemStack(contents.getContents()[i]);
+                potions[i] = Potion.fromItemStack(contents.getContents()[i]);
             }
         }
         return potions;

--- a/src/main/java/org/bukkit/event/inventory/BrewEndEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/BrewEndEvent.java
@@ -1,57 +1,28 @@
 package org.bukkit.event.inventory;
 
 import org.bukkit.block.Block;
-import org.bukkit.event.Cancellable;
-import org.bukkit.event.HandlerList;
-import org.bukkit.event.block.BlockEvent;
 import org.bukkit.inventory.BrewerInventory;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.potion.Potion;
 
-public class BrewEndEvent extends BlockEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-    private BrewerInventory contents;
-    private boolean cancelled;
+public class BrewEndEvent extends BrewEvent {
     private ItemStack ingredient;
 
+    /**
+     * This event is called after an ingredient is consumed in a brewing stand.
+     * @param brewer 
+     * @param contents
+     * @param ingredient
+     */
     public BrewEndEvent(Block brewer, BrewerInventory contents, ItemStack ingredient) {
-        super(brewer);
-        this.contents = contents;
+        super(brewer, contents);
         this.ingredient = ingredient;
     }
 
-    public BrewerInventory getContents() {
-        return contents;
-    }
-
-    public Potion[] getPotions() {
-        Potion[] potions = new Potion[3];
-        for (int i = 0; i < 3; i++) {
-            if (contents.getContents()[i] != null) {
-                potions[i] = Potion.fromItemStack(contents.getContents()[i]);
-            }
-        }
-        return potions;
-    }
-
+    /**
+     * Returns the ingredient used in this brewing session.
+     * @return The ingredient used as an {@link org.bukkit.inventory.ItemStack}.
+     */
     public ItemStack getIngredient() {
         return ingredient;
-    }
-
-    public boolean isCancelled() {
-        return cancelled;
-    }
-
-    public void setCancelled(boolean cancel) {
-        cancelled = cancel;
-    }
-
-    @Override
-    public HandlerList getHandlers() {
-        return handlers;
-    }
-
-    public static HandlerList getHandlerList() {
-        return handlers;
     }
 }

--- a/src/main/java/org/bukkit/event/inventory/BrewEndEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/BrewEndEvent.java
@@ -5,16 +5,19 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.block.BlockEvent;
 import org.bukkit.inventory.BrewerInventory;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.Potion;
 
-public class BrewEvent extends BlockEvent implements Cancellable {
+public class BrewEndEvent extends BlockEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private BrewerInventory contents;
     private boolean cancelled;
+    private ItemStack ingredient;
 
-    public BrewEvent(Block brewer, BrewerInventory contents) {
+    public BrewEndEvent(Block brewer, BrewerInventory contents, ItemStack ingredient) {
         super(brewer);
         this.contents = contents;
+        this.ingredient = ingredient;
     }
 
     public BrewerInventory getContents() {
@@ -31,7 +34,11 @@ public class BrewEvent extends BlockEvent implements Cancellable {
             potions[2] = Potion.fromItemStack(contents.getContents()[2]);
         return potions;
     }
-    
+
+    public ItemStack getIngredient() {
+        return ingredient;
+    }
+
     public boolean isCancelled() {
         return cancelled;
     }

--- a/src/main/java/org/bukkit/event/inventory/BrewEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/BrewEvent.java
@@ -23,15 +23,14 @@ public class BrewEvent extends BlockEvent implements Cancellable {
 
     public Potion[] getPotions() {
         Potion[] potions = new Potion[3];
-        if(contents.getContents()[0] != null)
-            potions[0] = Potion.fromItemStack(contents.getContents()[0]);
-        if(contents.getContents()[1] != null)
-            potions[1] = Potion.fromItemStack(contents.getContents()[1]);
-        if(contents.getContents()[2] != null)
-            potions[2] = Potion.fromItemStack(contents.getContents()[2]);
+        for (int i = 0; i < 3; i++) {
+            if (contents.getContents()[i] != null) {
+                potions[0] = Potion.fromItemStack(contents.getContents()[i]);
+            }
+        }
         return potions;
     }
-    
+
     public boolean isCancelled() {
         return cancelled;
     }

--- a/src/main/java/org/bukkit/event/inventory/BrewEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/BrewEvent.java
@@ -25,7 +25,7 @@ public class BrewEvent extends BlockEvent implements Cancellable {
         Potion[] potions = new Potion[3];
         for (int i = 0; i < 3; i++) {
             if (contents.getContents()[i] != null) {
-                potions[0] = Potion.fromItemStack(contents.getContents()[i]);
+                potions[i] = Potion.fromItemStack(contents.getContents()[i]);
             }
         }
         return potions;


### PR DESCRIPTION
#### The Issue:

There currently exists no way to retrieve the results from a Brewing Stand immediately as they are added to the three slots. There also doesn't exist a way to retrieve the three items as Potion objects without having to do so manually.
#### Justification for this PR:

Since no way exists to do this, plugins have to use workaround methods to retrieve the results exactly after they are complete, and thus these methods might not stay within the Bukkit API and abuse CraftBukkit and/or NMS. It is also frustrating to have to convert manually to a Potion object what should be provided by the event by default.

With BrewEndEvent, it has one extra method separate from BrewEvent, and that is the getIngredient method, which provides a cloned item of the current ingredient stack before it's amount is decreased. Using this it is possible to have ingredients with specific metadata to allow for a temporary method of adding new recipes to Bukkit. It also allows plugin creators to manipulate the potions (ie change name) or add functionality after brewing (ie shoot entities of the potions from the top of the brewer or something similar). The addition of getPotions() can aid in the comparison and manipulation of the resulting items.
#### PR Breakdown:

This PR adds another event class, BrewEndEvent, to be fired immediately after the resulting potions are brewed. It is fired prior to the removal of the ingredient to allow plugins to view a cloned version of the ItemStack of the ingredient.
#### Relevant PR(s)

BUKKIT-2441 - https://bukkit.atlassian.net/browse/BUKKIT-2441
CB-1157 - Bukkit/CraftBukkit#1157 - Corresponding CraftBukkit Pull
