### PR TITLE
Introduce comprehensive Horse API.  Adds BUKKIT-4426.

### DIFF
--- a/src/main/java/org/bukkit/entity/Horse.java
+++ b/src/main/java/org/bukkit/entity/Horse.java
@@ -1,6 +1,200 @@
 package org.bukkit.entity;
 
+import org.bukkit.inventory.HorseInventory;
+
 /**
- * Represents a Horse.
+ * Represents a Horse, Donkey, or Mule.
+ * 
+ * Horses, donkeys, and mules are all collectively represented as 
+ * "horses" and can be accessed through this API.
  */
-public interface Horse extends Animals, Vehicle {}
+public interface Horse extends Animals, Vehicle {
+
+    /**
+     * Describes the various types of horses.
+     */
+    public enum HorseType {
+        /**
+         * Represents a Horse.
+         */
+        HORSE,
+        
+        /**
+         * Represents a Donkey.
+         * 
+         * Donkeys cannot use armor, but can be carry with a chest.
+         */
+        DONKEY,
+        
+        /**
+         * Represents a Mule.
+         * 
+         * Mules are the result of breeding a horse and donkey.
+         */
+        MULE,
+        
+        /**
+         * Represents an Undead Horse.
+         */
+        UNDEAD_HORSE,
+        
+        /**
+         * Represents a Skeletal Horse.
+         */
+        SKELETAL_HORSE;
+        
+    }
+    
+    public enum CoatColor {
+        WHITE,
+        CREAMY,
+        CHESTNUT,
+        BROWN,
+        BLACK,
+        GRAY,
+        DARK_BROWN;
+    }
+    
+    public enum CoatPattern {
+        NONE,
+        WHITE,
+        WHITE_FIELD,
+        WHITE_DOTS,
+        BLACK_DOTS;
+    }
+    
+    /**
+     * Returns the type of this horse
+     * 
+     * @return the type of the horse
+     */
+    public HorseType getHorseType();
+    
+    /**
+     * Changes the type of this horse
+     * 
+     * @param type the HorseType to change to
+     */
+    public void setHorseType(HorseType type);
+    
+    /**
+     * Returns the coat color of this horse.
+     * 
+     * @return the horse's CoatColor
+     */
+    public CoatColor getCoatColor();
+    
+    /**
+     * Sets the coat color of this horse.
+     * 
+     * Only horses of HorseType.HORSE will display this color 
+     * in-game.
+     * 
+     * @param color the new CoatColor
+     */
+    public void setCoatColor(CoatColor color);
+    
+    /**
+     * Returns the coat pattern of this horse.
+     * 
+     * @return the horse's CoatPattern
+     */
+    public CoatPattern getCoatPattern();
+    
+    /**
+     * Sets the coat pattern of this horse.
+     * 
+     * Only horses of HorseType.HORSE will display this pattern 
+     * in-game.
+     * 
+     * @param pattern the new CoatPattern
+     */
+    public void setCoatPattern(CoatPattern pattern);
+    
+    /**
+     * Returns the speed of the horse.
+     * 
+     * @return the horse's speed
+     */
+    public double getSpeed();
+    
+    /**
+     * Sets the speed of the horse.
+     * 
+     * @param speed the new speed
+     */
+    public void setSpeed(double speed);
+    
+    /**
+     * Returns the horse's jump height.
+     * 
+     * @return the jump height
+     */
+    public double getJumpHeight();
+    
+    /**
+     * Sets the jump height of the horse.
+     * 
+     * @param jumpHeight the new jump height
+     */
+    public void setJumpHeight(double jumpHeight);
+    
+    /**
+     * Gets the temper of this horse.
+     * 
+     * A high temper makes the horse more resistant to taming.
+     * 
+     * @return the horse's temper
+     */
+    public int getTemper();
+    
+    /**
+     * Sets the temper of this horse.
+     * 
+     * @param temper the new temper
+     */
+    public void setTemper(int temper);
+    
+    /**
+     * Determines if this horse is tamed.
+     * 
+     * @return true if tamed, false otherwise
+     */
+    public boolean isTamed();
+    
+    /**
+     * Sets whether or not this horse is tamed.
+     * 
+     * @param tamed true if the horse should be tamed, false otherwise
+     */
+    public void setTamed(boolean tamed);
+    
+    /**
+     * Determines if this horse carries a chest.
+     * 
+     * Carrying a chest will make 15 inventory slots 
+     * available to the rider. In-game, chests can 
+     * only be placed on donkeys and mules. However, any 
+     * horse type can be given a chest through the API.
+     * 
+     * @return 
+     */
+    public boolean hasChest();
+    
+    /**
+     * Sets whether or not this horse has a chest.
+     * 
+     * @param hasChest true if this horse should have a chest, false otherwise
+     */
+    public void setHasChest(boolean hasChest);
+    
+    /**
+     * Gets this horse's inventory.
+     * 
+     * Provides access to the horse's saddle, armor, and 
+     * any chest slots.
+     * 
+     * @return a HorseInventory for this horse
+     */
+    public HorseInventory getInventory();
+}

