### PR TITLE
[B+C] Add a method of setting a LivingEntity's goal target. Adds BUKKIT-4256

### DIFF
--- a/src/main/java/org/bukkit/entity/LivingEntity.java
+++ b/src/main/java/org/bukkit/entity/LivingEntity.java
@@ -352,4 +352,24 @@ public interface LivingEntity extends Entity, Damageable {
      * @return if the custom name is displayed
      */
     public boolean isCustomNameVisible();
+    
+    /**
+     * Sets the goal target of the mob.
+     * <p>
+     * The goal target is used for some mobs as a way to target their enemies;
+     * for example, setting a wolf's goal target will cause it to become angry
+     * and attack the targeted entity.
+     * <p>
+     * This value has no effect on many entities.
+     * 
+     * @param entity the living entity to target
+     */
+    public void setGoalTarget(LivingEntity entity);
+    
+    /**
+     * Gets the goal target of the mob.
+     * 
+     * @return goal target of the mob or null
+     */
+    public LivingEntity getGoalTarget();
 }


### PR DESCRIPTION
**The Issue:**
Some living entities, such as wolves, use a different target, the "goal target", to determine what to attack.

**Justification for this PR:**
There is currently no method to set an entity's goal target. Using wolves as an example, a wolf will not attack a player when angry, even when setTarget is used, because EntityWolf checks for the wolf's "goal target".

**Testing results and materials:**
Spawns a wolf and sets its goal target to a player whenever a player joins. Plugin source is included inside the jar.
CraftBukkit - https://dl.dropboxusercontent.com/u/20614340/bukkit/goaltarget/craftbukkit-GoalTarget.jar
Plugin - https://dl.dropboxusercontent.com/u/20614340/bukkit/goaltarget/GoalTargetTest.jar

**Relevant PR:**
CB-1162 - Bukkit/CraftBukkit#1162

**JIRA Ticket:**
BUKKIT-4256: https://bukkit.atlassian.net/browse/BUKKIT-4256
