### PR TITLE
[B] Added equals() and isSimilar() methods for recipes. Fixes BUKKIT-2804, Adds BUKKIT-2291

### DIFF
--- a/src/main/java/org/bukkit/inventory/FurnaceRecipe.java
+++ b/src/main/java/org/bukkit/inventory/FurnaceRecipe.java
@@ -1,5 +1,6 @@
 package org.bukkit.inventory;
 
+import org.apache.commons.lang.Validate;
 import org.bukkit.Material;
 import org.bukkit.material.MaterialData;
 
@@ -90,5 +91,56 @@ public class FurnaceRecipe implements Recipe {
      */
     public ItemStack getResult() {
         return output.clone();
+    }
+
+    /**
+     * Checks if the supplied object is a recipe that has identical ingredients and identical results.<br>
+     * This is just like {@link #isSimilar(Recipe)} except it also checks results.
+     * 
+     * @return True if object is the same recipe as this recipe.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+
+        if (obj == this) {
+            return true;
+        }
+
+        if (obj instanceof FurnaceRecipe) {
+            FurnaceRecipe r = (FurnaceRecipe) obj;
+
+            if (!this.getResult().equals(r.getResult())) {
+                return false;
+            }
+
+            return this.isSimilar(r);
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if recipes are of the same type and have the same ingredient.
+     * 
+     * @param recipe the recipe to compare against, must not be null.
+     * @return
+     */
+    public boolean isSimilar(Recipe recipe) {
+        Validate.notNull(recipe, "Recipe can not be null.");
+
+        if (recipe == this) {
+            return true;
+        }
+
+        if (recipe instanceof FurnaceRecipe) {
+            FurnaceRecipe r = (FurnaceRecipe) recipe;
+
+            return this.getInput().getTypeId() == r.getInput().getTypeId(); // TODO use equals() on items when furnace data PR is pulled
+        }
+
+        return false;
     }
 }

--- a/src/main/java/org/bukkit/inventory/FurnaceRecipe.java
+++ b/src/main/java/org/bukkit/inventory/FurnaceRecipe.java
@@ -93,12 +93,6 @@ public class FurnaceRecipe implements Recipe {
         return output.clone();
     }
 
