### PR TITLE
[B+C] Add LeadKnot entity. Adds BUKKIT-4570

### DIFF
--- a/src/main/java/org/bukkit/entity/EntityType.java
+++ b/src/main/java/org/bukkit/entity/EntityType.java
@@ -27,6 +27,10 @@ public enum EntityType {
      */
     EXPERIENCE_ORB("XPOrb", ExperienceOrb.class, 2),
     /**
+     * A lead knot.
+     */
+    LEAD_KNOT("LeashKnot", LeadKnot.class, 8),
+    /**
      * A painting on a wall.
      */
     PAINTING("Painting", Painting.class, 9),

--- a/src/main/java/org/bukkit/entity/LeadKnot.java
+++ b/src/main/java/org/bukkit/entity/LeadKnot.java
@@ -1,0 +1,8 @@
+package org.bukkit.entity;
+
+
+/**
+ * Represents an Lead Knot
+ */
+public interface LeadKnot extends Hanging {
+}

--- a/src/main/java/org/bukkit/entity/LeadKnot.java
+++ b/src/main/java/org/bukkit/entity/LeadKnot.java
@@ -1,8 +1,7 @@
 package org.bukkit.entity;
 
-
 /**
- * Represents an Lead Knot
+ * Represents an Lead Knot.
  */
 public interface LeadKnot extends Hanging {
 }


### PR DESCRIPTION
The Issue:

There is no entity class in Bukkit for lead knots.

Justification for this PR:

Lead knots are entities created by player while right clicking a fence with at least one entity on a leash. In Bukkit there is no corresponding entity class.

PR Breakdown:

LeadKnot is extending Hanging. The name is choosen according to http://www.minecraftwiki.net/wiki/Data_values#Entity_IDs

Testing Results and Materials:

Working fine. Detailed material on request.

Relevant PR(s):

CB-1206 - https://github.com/Bukkit/CraftBukkit/pull/1206
B-897 - https://github.com/Bukkit/Bukkit/pull/897 (for leashing Entities)
CB-1190 - https://github.com/Bukkit/CraftBukkit/pull/1190 (for leashing Entities)

JIRA Ticket:

BUKKIT-4570 - https://bukkit.atlassian.net/browse/BUKKIT-4570
BUKKIT-4583 - https://bukkit.atlassian.net/browse/BUKKIT-4583 - partly related
