### PR TITLE
[B+C] Add the method getFireBlock to BlockBurnEvent. Fixes BUKKIT-4231

### DIFF
--- a/src/main/java/org/bukkit/event/block/BlockBurnEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockBurnEvent.java
@@ -38,7 +38,7 @@ public class BlockBurnEvent extends BlockEvent implements Cancellable {
     }
 
     /**
-     * Get the fire block at the source of the event
+     * Gets the fire block that destroyed this one.
      *
      * @return The fire block at the source of the event
      */

--- a/src/main/java/org/bukkit/event/block/BlockBurnEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockBurnEvent.java
@@ -12,9 +12,11 @@ import org.bukkit.event.HandlerList;
 public class BlockBurnEvent extends BlockEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancelled;
+    private final Block blockFire;
 
-    public BlockBurnEvent(final Block block) {
+    public BlockBurnEvent(final Block block, final Block blockFire) {
         super(block);
+        this.blockFire = blockFire;
         this.cancelled = false;
     }
 
@@ -33,5 +35,14 @@ public class BlockBurnEvent extends BlockEvent implements Cancellable {
 
     public static HandlerList getHandlerList() {
         return handlers;
+    }
+
+    /**
+     * Get the fire block at the source of the event
+     *
+     * @return The fire block at the source of the event
+     */
+    public Block getFireBlock() {
+        return blockFire;
     }
 }


### PR DESCRIPTION
Add a method to get the source (fire) block from the BlockBurnEvent.

Allows for more control for the fire (count the block is has burnt, for example, or put it out).

PR Breakdown:
Add a Block to the BlockBurnEvent, to store the fire block, and change the constructor to also get the fire block.

CB-1159 - https://github.com/Bukkit/CraftBukkit/pull/1159 - Implementation

BUKKIT-4231 - https://bukkit.atlassian.net/browse/BUKKIT-4231