-    /**
-     * Checks if the supplied object is a recipe that has identical ingredients and identical results.<br>
-     * This is just like {@link #isSimilar(Recipe)} except it also checks results.
-     * 
-     * @return True if object is the same recipe as this recipe.
-     */
     @Override
     public boolean equals(Object obj) {
         if (obj == null) {
@@ -122,12 +116,6 @@ public class FurnaceRecipe implements Recipe {
         return false;
     }
 
-    /**
-     * Check if recipes are of the same type and have the same ingredient.
-     * 
-     * @param recipe the recipe to compare against, must not be null.
-     * @return
-     */
     public boolean isSimilar(Recipe recipe) {
         Validate.notNull(recipe, "Recipe can not be null.");
 

--- a/src/main/java/org/bukkit/inventory/FurnaceRecipe.java
+++ b/src/main/java/org/bukkit/inventory/FurnaceRecipe.java
@@ -10,6 +10,7 @@ import org.bukkit.material.MaterialData;
 public class FurnaceRecipe implements Recipe {
     private ItemStack output;
     private ItemStack ingredient;
+    private int hash;
 
     /**
      * Create a furnace recipe to craft the specified ItemStack.
@@ -41,6 +42,7 @@ public class FurnaceRecipe implements Recipe {
     public FurnaceRecipe(ItemStack result, Material source, int data) {
         this.output = new ItemStack(result);
         this.ingredient = new ItemStack(source, 1, (short) data);
+        calculateHashCode();
     }
 
     /**
@@ -72,6 +74,7 @@ public class FurnaceRecipe implements Recipe {
      */
     public FurnaceRecipe setInput(Material input, int data) {
         this.ingredient = new ItemStack(input, 1, (short) data);
+        calculateHashCode();
         return this;
     }
 
@@ -91,6 +94,16 @@ public class FurnaceRecipe implements Recipe {
      */
     public ItemStack getResult() {
         return output.clone();
+    }
+
+    @Override
+    public int hashCode() {
+        return hash;
+    }
+
+    private void calculateHashCode() {
+        // TODO use ingredient.hashCode() when furnace data PR is pulled
+        hash = ("smelt:" + ingredient.getTypeId() + "=" + output.hashCode()).hashCode();
     }
 
     @Override

--- a/src/main/java/org/bukkit/inventory/Recipe.java
+++ b/src/main/java/org/bukkit/inventory/Recipe.java
@@ -13,18 +13,19 @@ public interface Recipe {
     ItemStack getResult();
 
     /**
-     * Checks if supplied object is a recipe of the same type with same ingredients and result.
-     * 
-     * @param obj
-     * @return True if recipes are equal, false otherwise.
+     * Checks if the supplied object is a recipe that has identical ingredient layout and identical results.
+     * <br>This is like {@link #isSimilar(Recipe)} except it checks the result.
+     *
+     * @return True if object is the same recipe as this recipe.
      */
     boolean equals(Object obj);
 
     /**
-     * CHecks if supplied recipe is similar to this one by only checking if ingredients match.
-     * 
-     * @param recipe the recipe to check against
-     * @return True if recipes are of same type and have same ingredients, false otherwise.
+     * Checks if recipes are of the same type and have matching ingredients and shape.
+     * <br>This is like {@link #equals(Object)} except it doesn't check result.
+     *
+     * @param recipe the recipe to compare against, must not be null.
+     * @return True if both recipes have the same unique ingredient mix, false otherwise.
      */
     boolean isSimilar(Recipe recipe);
 }

--- a/src/main/java/org/bukkit/inventory/Recipe.java
+++ b/src/main/java/org/bukkit/inventory/Recipe.java
@@ -11,4 +11,20 @@ public interface Recipe {
      * @return The result stack
      */
     ItemStack getResult();
+
+    /**
+     * Checks if supplied object is a recipe of the same type with same ingredients and result.
+     * 
+     * @param obj
+     * @return True if recipes are equal, false otherwise.
+     */
+    boolean equals(Object obj);
+
+    /**
+     * CHecks if supplied recipe is similar to this one by only checking if ingredients match.
+     * 
+     * @param recipe the recipe to check against
+     * @return True if recipes are of same type and have same ingredients, false otherwise.
+     */
+    boolean isSimilar(Recipe recipe);
 }

--- a/src/main/java/org/bukkit/inventory/Recipe.java
+++ b/src/main/java/org/bukkit/inventory/Recipe.java
@@ -13,6 +13,13 @@ public interface Recipe {
     ItemStack getResult();
 
     /**
+     * A pre-generated hashcode for the recipe, unique for each recipe's ingredients and result regardless of definition style.
+     *
+     * @return unique hashcode of this recipe
+     */
+    int hashCode();
+
+    /**
      * Checks if the supplied object is a recipe that has identical ingredient layout and identical results.
      * <br>This is like {@link #isSimilar(Recipe)} except it checks the result.
      *

--- a/src/main/java/org/bukkit/inventory/ShapedRecipe.java
+++ b/src/main/java/org/bukkit/inventory/ShapedRecipe.java
@@ -16,6 +16,7 @@ public class ShapedRecipe implements Recipe {
     private ItemStack output;
     private String[] rows;
     private Map<Character, ItemStack> ingredients = new HashMap<Character, ItemStack>();
+    private int hash;
 
     /**
      * Create a shaped recipe to craft the specified ItemStack. The constructor merely determines the
@@ -29,6 +30,7 @@ public class ShapedRecipe implements Recipe {
      */
     public ShapedRecipe(ItemStack result) {
         this.output = new ItemStack(result);
+        calculateHashCode();
     }
 
     /**
@@ -61,7 +63,7 @@ public class ShapedRecipe implements Recipe {
             }
         }
         this.ingredients = newIngredients;
-
+        calculateHashCode();
         return this;
     }
 
@@ -104,6 +106,7 @@ public class ShapedRecipe implements Recipe {
         }
 
         ingredients.put(key, new ItemStack(ingredient, 1, (short) raw));
+        calculateHashCode();
         return this;
     }
 
@@ -140,6 +143,29 @@ public class ShapedRecipe implements Recipe {
      */
     public ItemStack getResult() {
         return output.clone();
+    }
+
+    @Override
+    public int hashCode() {
+        return hash;
+    }
+
+    private void calculateHashCode() {
+        ItemStack[] matrix = shapeToMatrix(this.getShape(), this.ingredients);
+        StringBuilder str = new StringBuilder("shaped:");
+
+        for (ItemStack item : matrix) {
+            if (item == null) {
+                str.append('0');
+            } else {
+                str.append(item.hashCode());
+            }
+            str.append(';');
+        }
+
+        str.append('=').append(output.hashCode());
+
+        hash = str.toString().hashCode();
     }
 
     @Override

--- a/src/main/java/org/bukkit/inventory/ShapedRecipe.java
+++ b/src/main/java/org/bukkit/inventory/ShapedRecipe.java
@@ -1,5 +1,6 @@
 package org.bukkit.inventory;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -139,5 +140,94 @@ public class ShapedRecipe implements Recipe {
      */
     public ItemStack getResult() {
         return output.clone();
+    }
+
+    /**
+     * Checks if the supplied object is a recipe that has identical ingredient layout and identical results.<br>
+     * This is just like {@link #isSimilar(Recipe)} except it also checks results.
+     * 
+     * @return True if object is the same recipe as this recipe.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+
+        if (obj == this) {
+            return true;
+        }
+
+        if (obj instanceof ShapedRecipe) {
+            ShapedRecipe r = (ShapedRecipe) obj;
+
+            if (!this.getResult().equals(r.getResult())) {
+                return false;
+            }
+
+            return this.isSimilar(r);
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if recipes are of the same type and have matching ingredients and shape.<br>
+     * Shape is also checked horizontally mirrored if does not match as-is.
+     * 
+     * @param recipe the recipe to compare against, must not be null.
+     * @return True if both recipes have the same unique ingredient mix, false otherwise.
+     */
+    public boolean isSimilar(Recipe recipe) {
+        Validate.notNull(recipe, "Recipe can not be null.");
+
+        if (recipe == this) {
+            return true;
+        }
+
+        if (recipe instanceof ShapedRecipe) {
+            ShapedRecipe r = (ShapedRecipe) recipe;
+
+            // convert both shapes and ingredient maps to common ItemStack array.
+            ItemStack[] matrix1 = shapeToMatrix(this.getShape(), this.getIngredientMap());
+            ItemStack[] matrix2 = shapeToMatrix(r.getShape(), r.getIngredientMap());
+
+            // compare arrays and if they don't match run another check with one shape mirrored.
+            if (!Arrays.equals(matrix1, matrix2)) {
+                mirrorMatrix(matrix1);
+
+                return Arrays.equals(matrix1, matrix2);
+            }
+
+            return true; // ingredients match.
+        }
+
+        return false;
+    }
+
+    private static ItemStack[] shapeToMatrix(String[] shape, Map<Character, ItemStack> map) {
+        ItemStack[] matrix = new ItemStack[9];
+        int slot = 0;
+
+        for (int r = 0; r < shape.length; r++) {
+            for (char col : shape[r].toCharArray()) {
+                matrix[slot] = map.get(col);
+                slot++;
+            }
+
+            slot = ((r + 1) * 3);
+        }
+
+        return matrix;
+    }
+
+    private static void mirrorMatrix(ItemStack[] matrix) {
+        ItemStack tmp;
+
+        for (int r = 0; r < 3; r++) {
+            tmp = matrix[(r * 3)];
+            matrix[(r * 3)] = matrix[(r * 3) + 2];
+            matrix[(r * 3) + 2] = tmp;
+        }
     }
 }

--- a/src/main/java/org/bukkit/inventory/ShapedRecipe.java
+++ b/src/main/java/org/bukkit/inventory/ShapedRecipe.java
@@ -142,12 +142,6 @@ public class ShapedRecipe implements Recipe {
         return output.clone();
     }
 
-    /**
-     * Checks if the supplied object is a recipe that has identical ingredient layout and identical results.<br>
-     * This is just like {@link #isSimilar(Recipe)} except it also checks results.
-     * 
-     * @return True if object is the same recipe as this recipe.
-     */
     @Override
     public boolean equals(Object obj) {
         if (obj == null) {
@@ -172,11 +166,9 @@ public class ShapedRecipe implements Recipe {
     }
 
     /**
-     * Checks if recipes are of the same type and have matching ingredients and shape.<br>
-     * Shape is also checked horizontally mirrored if does not match as-is.
-     * 
-     * @param recipe the recipe to compare against, must not be null.
-     * @return True if both recipes have the same unique ingredient mix, false otherwise.
+     * {@inheritDoc}
+     * <br>
+     * <br>Shape is also checked horizontally mirrored if does not match as-is.
      */
     public boolean isSimilar(Recipe recipe) {
         Validate.notNull(recipe, "Recipe can not be null.");

--- a/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
+++ b/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
@@ -244,12 +244,6 @@ public class ShapelessRecipe implements Recipe {
         return false;
     }
 
-    /**
-     * Checks if recipes are of the same type and have the same ingredients.
-     * 
-     * @param recipe the recipe to compare against, must not be null.
-     * @return True if both recipes have the same unique ingredient mix, false otherwise.
-     */
     public boolean isSimilar(Recipe recipe) {
         Validate.notNull(recipe, "Recipe can not be null.");
 

--- a/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
+++ b/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
@@ -16,6 +16,7 @@ import org.bukkit.material.MaterialData;
 public class ShapelessRecipe implements Recipe {
     private ItemStack output;
     private List<ItemStack> ingredients = new ArrayList<ItemStack>();
+    private int hash;
 
     /**
      * Create a shapeless recipe to craft the specified ItemStack. The constructor merely determines the
@@ -31,6 +32,7 @@ public class ShapelessRecipe implements Recipe {
      */
     public ShapelessRecipe(ItemStack result) {
         this.output = new ItemStack(result);
+        calculateHashCode();
     }
 
     /**
@@ -105,6 +107,7 @@ public class ShapelessRecipe implements Recipe {
         while (count-- > 0) {
             ingredients.add(new ItemStack(ingredient, 1, (short) rawdata));
         }
+        calculateHashCode();
         return this;
     }
 
@@ -190,6 +193,7 @@ public class ShapelessRecipe implements Recipe {
                 count--;
             }
         }
+        calculateHashCode();
         return this;
     }
 
@@ -221,6 +225,23 @@ public class ShapelessRecipe implements Recipe {
      * 
      * @return True if object is the same recipe as this recipe.
      */
+    @Override
+    public int hashCode() {
+        return hash;
+    }
+
+    private void calculateHashCode() {
+        StringBuilder str = new StringBuilder("shapeless:");
+
+        for (ItemStack item : ingredients) {
+            str.append(item.hashCode()).append(';');
+        }
+
+        str.append('=').append(output.hashCode());
+
+        hash = str.toString().hashCode();
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == null) {

--- a/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
+++ b/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
@@ -214,4 +214,66 @@ public class ShapelessRecipe implements Recipe {
         }
         return result;
     }
+
+    /**
+     * Checks if the supplied object is a recipe that has identical ingredients and identical results.<br>
+     * This is just like {@link #isSimilar(Recipe)} except it also checks results.
+     * 
+     * @return True if object is the same recipe as this recipe.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+
+        if (obj == this) {
+            return true;
+        }
+
+        if (obj instanceof ShapelessRecipe) {
+            ShapelessRecipe r = (ShapelessRecipe) obj;
+
+            if (!this.getResult().equals(r.getResult())) {
+                return false;
+            }
+
+            return this.isSimilar(r);
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if recipes are of the same type and have the same ingredients.
+     * 
+     * @param recipe the recipe to compare against, must not be null.
+     * @return True if both recipes have the same unique ingredient mix, false otherwise.
+     */
+    public boolean isSimilar(Recipe recipe) {
+        Validate.notNull(recipe, "Recipe can not be null.");
+
+        if (recipe == this) {
+            return true;
+        }
+
+        if (recipe instanceof ShapelessRecipe) {
+            ShapelessRecipe r = (ShapelessRecipe) recipe;
+            List<ItemStack> find = r.getIngredientList(); // get the cloned ingredient list
+
+            if (find.size() != this.ingredients.size()) {
+                return false; // if they don't have the same amount of ingredients they're not equal.
+            }
+
+            for (ItemStack item : this.ingredients) {
+                if (!find.remove(item)) {
+                    return false; // if ingredient wasn't removed (not found) then they're not equal.
+                }
+            }
+
+            return find.isEmpty(); // if there are any ingredients not removed then they're not equal.
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
**The Issue**

There is no way of comparing recipes, expecially against recipes from events which are new objects with diferent content that make the same recipe.

**Justification for this PR and breakdown**

This PR provides equals() and isSimilar() methods for Recipe objects which will compare ingredients properly regardless of the style used in creating the recipe.

More information in the code as comments and javadoc.

**Testing Results and Materials**

A sample plugin that will add some custom recipes and use the created methods.
http://s000.tinyupload.com/index.php?file_id=00522648373141133929

**Tickets**
[Ingredients for recipes are different (after creation != at an event) / BUKKIT-2804](https://bukkit.atlassian.net/browse/BUKKIT-2804)
[Implemented matches method for all Recipes! / BUKKIT-2291](https://bukkit.atlassian.net/browse/BUKKIT-2291)
