### PR TITLE
[B] Remove unnecessary call to setAccessible. Fixes BUKKIT-4287

### DIFF
--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -539,7 +539,6 @@ public final class SimplePluginManager implements PluginManager {
     private HandlerList getEventListeners(Class<? extends Event> type) {
         try {
             Method method = getRegistrationClass(type).getDeclaredMethod("getHandlerList");
-            method.setAccessible(true);
             return (HandlerList) method.invoke(null);
         } catch (Exception e) {
             throw new IllegalPluginAccessException(e.toString());

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -386,7 +386,6 @@ public class JavaPluginLoader implements PluginLoader {
                 continue;
             }
             final Class<? extends Event> eventClass = checkClass.asSubclass(Event.class);
-            method.setAccessible(true);
             Set<RegisteredListener> eventSet = ret.get(eventClass);
             if (eventSet == null) {
                 eventSet = new HashSet<RegisteredListener>();


### PR DESCRIPTION
Method reflected through the plugins manager and loader are already public and accessible. Calling setAccessible is unecessary and require permission java.lang.reflect.ReflectPermission "suppressAccessChecks" even if already accessible. This permission defeat the use of a java security manager which ones may want to use.
