### PR TITLE
[B+C] Add ChickenLayEggEvent. Adds BUKKIT-4558.

### DIFF
--- a/src/main/java/org/bukkit/event/entity/ChickenLayEggEvent.java
+++ b/src/main/java/org/bukkit/event/entity/ChickenLayEggEvent.java
@@ -1,0 +1,110 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.Chicken;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Called when a chicken lays an egg
+ */
+public class ChickenLayEggEvent extends EntityEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancelled;
+    private boolean playSound;
+    private ItemStack droppedItem;
+    private int timeUntilNextEgg;
+
+    public ChickenLayEggEvent(final Chicken chicken, int ticksUntilNextEgg) {
+        super(chicken);
+        playSound = true;
+        droppedItem = new ItemStack(344, 1); // The default item is an egg
+        timeUntilNextEgg = ticksUntilNextEgg; // -1 signifies time until next egg is determined by vanilla server
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    /**
+     * Sets the cancellation state of this event. A cancelled event will not be executed in the server,
+     * but will still pass to other plugins. NOTE: the time until the next egg will still be updated with the value in this event,
+     * even if it is cancelled.
+     */
+    public void setCancelled(boolean cancel) {
+        cancelled = cancel;
+    }
+
+    @Override
+    public Chicken getEntity() {
+        return (Chicken) entity;
+    }
+
+	/**
+	 * Gets the item the chicken is laying. Modifying the returned ItemStack will have no effect;
+	 * use {@link #setItem(org.bukkit.inventory.ItemStack)} instead.
+	 * 
+	 * @return The item being laid
+	 */
+    public ItemStack getItem() {
+        return droppedItem.clone();
+    }
+
+	/**
+	 * Sets the item to be laid by the chicken. Passing null will effectively cancel the event:
+	 * no sound will be played but the time until the next egg is laid will be updated with the value set in the event.
+	 * 
+	 * @param item the item being laid
+	 */
+    public void setItem(ItemStack item) {
+        droppedItem = item;
+    }
+
+	/**
+	 * Gets the amount of time after the current event completes before the next egg is laid.
+	 * By default, this value ranges from 6000 to 12000 ticks.
+	 * 
+	 * @return The time, in ticks, before the next egg drop
+	 */
+    public int getTicksUntilNextEgg() {
+        return timeUntilNextEgg;
+    }
+
+	/**
+	 * Sets the amount of time after the current event completes before the next egg is laid.
+	 * This value cannot be less than zero.
+	 * 
+	 * @param ticks The time, in ticks, before teh next egg drop
+	 */
+    public void setTicksUntilNextEgg(int ticks) {
+        if (ticks < 0) // default to the current value, assigned by another plugin or by vanilla server code
+            return;
+        timeUntilNextEgg = ticks;
+    }
+
+    /**
+     * @return whether the "mob.chicken.plop" sound will play when the egg is laid
+     */
+    public boolean willSoundPlay() {
+        return playSound;
+    }
+
+    /**
+     * Sets whether the "mob.chicken.plop" sound will play when the egg is laid. This value will have no effect
+     * if the event is cancelled.
+     * 
+     * @param play Whether the chicken should make a sound when laying the egg (defaults to true)
+     */
+    public void playSound(boolean play) {
+        playSound = play;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/org/bukkit/event/entity/ChickenLayEggEvent.java
+++ b/src/main/java/org/bukkit/event/entity/ChickenLayEggEvent.java
@@ -74,7 +74,7 @@ public class ChickenLayEggEvent extends EntityEvent implements Cancellable {
 	 * Sets the amount of time after the current event completes before the next egg is laid.
 	 * This value cannot be less than zero.
 	 * 
-	 * @param ticks The time, in ticks, before teh next egg drop
+	 * @param ticks The time, in ticks, before the next egg drop
 	 */
     public void setTicksUntilNextEgg(int ticks) {
         if (ticks < 0) // default to the current value, assigned by another plugin or by vanilla server code
@@ -85,7 +85,7 @@ public class ChickenLayEggEvent extends EntityEvent implements Cancellable {
     /**
      * @return whether the "mob.chicken.plop" sound will play when the egg is laid
      */
-    public boolean willSoundPlay() {
+    public boolean willPlaySound() {
         return playSound;
     }
 
@@ -95,7 +95,7 @@ public class ChickenLayEggEvent extends EntityEvent implements Cancellable {
      * 
      * @param play Whether the chicken should make a sound when laying the egg (defaults to true)
      */
-    public void playSound(boolean play) {
+    public void setWillPlaySound(boolean play) {
         playSound = play;
     }
 


### PR DESCRIPTION
### The Issue:

Bukkit currently provides no adequate method of determining when a chicken lays an egg, something developers have long desired to do in order to regulate "chicken farms" and add modify the items dropped, among other things.  Forced to exercise their creativity, members of the community have devised a variety of workarounds - such as checking for the proximity of a chicken in an ItemSpawnEvent handler - but even in the event that one is able to stop an egg from being spawned, the "plopping" sound is still played; this can currently only be prevented using packet manipulation.
### The Justification:

The aforementioned workarounds are inelegant and inefficient, and can be rendered unnecessary with ten or so lines of CraftBukkit code (see accompanying PR). This PR enables chickens' egg laying behavior to be modified in the following ways:
- Egg laying events can be cancelled and will prevent the egg drop sound from being played
- The item being laid can be retrieved and changed (setting the item to null effectively cancels the event)
- The amount of time, in ticks, before the next egg is laid can be retrieved and changed
- Whether the "mob.chicken.plop" sound plays can be toggled, allowing for silent drops
### PR Breakdown:

This PR adds the ChickenLayEggEvent class (a cancellable EntityEvent subclass), which fires directly before a chicken lays an egg and provides methods for the behavioral modifications listed above.
### Testing Materials and Results:

The following plugin was used to verify the functionality of the changes made in this commit and in those of the sister PR:
- Source: https://github.com/LinearLogic/ChickenOut
- Compiled jar: http://veltro.org/dev/mc/ChickenOut.jar

No issues were encountered during testing.
### Other Resources:

**Relevant PR:**
CB-1197 - https://github.com/Bukkit/CraftBukkit/pull/1197 - implements the ChickenLayEggEvent added in this PR.

**JIRA Ticket:**
BUKKIT-4558 - https://bukkit.atlassian.net/browse/BUKKIT-4558

_No chickens were harmed in the making of this PR._
