### PR TITLE
[B+C] Add EnderSignalLaunchEvent; Adds BUKKIT-4572

### DIFF
--- a/src/main/java/org/bukkit/event/entity/EnderSignalLaunchEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EnderSignalLaunchEvent.java
@@ -1,0 +1,57 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.EnderSignal;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Thrown when an ender signal (eye of ender) is launched by a human
+ */
+public class EnderSignalLaunchEvent extends EntityEvent implements Cancellable{
+    private static final HandlerList handlers = new HandlerList();
+	private HumanEntity shooter;
+	private boolean cancel = false;
+	
+	/**
+	 * Creates a new EnderSignalLaunchEvent
+	 * @param what the {@link org.bukkit.entity.EnderSignal} object
+	 * @param shooter the shooter, likely a player
+	 */
+	public EnderSignalLaunchEvent(Entity what, HumanEntity shooter){
+		super(what);
+	}
+	
+	/**
+	 * Gets who shot the ender signal
+	 * @return the shooter
+	 */
+	public HumanEntity getShooter(){
+		return shooter;
+	}
+	
+	@Override
+	public EnderSignal getEntity(){
+		return (EnderSignal)entity;
+	}
+
+	@Override
+	public boolean isCancelled(){
+		return cancel;
+	}
+
+	@Override
+	public void setCancelled(boolean cancel){
+		this.cancel=cancel;
+	}
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/org/bukkit/event/entity/EnderSignalLaunchEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EnderSignalLaunchEvent.java
@@ -7,45 +7,41 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
 /**
- * Thrown when an ender signal (eye of ender) is launched by a human
+ * Thrown when an ender signal (eye of ender) is launched.<br>
+ * This currently can only be initiated by a player.
  */
 public class EnderSignalLaunchEvent extends EntityEvent implements Cancellable{
     private static final HandlerList handlers = new HandlerList();
-	private HumanEntity shooter;
-	private boolean cancel = false;
-	
-	/**
-	 * Creates a new EnderSignalLaunchEvent
-	 * @param what the {@link org.bukkit.entity.EnderSignal} object
-	 * @param shooter the shooter, likely a player
-	 */
-	public EnderSignalLaunchEvent(Entity what, HumanEntity shooter){
-		super(what);
-		this.shooter = shooter;
-	}
-	
-	/**
-	 * Gets who shot the ender signal
-	 * @return the shooter
-	 */
-	public HumanEntity getShooter(){
-		return shooter;
-	}
-	
-	@Override
-	public EnderSignal getEntity(){
-		return (EnderSignal)entity;
-	}
+    private HumanEntity shooter;
+    private boolean cancel = false;
+    
+    public EnderSignalLaunchEvent(Entity what, HumanEntity shooter){
+        super(what);
+        this.shooter = shooter;
+    }
+    
+    /**
+     * Gets who launched the ender signal
+     * @return the shooter
+     */
+    public HumanEntity getShooter(){
+        return shooter;
+    }
+    
+    @Override
+    public EnderSignal getEntity(){
+        return (EnderSignal) entity;
+    }
 
-	@Override
-	public boolean isCancelled(){
-		return cancel;
-	}
+    @Override
+    public boolean isCancelled(){
+        return cancel;
+    }
 
-	@Override
-	public void setCancelled(boolean cancel){
-		this.cancel=cancel;
-	}
+    @Override
+    public void setCancelled(boolean cancel){
+        this.cancel = cancel;
+    }
 
     @Override
     public HandlerList getHandlers() {

--- a/src/main/java/org/bukkit/event/entity/EnderSignalLaunchEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EnderSignalLaunchEvent.java
@@ -7,7 +7,8 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
 /**
- * Thrown when an ender signal (eye of ender) is launched.
+ * This event is called when an Eye of Ender item is launched by a player
+ * to become an Ender Signal entity.
  * <br>
  * This currently can only be initiated by a player.
  */

--- a/src/main/java/org/bukkit/event/entity/EnderSignalLaunchEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EnderSignalLaunchEvent.java
@@ -21,6 +21,7 @@ public class EnderSignalLaunchEvent extends EntityEvent implements Cancellable{
 	 */
 	public EnderSignalLaunchEvent(Entity what, HumanEntity shooter){
 		super(what);
+		this.shooter = shooter;
 	}
 	
 	/**

--- a/src/main/java/org/bukkit/event/entity/EnderSignalLaunchEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EnderSignalLaunchEvent.java
@@ -7,25 +7,26 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
 /**
- * Thrown when an ender signal (eye of ender) is launched.<br>
+ * Thrown when an ender signal (eye of ender) is launched.
+ * <br>
  * This currently can only be initiated by a player.
  */
 public class EnderSignalLaunchEvent extends EntityEvent implements Cancellable{
     private static final HandlerList handlers = new HandlerList();
-    private HumanEntity shooter;
+    private HumanEntity launcher;
     private boolean cancel = false;
     
     public EnderSignalLaunchEvent(Entity what, HumanEntity shooter){
         super(what);
-        this.shooter = shooter;
+        this.launcher = shooter;
     }
     
     /**
-     * Gets who launched the ender signal
-     * @return the shooter
+     * Gets who launched the ender signal.
+     * @return the launcher of the ender signal
      */
-    public HumanEntity getShooter(){
-        return shooter;
+    public HumanEntity getLauncher(){
+        return launcher;
     }
     
     @Override

--- a/src/main/java/org/bukkit/event/entity/EnderSignalLaunchEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EnderSignalLaunchEvent.java
@@ -12,36 +12,36 @@ import org.bukkit.event.HandlerList;
  * <br>
  * This currently can only be initiated by a player.
  */
-public class EnderSignalLaunchEvent extends EntityEvent implements Cancellable{
+public class EnderSignalLaunchEvent extends EntityEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private HumanEntity launcher;
     private boolean cancel = false;
-    
-    public EnderSignalLaunchEvent(Entity what, HumanEntity shooter){
+
+    public EnderSignalLaunchEvent(Entity what, HumanEntity shooter) {
         super(what);
         this.launcher = shooter;
     }
-    
+
     /**
      * Gets who launched the ender signal.
      * @return the launcher of the ender signal
      */
-    public HumanEntity getLauncher(){
+    public HumanEntity getLauncher() {
         return launcher;
     }
-    
+
     @Override
-    public EnderSignal getEntity(){
+    public EnderSignal getEntity() {
         return (EnderSignal) entity;
     }
 
     @Override
-    public boolean isCancelled(){
+    public boolean isCancelled() {
         return cancel;
     }
 
     @Override
-    public void setCancelled(boolean cancel){
+    public void setCancelled(boolean cancel) {
         this.cancel = cancel;
     }
 

--- a/src/main/java/org/bukkit/event/entity/EnderSignalLaunchEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EnderSignalLaunchEvent.java
@@ -17,9 +17,9 @@ public class EnderSignalLaunchEvent extends EntityEvent implements Cancellable {
     private HumanEntity launcher;
     private boolean cancel = false;
 
-    public EnderSignalLaunchEvent(Entity what, HumanEntity shooter) {
+    public EnderSignalLaunchEvent(Entity what, HumanEntity launcher) {
         super(what);
-        this.launcher = shooter;
+        this.launcher = launcher;
     }
 
     /**


### PR DESCRIPTION
## The Issue

Currently there is no way to simply detect when an Ender Signal (or Eye of Ender) is sent into the world by player means. This causes issues for plugins that want to block this action or at least detect it for logging (or other) purposes.
## Justification for this PR

With this addition plugins will be able to detect when an Ender Signal is launched into the world. Currently this can only happen by the player's hand therefore this event has a `HumanEntity getShooter()` method to represent the shooter. 

Plugins such as mine, AntiShare, will be able to use this event to do all sorts of actions. In my particular case this will add the ability for AntiShare to stop further sharing of items between creative and survival mode players by eliminating the infinite supply of Ender Signals that can be launched by creative mode players. This event will help prevent the issue of spreading Ender Signals within a server.

This event is cancellable to allow for plugins to block the action entirely. 
## Testing Results and Materials

[source](http://pastebin.com/tL7qYXmW) || [compiled](https://docs.google.com/file/d/0B6JIYSBkLkAnSUpCRXNFSnVlakk/edit?usp=sharing) || [server log](http://pastebin.com/EVh0dnZ6)

In the server log lines 18-23 will be of the most interest.
## Relevant PRs

B-906 - https://github.com/Bukkit/Bukkit/pull/906 - The actual event object
C-1207 - https://github.com/Bukkit/CraftBukkit/pull/1207 - The implementation of this event
## JIRA Ticket

BUKKIT-4572 - https://bukkit.atlassian.net/browse/BUKKIT-4572
## Other Example Implementations
- Determining where Eye of Ender items are being sent (logging plugins)
- Changing direction of Ender Eye (not currently possible, maybe in the future)
- Stopping players from sending them (creative protection plugins)
- Flares/markers (more changing of location - not currently possible)
