### PR TITLE
[B + C] Fixed HumanEntity#openInventory not being up to date, Fixes BUKKIT-3690

### DIFF
--- a/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -59,8 +59,6 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, Permissible, Inv
      *
      * @param inventory The inventory to open
      * @return The newly opened inventory view
-     * @throws IllegalArgumentException if the specified inventory cannot be
-     * opened via this method.
      */
     public InventoryView openInventory(Inventory inventory);
 
@@ -89,11 +87,11 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, Permissible, Inv
      * the bottom.
      *
      * @param location The location to attach it to. If null, the player's
-     *            location is used.
+     *     location is used.
      * @param force If false, and there is no anvil at the location, no
-     *            inventory will be opened and null will be returned.
+     *     inventory will be opened and null will be returned.
      * @return The newly opened inventory view, or null if it could not be
-     *         opened.
+     *     opened.
      */
     public InventoryView openAnvil(Location location, boolean force); 
 

--- a/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -59,6 +59,8 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, Permissible, Inv
      *
      * @param inventory The inventory to open
      * @return The newly opened inventory view
+     * @throws IllegalArgumentException if the specified inventory cannot be
+     * opened via this method.
      */
     public InventoryView openInventory(Inventory inventory);
 
@@ -81,6 +83,19 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, Permissible, Inv
      * @return The newly opened inventory view, or null if it could not be opened.
      */
     public InventoryView openEnchanting(Location location, boolean force);
+
+    /**
+     * Opens an empty anvil inventory window with the player's inventory on
+     * the bottom.
+     *
+     * @param location The location to attach it to. If null, the player's
+     *            location is used.
+     * @param force If false, and there is no anvil at the location, no
+     *            inventory will be opened and null will be returned.
+     * @return The newly opened inventory view, or null if it could not be
+     *         opened.
+     */
+    public InventoryView openAnvil(Location location, boolean force); 
 
     /**
      * Opens an inventory window to the specified inventory view.

--- a/src/main/java/org/bukkit/event/inventory/InventoryType.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryType.java
@@ -64,6 +64,11 @@ public enum InventoryType {
      * A hopper inventory, with 5 slots of type CONTAINER.
      */
     HOPPER(5, "Item Hopper"),
+    /**
+     * A horse inventory, with either two ARMOUR slots or one AMOUR slot and
+     * 15 CONTAINER slots.
+     */
+    HORSE(2, "Horse"),
     ;
 
     private final int size;


### PR DESCRIPTION
#### Description:

CraftEntityHuman#openInventory(Inventory) is missing the code to deal with Anvil/Beacon/Trade/Horse inventory types and bukkit is missing a Horse inventory type, and if a unknown type is passed to it the method will fail silently.
#### Justification and breakdown

Any method should not fail silently if an error has occurred, and the new inventory types should be able to be opened via these methods. This PR adds the new inventory types to the switch statement to handle opening of them correctly, it also adds a default case at the end so any unknown inventory types will though a IllegalArgumentException. Finally this PR adds the new inventory types to the CraftContainer so that it knows how to handle opening them correctly.
#### Testing Results and Materials:
##### TestPlugin

(Plugin allows for opening of inventories by using '/&lt;inventory type&gt;')
source - https://github.com/thefishlive/Bukkit-test/tree/inventory
binary  - https://www.dropbox.com/s/p7hibwjqb2wqo4r/bukkit-test-0.1-SNAPSHOT.jar
#### Relevant PR(s):

CB-1175 - https://github.com/Bukkit/CraftBukkit/pull/1175
Ticket: BUKKIT-3690- https://bukkit.atlassian.net/browse/BUKKIT-3690
