### PR TITLE
[B+C] Allow teleportation of entities on vehicles. Fixes BUKKIT-4210.

### DIFF
--- a/src/main/java/org/bukkit/entity/Entity.java
+++ b/src/main/java/org/bukkit/entity/Entity.java
@@ -81,7 +81,7 @@ public interface Entity extends Metadatable {
     public boolean teleport(Location location, TeleportCause cause);
 
     /**
-     * Teleports this entity to the target Entity.  If this entity is riding a
+     * Teleports this entity to the target Entity. If this entity is riding a
      * vehicle, it will be dismounted prior to teleportation.
      *
      * @param destination Entity to teleport this entity to

--- a/src/main/java/org/bukkit/entity/Entity.java
+++ b/src/main/java/org/bukkit/entity/Entity.java
@@ -62,7 +62,8 @@ public interface Entity extends Metadatable {
     public World getWorld();
 
     /**
-     * Teleports this entity to the given location
+     * Teleports this entity to the given location. If this entity is riding a
+     * vehicle, it will be dismounted prior to teleportation.
      *
      * @param location New location to teleport this entity to
      * @return <code>true</code> if the teleport was successful
@@ -70,7 +71,8 @@ public interface Entity extends Metadatable {
     public boolean teleport(Location location);
 
     /**
-     * Teleports this entity to the given location
+     * Teleports this entity to the given location. If this entity is riding a
+     * vehicle, it will be dismounted prior to teleportation.
      *
      * @param location New location to teleport this entity to
      * @param cause The cause of this teleportation
@@ -79,7 +81,8 @@ public interface Entity extends Metadatable {
     public boolean teleport(Location location, TeleportCause cause);
 
     /**
-     * Teleports this entity to the target Entity
+     * Teleports this entity to the target Entity.  If this entity is riding a
+     * vehicle, it will be dismounted prior to teleportation.
      *
      * @param destination Entity to teleport this entity to
      * @return <code>true</code> if the teleport was successful
@@ -87,7 +90,8 @@ public interface Entity extends Metadatable {
     public boolean teleport(Entity destination);
 
     /**
-     * Teleports this entity to the target Entity
+     * Teleports this entity to the target Entity. If this entity is riding a
+     * vehicle, it will be dismounted prior to teleportation.
      *
      * @param destination Entity to teleport this entity to
      * @param cause The cause of this teleportation


### PR DESCRIPTION
#### The Issue

When Minecraft 1.5 was released, teleportation code in the vanilla Minecraft server was changed so that any players on vehicles are dismounted before being teleported. Currently, the CraftBukkit code simply disallows teleportation when players are in vehicles.
#### Justification for PR

The behavior that CraftBukkit exhibits when teleporting players while in vehicles is different than the behavior of a vanilla Minecraft server under the same conditions. Any plugins which teleport players without first making sure they are dismounted may have their teleports unexpectedly fail. In order to keep consistent behavior, teleportation of other entities has also been modified to mimic this behavior.
#### PR Breakdown

This commit changes the Javadoc on all variations of `Entity.teleport` to document the change to the behaviour of these functions as a result of the CraftBukkit change.
#### Testing Results and Materials

Testing was done by using the built-in /tp command to teleport between players, with one player in a boat when being teleported. In addition, teleportation with both players as normal was tested.
#### JIRA Ticket

BUKKIT-4210 - https://bukkit.atlassian.net/browse/BUKKIT-4210
#### Relevant PR(s)

CB-1191 - https://github.com/Bukkit/CraftBukkit/pull/1191 - Actual CraftBukkit code change
