### PR TITLE
[B+C] Add broadcast and broadcastMessage to World. Adds BUKKIT-3638

### DIFF
--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -1,7 +1,9 @@
 package org.bukkit;
 
 import java.io.File;
+
 import org.bukkit.generator.ChunkGenerator;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -1062,6 +1064,25 @@ public interface World extends PluginMessageRecipient, Metadatable {
      * @return True if rule exists
      */
     public boolean isGameRule(String rule);
+
+    /**
+     * Broadcasts the specified message to every user in this world with the given permission
+     *
+     * @param message Message to broadcast
+     * @param permission Permission the users must have to receive the broadcast
+     * @return Amount of users who received the message
+     */
+    public int broadcast(String message, String permission);
+
+    /**
+     * Broadcast a message to all players in this world.
+     * <p>
+     * This is the same as calling {@link #broadcast(java.lang.String, java.lang.String)} to {@link #BROADCAST_CHANNEL_USERS}
+     *
+     * @param message the message
+     * @return the number of players
+     */
+    public int broadcastMessage(String message);
 
     /**
      * Represents various map environment types that a world may be


### PR DESCRIPTION
**The Issue:**
There is no way (using the Bukkit API alone) that I can send everyone in a specified world a message.

**Justification for this PR:**
Mainly this PR contains a simple time saver for all developers out there. I know that doesn't sound like a good reason but it is just a lot nicer than using Iteration all the time.

**PR Breakdown**:
This PR adds two methods to the `World` class: `broadcast` and `broadcastMessage`. These methods are then implemented in the `CraftWorld` class.

**Testing Results and Materials:**
I made a plugin that uses these methods that you can download [here](https://www.dropbox.com/s/mgwgxzw6r44b4xv/WBT.jar?dl=1). It only has one command:

```
/test [worldName] [permission]
```

**Relevant PR(s):**
B-881 - https://github.com/Bukkit/Bukkit/pull/881
CB-1170 - https://github.com/Bukkit/CraftBukkit/pull/1170

**JIRA Ticket:**
BUKKIT-3638 - https://bukkit.atlassian.net/browse/BUKKIT-3638