--- a/src/main/java/org/bukkit/inventory/HorseInventory.java
+++ b/src/main/java/org/bukkit/inventory/HorseInventory.java
@@ -1,0 +1,38 @@
+package org.bukkit.inventory;
+
+public interface HorseInventory extends Inventory {
+    /**
+     * Gets the horse's saddle.
+     * 
+     * Returns null if the horse lacks a saddle.
+     * 
+     * @return An ItemStack representing the saddle
+     */
+    public ItemStack getSaddle();
+    
+    /**
+     * Gets the horse's armor.
+     * 
+     * Returns null if the horse lacks armor.
+     * 
+     * @return An ItemStack representing the armor
+     */
+    public ItemStack getArmor();
+    
+    /**
+     * Sets the horse's saddle.
+     * 
+     * @param saddle The saddle to set.
+     */
+    public void setSaddle(ItemStack saddle);
+    
+    /**
+     * Sets the horse's armor.
+     * 
+     * Adding armor to any horse type besides HORSE may prevent 
+     * the client from properly rendering the texture.
+     * 
+     * @param armor The armor to set
+     */
+    public void setArmor(ItemStack armor);
+}


### PR DESCRIPTION
## Issue & Justification:

Minecraft 1.6.1 introduced the new Horse entity.  We need to expose an API for this new entity.
## Breakdown

This PR fleshes out the Horse interface and introduces a new HorseInventory interface.

The Horse interface exposes the following horse traits with getters/setters: 
- Horse Type (horse, donkey, mule, undead, skeletal)
- Coat Color (for HorseType.HORSE)
- Coat Pattern (for HorseType.HORSE)
- Speed
- Jump Height
- Temper (how likely the horse is to toss you off)
- whether of not the horse is tamed
- whether or not the horse has a chest

The new HorseInventory interface exposes a few additional properties:
- The horse's saddle
- The horse's armor piece
- The horse's chest contents, slots 1-15
## Larger Issues

The Horse entity exposes a more complex issue with some class structures within Bukkit.  While Horse implements an isTamed() and setTamed(bool), it _cannot implement Tameable_ because Horses do not keep track of their owners.  If Mojang introduces other tameable entities in the future, we should consider adding more granular interfaces.
## Testing

Please see the associated CraftBukkit commit.
## Related

Associated CraftBukkit PR: https://github.com/Bukkit/CraftBukkit/pull/1189

This PR provides the same functionality as https://github.com/Bukkit/Bukkit/pull/889 (albeit with a slightly different structure), as well as quite a bit more.

This is my first Bukkit/CraftBukkit contribution. I've taken multiple steps to ensure I've done this right. Please let me know if there is any way I can improve.
