### PR TITLE
Add Vine to BlockSpeadEvent JavaDoc example list.

### DIFF
--- a/src/main/java/org/bukkit/event/block/BlockSpreadEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockSpreadEvent.java
@@ -12,6 +12,7 @@ import org.bukkit.event.HandlerList;
  * <ul>
  * <li>Mushrooms spreading.</li>
  * <li>Fire spreading.</li>
+ * <li>Vine spreading.</li>
  * </ul>
  * <p>
  * If a Block Spread event is cancelled, the block will not spread.


### PR DESCRIPTION
This is a minor issue.

Vine, being a plant, might mislead a developer to use BlockGrowEvent instead of BlockSpreadEvent. To prevent this confusion it should be added to BlockSpreadEvent JavaDoc examples. 
