### PR TITLE
[B] Handle BlockCommandSender for /gamerule. Fixes BUKKIT-3274

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/GameRuleCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/GameRuleCommand.java
@@ -3,6 +3,7 @@ package org.bukkit.command.defaults;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang.Validate;
 import org.bukkit.ChatColor;
+import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.util.StringUtil;
@@ -58,6 +59,11 @@ public class GameRuleCommand extends VanillaCommand {
     private World getGameWorld(CommandSender sender) {
         if (sender instanceof HumanEntity) {
             World world = ((HumanEntity) sender).getWorld();
+            if (world != null) {
+                return world;
+            }
+        } else if (sender instanceof BlockCommandSender) {
+            World world = ((BlockCommandSender) sender).getBlock().getWorld();
             if (world != null) {
                 return world;
             }


### PR DESCRIPTION
### Issue

The GameRuleCommand checks if the CommandSender is a HumanEntity, and if so, applies the GameRule to the world that they are in. However, this is not done for Command Blocks, so a Command Block always affects world 0 with a /gamerule command.
### PR Description

An else-block is added to the `instanceof HumanEntity` check of `getGameWorld(CommandSender sender)` that checks `instanceof BlockCommandSender` and returns the world from the block.
### Justification

A Command Block, unlike the console, has world context, and there is no good reason to not use it.
### JIRA

https://bukkit.atlassian.net/browse/BUKKIT-3274
