### PR TITLE
[B] Lowers needed jvm permission without breaking plugins compatibility - Fixes BUKKIT-4287

### DIFF
--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -31,6 +31,7 @@ import org.bukkit.permissions.Permissible;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
 import org.bukkit.util.FileUtil;
+import org.bukkit.util.Security;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -539,7 +540,7 @@ public final class SimplePluginManager implements PluginManager {
     private HandlerList getEventListeners(Class<? extends Event> type) {
         try {
             Method method = getRegistrationClass(type).getDeclaredMethod("getHandlerList");
-            method.setAccessible(true);
+            Security.setAccessible(method, server);
             return (HandlerList) method.invoke(null);
         } catch (Exception e) {
             throw new IllegalPluginAccessException(e.toString());

--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -42,6 +42,7 @@ import org.bukkit.plugin.PluginLoader;
 import org.bukkit.plugin.RegisteredListener;
 import org.bukkit.plugin.TimedRegisteredListener;
 import org.bukkit.plugin.UnknownDependencyException;
+import org.bukkit.util.Security;
 import org.yaml.snakeyaml.error.YAMLException;
 
 import com.google.common.collect.ImmutableList;
@@ -386,7 +387,7 @@ public class JavaPluginLoader implements PluginLoader {
                 continue;
             }
             final Class<? extends Event> eventClass = checkClass.asSubclass(Event.class);
-            method.setAccessible(true);
+            Security.setAccessible(method, server);
             Set<RegisteredListener> eventSet = ret.get(eventClass);
             if (eventSet == null) {
                 eventSet = new HashSet<RegisteredListener>();

--- a/src/main/java/org/bukkit/util/Security.java
+++ b/src/main/java/org/bukkit/util/Security.java
@@ -1,0 +1,48 @@
+package org.bukkit.util;
+
+import java.util.logging.Level;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import org.bukkit.Server;
+
+import sun.reflect.Reflection;
+
+/**
+ * Handle jvm security concerns
+ */
+public class Security {
+
+    /**
+     * Attempts to make a method invocation possible with the least privilege
+     *
+     * @param method method to be invoked
+     */
+    public static void setAccessible(Method method, Server server) {
+        // if security manager is not set, no need to check
+        // System.getSecurityManager is the fastest way to check and
+        // should not have any impact on performance
+        SecurityManager sm = System.getSecurityManager();
+        if (sm == null) {
+            method.setAccessible(true);
+        } else {
+            final Method fmethod = method;
+            // Plugins registered methods should be accessible by World meaning public method declared in public class
+            if(!Modifier.isPublic(fmethod.getModifiers()) && !Modifier.isPublic(fmethod.getDeclaringClass().getModifiers()))
+            {
+                server.getLogger().log(Level.FINE, "Attempt to invoke a non public method \"" + fmethod.toGenericString() + "\" in " + fmethod.getDeclaringClass());
+                // methods and declaring classes should be public
+                // if not, remove check access in an elevated block code so that
+                // "suppressAccessChecks" ReflectPermission is only needed for this class
+                AccessController.doPrivileged(new PrivilegedAction() {
+                    public Object run() {
+                        fmethod.setAccessible(true);
+                        return null;
+                    }
+                });
+            }
+        }
+    }
+}


### PR DESCRIPTION
##### The Issue

When running with a security manager, require a global suppressAccessCheck ReflectionPermission because of setAccessible calls. Plugins could use this to replace and defeat the security manager.
##### PR Breakdown

Replace java reflection API setAccessible call by a static method that will handle this security concern.
This method tests for the presence of a security manager. If not present, no change, setAccessible is called as it was previously to avoid breaking plugins compatibility. don't check for accessibility as it could add a unnecessary performance overhead.

If present but the targeted method is public and is owned by a public class, don't do anything, setAccessible is not necessary. I hope a vast majority of plugins will go that way.

If present but the targeted method is not public, then call setAccessible in a privileged action block to limit the need to grant ReflectionPermission "suppressAccessCheck" to the jar only.

A debug trace (FINE Level) is outputted whenever a security manager is set and setAccessible is called on a non public method. Hoping this will convince plugins developer to expose public methods.
#### JIRA Ticket

BUKKIT-4287 - https://bukkit.atlassian.net/browse/BUKKIT-4287
#### Tests

I select plugins that registers public, private, nested listeners.
- Running without security manager : no impact.
- Running with a security manager but suppressAccessCheck not granted : plugins with public method works as expected while others don't (exception is thrown as expected). Auto updater doesn't work cause the same permission is needed in google-json library (https://code.google.com/p/google-gson/issues/detail?id=344).
- Running with a security manager with suppressAccessCheck granted to craftbukkit.jar, plugins and auto-updater work as expected.
