### PR TITLE
[B] Update /say to vanilla behavior. Fixes BUKKIT-4224

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/SayCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/SayCommand.java
@@ -1,15 +1,13 @@
 package org.bukkit.command.defaults;
 
-import java.util.List;
-
+import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
-import org.bukkit.command.RemoteConsoleCommandSender;
 
-import com.google.common.collect.ImmutableList;
+import java.util.List;
 
 public class SayCommand extends VanillaCommand {
     public SayCommand() {
@@ -28,7 +26,7 @@ public class SayCommand extends VanillaCommand {
         }
 
         StringBuilder message = new StringBuilder();
-        message.append("[");
+        message.append(ChatColor.DARK_PURPLE).append("[");
         if (sender instanceof ConsoleCommandSender) {
             message.append("Server");
         } else {
@@ -39,8 +37,7 @@ public class SayCommand extends VanillaCommand {
         if (args.length > 0) {
             message.append(args[0]);
             for (int i = 1; i < args.length; i++) {
-                message.append(" ");
-                message.append(args[i]);
+                message.append(" ").append(args[i]);
             }
         }
 

--- a/src/main/java/org/bukkit/command/defaults/SayCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/SayCommand.java
@@ -5,11 +5,9 @@ import java.util.List;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
-import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.command.RemoteConsoleCommandSender;
-import org.bukkit.entity.Player;
 
 import com.google.common.collect.ImmutableList;
 
@@ -31,14 +29,12 @@ public class SayCommand extends VanillaCommand {
 
         StringBuilder message = new StringBuilder();
         message.append("[");
-        if (sender instanceof Player || sender instanceof BlockCommandSender) {
-            message.append(sender.getName());
-        } else if (sender instanceof RemoteConsoleCommandSender) {
+        if (sender instanceof RemoteConsoleCommandSender) {
             message.append("Rcon");
         } else if (sender instanceof ConsoleCommandSender) {
             message.append("Server");
         } else {
-            message.append("Unknown");
+            message.append(sender.getName());
         }
         message.append("]");
 

--- a/src/main/java/org/bukkit/command/defaults/SayCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/SayCommand.java
@@ -8,6 +8,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.command.RemoteConsoleCommandSender;
 import org.bukkit.entity.Player;
 
 import com.google.common.collect.ImmutableList;
@@ -32,8 +33,12 @@ public class SayCommand extends VanillaCommand {
         message.append("[");
         if (sender instanceof Player || sender instanceof BlockCommandSender) {
             message.append(sender.getName());
+        } else if (sender instanceof RemoteConsoleCommandSender) {
+            message.append("Rcon");
         } else if (sender instanceof ConsoleCommandSender) {
             message.append("Server");
+        } else {
+            message.append("Unknown");
         }
         message.append("]");
 

--- a/src/main/java/org/bukkit/command/defaults/SayCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/SayCommand.java
@@ -1,13 +1,14 @@
 package org.bukkit.command.defaults;
 
-import com.google.common.collect.ImmutableList;
+import java.util.List;
+
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 
-import java.util.List;
+import com.google.common.collect.ImmutableList;
 
 public class SayCommand extends VanillaCommand {
     public SayCommand() {
@@ -32,7 +33,7 @@ public class SayCommand extends VanillaCommand {
         } else {
             message.append(sender.getName());
         }
-        message.append("]");
+        message.append("] ");
 
         if (args.length > 0) {
             message.append(args[0]);

--- a/src/main/java/org/bukkit/command/defaults/SayCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/SayCommand.java
@@ -5,7 +5,9 @@ import java.util.List;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 
 import com.google.common.collect.ImmutableList;
@@ -14,7 +16,7 @@ public class SayCommand extends VanillaCommand {
     public SayCommand() {
         super("say");
         this.description = "Broadcasts the given message as the console";
-        this.usageMessage = "/say <message>";
+        this.usageMessage = "/say <message ...>";
         this.setPermission("bukkit.command.say");
     }
 
@@ -27,6 +29,16 @@ public class SayCommand extends VanillaCommand {
         }
 
         StringBuilder message = new StringBuilder();
+        message.append("[");
+        if (sender instanceof Player) {
+            message.append(sender.getName());
+        } else if (sender instanceof BlockCommandSender) {
+            message.append("@");
+        } else if (sender instanceof ConsoleCommandSender) {
+            message.append("Server");
+        }
+        message.append("]");
+
         if (args.length > 0) {
             message.append(args[0]);
             for (int i = 1; i < args.length; i++) {
@@ -35,12 +47,7 @@ public class SayCommand extends VanillaCommand {
             }
         }
 
-        if (sender instanceof Player) {
-            Bukkit.getLogger().info("[" + sender.getName() + "] " + message);
-        }
-
-        Bukkit.broadcastMessage(ChatColor.LIGHT_PURPLE + "[Server] " + message);
-
+        Bukkit.broadcastMessage(message.toString());
         return true;
     }
 

--- a/src/main/java/org/bukkit/command/defaults/SayCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/SayCommand.java
@@ -7,6 +7,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.entity.Player;
 
 import com.google.common.collect.ImmutableList;
 
@@ -27,9 +28,11 @@ public class SayCommand extends VanillaCommand {
         }
 
         StringBuilder message = new StringBuilder();
-        message.append(ChatColor.DARK_PURPLE).append("[");
+        message.append(ChatColor.LIGHT_PURPLE).append("[");
         if (sender instanceof ConsoleCommandSender) {
             message.append("Server");
+        } else if (sender instanceof Player) {
+            message.append(((Player) sender).getDisplayName());
         } else {
             message.append(sender.getName());
         }

--- a/src/main/java/org/bukkit/command/defaults/SayCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/SayCommand.java
@@ -29,9 +29,7 @@ public class SayCommand extends VanillaCommand {
 
         StringBuilder message = new StringBuilder();
         message.append("[");
-        if (sender instanceof RemoteConsoleCommandSender) {
-            message.append("Rcon");
-        } else if (sender instanceof ConsoleCommandSender) {
+        if (sender instanceof ConsoleCommandSender) {
             message.append("Server");
         } else {
             message.append(sender.getName());

--- a/src/main/java/org/bukkit/command/defaults/SayCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/SayCommand.java
@@ -30,10 +30,8 @@ public class SayCommand extends VanillaCommand {
 
         StringBuilder message = new StringBuilder();
         message.append("[");
-        if (sender instanceof Player) {
+        if (sender instanceof Player || sender instanceof BlockCommandSender) {
             message.append(sender.getName());
-        } else if (sender instanceof BlockCommandSender) {
-            message.append("@");
         } else if (sender instanceof ConsoleCommandSender) {
             message.append("Server");
         }


### PR DESCRIPTION
**The issue**
Bukkit's implementation of the `/say` command doesn't match its vanilla counterpart. The following screenshots show the differences when running the command in the following ways:
1. From in-game
2. From the console
3. From a command block (un-named)
4. From a command block (named 'Test')
5. Remotely, using a [RCON utility](http://www.minecraftforum.net/topic/842376-minecraft-server-rconquery-utility/)
6. In-game without any arguments

Vanilla:
![Vanilla](http://puu.sh/3wiiT.png)

Bukkit:
![Bukkit](http://puu.sh/3wiea.png)

**PR Rundown**
This PR makes Bukkit's implementation of the `/say` command act exactly the same as the vanilla one, but in the dark purple colour. I would show you a screenshot but there really is no point :wink: 

**Justification for this PR**
To quote from CONTRIBUTING.md:

> One of the goals of the Bukkit project is to be an extended Minecraft vanilla server

This PR makes Bukkit one step closer to being an extended Minecraft vanilla server!

**Related Links**
Jira: [BUKKIT-4224](https://bukkit.atlassian.net/browse/BUKKIT-4224)
