### PR TITLE
[B] Add InventoryClickEvent.getClickedInventory. Adds BUKKIT-4495

### DIFF
--- a/src/main/java/org/bukkit/event/inventory/InventoryClickEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryClickEvent.java
@@ -47,6 +47,7 @@ public class InventoryClickEvent extends InventoryInteractEvent {
     private static final HandlerList handlers = new HandlerList();
     private final ClickType click;
     private final InventoryAction action;
+    private final Inventory clickedInventory;
     private SlotType slot_type;
     private int whichSlot;
     private int rawSlot;
@@ -62,6 +63,13 @@ public class InventoryClickEvent extends InventoryInteractEvent {
         super(view);
         this.slot_type = type;
         this.rawSlot = slot;
+        if (slot < 0) {
+            this.clickedInventory = null;
+        } else if (view.getTopInventory() != null && slot < view.getTopInventory().getSize()) {
+            this.clickedInventory = view.getTopInventory();
+        } else {
+            this.clickedInventory = view.getBottomInventory();
+        }
         this.whichSlot = view.convertSlot(slot);
         this.click = click;
         this.action = action;
@@ -70,6 +78,14 @@ public class InventoryClickEvent extends InventoryInteractEvent {
     public InventoryClickEvent(InventoryView view, SlotType type, int slot, ClickType click, InventoryAction action, int key) {
         this(view, type, slot, click, action);
         this.hotbarKey = key;
+    }
+
+    /**
+     * Gets the inventory that was clicked, or null if outside of window
+     * @return The clicked inventory
+     */
+    public Inventory getClickedInventory() {
+        return clickedInventory;
     }
 
     /**


### PR DESCRIPTION
**The Issue:**
Plugins currently have to do the logic themselves on the raw slot ID in order to determine the inventory clicked. 

**Justification**
An API that simply returns which inventory was clicked will simplify plugin development. If the internals change in the future where the raw slot method is not accurate or not needed, then the getClickedInventory calculation can be updated and plugins will not break.

Currently plugins require checking an implementation detail to figure this out, and that is not recommended.

**Breakdown**
This change uses the current method of determining the clicked inventory and exposes it by getClickedInventory()
