### PR TITLE
[B] Reduce thread synchronization in MetadataStoreBase Fixes BUKKIT-4294.

### DIFF
--- a/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
+++ b/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
@@ -4,9 +4,10 @@ import org.apache.commons.lang.Validate;
 import org.bukkit.plugin.Plugin;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 public abstract class MetadataStoreBase<T> {
-    private Map<String, Map<Plugin, MetadataValue>> metadataMap = new HashMap<String, Map<Plugin, MetadataValue>>();
+    private Map<String, Map<Plugin, MetadataValue>> metadataMap = new ConcurrentHashMap<String, Map<Plugin, MetadataValue>>();
 
     /**
      * Adds a metadata value to an object. Each metadata value is owned by a
@@ -14,14 +15,6 @@ public abstract class MetadataStoreBase<T> {
      * to an object, that value will be replaced with the value of {@code
      * newMetadataValue}. Multiple plugins can set independent values for the
      * same {@code metadataKey} without conflict.
-     * <p>
-     * Implementation note: I considered using a {@link
-     * java.util.concurrent.locks.ReadWriteLock} for controlling access to
-     * {@code metadataMap}, but decided that the added overhead wasn't worth
-     * the finer grained access control.
-     * <p>
-     * Bukkit is almost entirely single threaded so locking overhead shouldn't
-     * pose a problem.
      *
      * @param subject The object receiving the metadata.
      * @param metadataKey A unique key to identify this metadata.
@@ -30,7 +23,7 @@ public abstract class MetadataStoreBase<T> {
      * @throws IllegalArgumentException If value is null, or the owning plugin
      *     is null
      */
-    public synchronized void setMetadata(T subject, String metadataKey, MetadataValue newMetadataValue) {
+    public void setMetadata(T subject, String metadataKey, MetadataValue newMetadataValue) {
         Validate.notNull(newMetadataValue, "Value cannot be null");
         Plugin owningPlugin = newMetadataValue.getOwningPlugin();
         Validate.notNull(owningPlugin, "Plugin cannot be null");
@@ -40,7 +33,9 @@ public abstract class MetadataStoreBase<T> {
             entry = new WeakHashMap<Plugin, MetadataValue>(1);
             metadataMap.put(key, entry);
         }
-        entry.put(owningPlugin, newMetadataValue);
+        synchronized (entry) {
+            entry.put(owningPlugin, newMetadataValue);
+        }
     }
 
     /**
@@ -53,10 +48,11 @@ public abstract class MetadataStoreBase<T> {
      *     requested value.
      * @see MetadataStore#getMetadata(Object, String)
      */
-    public synchronized List<MetadataValue> getMetadata(T subject, String metadataKey) {
+    public List<MetadataValue> getMetadata(T subject, String metadataKey) {
         String key = disambiguate(subject, metadataKey);
-        if (metadataMap.containsKey(key)) {
-            Collection<MetadataValue> values = metadataMap.get(key).values();
+        Map<Plugin, MetadataValue> entry = metadataMap.get(key);
+        if (entry != null) {
+            Collection<MetadataValue> values = entry.values();
             return Collections.unmodifiableList(new ArrayList<MetadataValue>(values));
         } else {
             return Collections.emptyList();
@@ -71,7 +67,7 @@ public abstract class MetadataStoreBase<T> {
      * @param metadataKey the unique metadata key being queried.
      * @return the existence of the metadataKey within subject.
      */
-    public synchronized boolean hasMetadata(T subject, String metadataKey) {
+    public boolean hasMetadata(T subject, String metadataKey) {
         String key = disambiguate(subject, metadataKey);
         return metadataMap.containsKey(key);
     }
@@ -87,17 +83,18 @@ public abstract class MetadataStoreBase<T> {
      *     org.bukkit.plugin.Plugin)
      * @throws IllegalArgumentException If plugin is null
      */
-    public synchronized void removeMetadata(T subject, String metadataKey, Plugin owningPlugin) {
+    public void removeMetadata(T subject, String metadataKey, Plugin owningPlugin) {
         Validate.notNull(owningPlugin, "Plugin cannot be null");
         String key = disambiguate(subject, metadataKey);
         Map<Plugin, MetadataValue> entry = metadataMap.get(key);
         if (entry == null) {
             return;
         }
-
-        entry.remove(owningPlugin);
-        if (entry.isEmpty()) {
-            metadataMap.remove(key);
+        synchronized (entry) {
+            entry.remove(owningPlugin);
+            if (entry.isEmpty()) {
+                metadataMap.remove(key);
+            }
         }
     }
 
@@ -110,11 +107,12 @@ public abstract class MetadataStoreBase<T> {
      * @see MetadataStore#invalidateAll(org.bukkit.plugin.Plugin)
      * @throws IllegalArgumentException If plugin is null
      */
-    public synchronized void invalidateAll(Plugin owningPlugin) {
+    public void invalidateAll(Plugin owningPlugin) {
         Validate.notNull(owningPlugin, "Plugin cannot be null");
         for (Map<Plugin, MetadataValue> values : metadataMap.values()) {
-            if (values.containsKey(owningPlugin)) {
-                values.get(owningPlugin).invalidate();
+            MetadataValue value = values.get(owningPlugin);
+            if (value != null) {
+                value.invalidate();
             }
         }
     }


### PR DESCRIPTION
**The Issue:**
MetadataStoreBase [as is currently written](https://github.com/Bukkit/Bukkit/blob/410bd305b874474c7e9c6f005c5cab53cfad9b58/src/main/java/org/bukkit/metadata/MetadataStoreBase.java) has every method synchronized. This means that even for read-access (and the metadata is intentionally quite a read-heavy API) that a lock must be acquired every single time, across the entire store.

This goes without saying is a rather silly performance hurt (even though it does create the predictability)

**Justification for this PR:**
Bukkit is mostly single-threaded, but even still, certain things should "just work" if things are accessed from other threads and do what one would expect. At the same time, it really shouldn't incur global locking for something that happens rarely (it should just be safe from concurrent modification smashing of values mostly)

Metadata is a read-heavy API, and as such optimizing reads if possible is definitely advantageous in terms of server ticks. Imagine something checking metadata on a sheep every time the sheep moved, which is basically every tick. Do we really want to acquire a global lock on the entire metadata store just for checking if hasMetadata on something?

**PR Breakdown:**
The primary change here is to use a ConcurrentHashMap as the top-level map instead of a normal HashMap. Furthermore, instead of synchronizing the whole metadata store, we only synchronize the writes on the second-level hashmap. 

Synchronizing writes on the second-level hashmap means calls to `setMetadata`/`removeMetadata` lock on a much more fine-grained object (in other words, the only time two threads would have contention is if they're both setting the _exact_ same key). This allows taking advantage of atomic primitives while still being thread-safe.

Furthermore, this means all calls to `getMetadata` and `hasMetadata` need use **no locking at all**

**Testing Results and Materials:**

Because of how multi-threading works, there's no real way to write new unit tests for this in a predictable manner, because you can't really enforce ordering of statements such that they exactly line up in some way or another. All I can say is, the code is very simple by intention, there's no magic sauce happening, and all the existing tests pass for ensuring the API performs as expected.

**Relevant PR(s):**
n/a

**JIRA Ticket:**
BUKKIT-4294 - https://bukkit.atlassian.net/browse/BUKKIT-4294
