### PR TITLE
Add new API method "getAPIs()"

### DIFF
--- a/src/main/java/org/bukkit/Bukkit.java
+++ b/src/main/java/org/bukkit/Bukkit.java
@@ -638,6 +638,13 @@ public final class Bukkit {
     public static WarningState getWarningState() {
         return server.getWarningState();
     }
+    
+    /**
+     * @see Server#getAPIs()
+     */
+    public static String[] getAPIs() {
+    	return server.getAPIs();
+    }
 
     /**
      * @see Server#getItemFactory()

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -682,6 +682,13 @@ public interface Server extends PluginMessageRecipient {
      * @return The configured WarningState
      */
     public WarningState getWarningState();
+    
+    /**
+     * Gets the names of the APIs this server implements
+     * 
+     * @return the APIs this server has implemented
+     */
+    public String[] getAPIs();
 
     /**
      * Gets the instance of the item factory (for {@link ItemMeta}).


### PR DESCRIPTION
(The CraftBukkit Pull Request for this on is [Issue #1178](https://github.com/Bukkit/CraftBukkit/pull/1178))

As per http://forums.bukkit.org/threads/bukkit-getserver-getname-and-a-brainstorm.153724, I'm pushing a change to have a way for downstream server implementations to pass what APIs the server implements without having the Bukkit API fragment between different implementations.

If a plugin wants to know if the Server implements the Forge API, for example, the plugin would call Bukkit.getServer().getAPIs() and parse the String[] array for "Forge". Quite simple, no?

This PR will not break the current API in any way. All past plugins will work correctly.
