### PR TITLE
[C+B] Add Wither API. Adds BUKKIT-4571

### DIFF
--- a/src/main/java/org/bukkit/entity/Wither.java
+++ b/src/main/java/org/bukkit/entity/Wither.java
@@ -1,7 +1,46 @@
 package org.bukkit.entity;
 
+import org.bukkit.Location;
+
 /**
  * Represents a Wither boss
  */
 public interface Wither extends Monster {
+    /**
+     * Gets the current target of a wither head
+     *
+     * @param head which head to check the target of
+     * @return the current target of a wither head, or null if none
+     */
+    public LivingEntity getTarget(WitherHead head);
+    /**
+     * Sets the current target of a wither head
+     *
+     * @param head which head to check the target of
+     * @param entity the entity to set as the target
+     */
+    public void setTarget(WitherHead head, LivingEntity entity);
+    /**
+     * Fires a wither skull from a wither head
+     *
+     * @param head which head to fire from
+     * @param entity the entity to fire at
+     */
+    public void shoot(WitherHead head, LivingEntity entity);
+    /**
+     * Fires a wither skull from a wither head
+     *
+     * @param head which head to fire from
+     * @param location the location to fire at
+     */
+    public void shoot(WitherHead head, Location location);
+    
+    /**
+     * An enum to specify which head of the wither
+     */
+    public enum WitherHead {
+        LEFT,
+        CENTER,
+        RIGHT,
+    }
 }

--- a/src/main/java/org/bukkit/entity/Wither.java
+++ b/src/main/java/org/bukkit/entity/Wither.java
@@ -39,13 +39,24 @@ public interface Wither extends Monster {
      */
     public void shoot(WitherHead head, Location location);
 
-    
     /**
      * An enum to specify which head of the wither
      */
     public enum WitherHead {
+
+        /**
+         * The Left head in respect to a frontal view
+         */
         LEFT,
+
+        /**
+         * The Center head in respect to a frontal view
+         */
         CENTER,
+
+        /**
+         * The Right head in respect to a frontal view
+         */
         RIGHT,
     }
 }

--- a/src/main/java/org/bukkit/entity/Wither.java
+++ b/src/main/java/org/bukkit/entity/Wither.java
@@ -40,7 +40,7 @@ public interface Wither extends Monster {
     public void shoot(WitherHead head, Location location);
 
     /**
-     * An enum to specify which head of the wither
+     * An enum to specify a head on the Wither
      */
     public enum WitherHead {
 
@@ -57,6 +57,6 @@ public interface Wither extends Monster {
         /**
          * The Right head in respect to a frontal view
          */
-        RIGHT,
+        RIGHT
     }
 }

--- a/src/main/java/org/bukkit/entity/Wither.java
+++ b/src/main/java/org/bukkit/entity/Wither.java
@@ -7,28 +7,28 @@ import org.bukkit.Location;
  */
 public interface Wither extends Monster {
     /**
-     * Gets the current target of a wither head
+     * Gets the current target of a wither head.
      *
      * @param head which head to check the target of
      * @return the current target of a wither head, or null if none
      */
     public LivingEntity getTarget(WitherHead head);
     /**
-     * Sets the current target of a wither head
+     * Sets the current target of a wither head.
      *
      * @param head which head to check the target of
      * @param entity the entity to set as the target
      */
     public void setTarget(WitherHead head, LivingEntity entity);
     /**
-     * Fires a wither skull from a wither head
+     * Fires a wither skull from a wither head.
      *
      * @param head which head to fire from
      * @param entity the entity to fire at
      */
     public void shoot(WitherHead head, LivingEntity entity);
     /**
-     * Fires a wither skull from a wither head
+     * Fires a wither skull from a wither head.
      *
      * @param head which head to fire from
      * @param location the location to fire at

--- a/src/main/java/org/bukkit/entity/Wither.java
+++ b/src/main/java/org/bukkit/entity/Wither.java
@@ -6,6 +6,7 @@ import org.bukkit.Location;
  * Represents a Wither boss
  */
 public interface Wither extends Monster {
+
     /**
      * Gets the current target of a wither head.
      *
@@ -13,6 +14,7 @@ public interface Wither extends Monster {
      * @return the current target of a wither head, or null if none
      */
     public LivingEntity getTarget(WitherHead head);
+
     /**
      * Sets the current target of a wither head.
      *
@@ -20,6 +22,7 @@ public interface Wither extends Monster {
      * @param entity the entity to set as the target
      */
     public void setTarget(WitherHead head, LivingEntity entity);
+
     /**
      * Fires a wither skull from a wither head.
      *
@@ -27,6 +30,7 @@ public interface Wither extends Monster {
      * @param entity the entity to fire at
      */
     public void shoot(WitherHead head, LivingEntity entity);
+
     /**
      * Fires a wither skull from a wither head.
      *
@@ -34,6 +38,7 @@ public interface Wither extends Monster {
      * @param location the location to fire at
      */
     public void shoot(WitherHead head, Location location);
+
     
     /**
      * An enum to specify which head of the wither

--- a/src/main/java/org/bukkit/entity/Wither.java
+++ b/src/main/java/org/bukkit/entity/Wither.java
@@ -3,7 +3,7 @@ package org.bukkit.entity;
 import org.bukkit.Location;
 
 /**
- * Represents a Wither boss
+ * Represents a Wither boss.
  */
 public interface Wither extends Monster {
 
@@ -40,22 +40,22 @@ public interface Wither extends Monster {
     public void shoot(WitherHead head, Location location);
 
     /**
-     * An enum to specify a head on the Wither
+     * An enum to specify a head on the Wither.
      */
     public enum WitherHead {
 
         /**
-         * The Left head in respect to a frontal view
+         * The Left head in respect to a frontal view.
          */
         LEFT,
 
         /**
-         * The Center head in respect to a frontal view
+         * The Center head in respect to a frontal view.
          */
         CENTER,
 
         /**
-         * The Right head in respect to a frontal view
+         * The Right head in respect to a frontal view.
          */
         RIGHT
     }

--- a/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java
@@ -122,7 +122,7 @@ public class EntityTargetEvent extends EntityEvent implements Cancellable {
          */
         DEFEND_VILLAGE,
         /**
-         * When an wither selects it's chase target as an attack target for it's middle head
+         * When a wither boss selects an attack target for its primary head.
          */
         WITHER_TARGET,
         /**

--- a/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java
@@ -122,6 +122,10 @@ public class EntityTargetEvent extends EntityEvent implements Cancellable {
          */
         DEFEND_VILLAGE,
         /**
+         * When an wither selects it's chase target as an attack target for it's middle head
+         */
+        WITHER_TARGET,
+        /**
          * For custom calls to the event.
          */
         CUSTOM

--- a/src/main/java/org/bukkit/event/entity/WitherHeadTargetEvent.java
+++ b/src/main/java/org/bukkit/event/entity/WitherHeadTargetEvent.java
@@ -20,9 +20,9 @@ public class WitherHeadTargetEvent extends EntityTargetLivingEntityEvent impleme
     }
 
     /**
-     * Get the enum representation of which head is targeting an entity
+     * Gets which head of the wither is targeting an entity
      *
-     * @return Which wither head
+     * @return Which wither head is targeting an entity
      */
     public WitherHead getWitherHead() {
         return head;

--- a/src/main/java/org/bukkit/event/entity/WitherHeadTargetEvent.java
+++ b/src/main/java/org/bukkit/event/entity/WitherHeadTargetEvent.java
@@ -6,16 +6,17 @@ import org.bukkit.entity.Wither.WitherHead;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
-public class WitherHeadTargetEvent extends EntityEvent implements Cancellable {
+/**
+ * Called when a wither head targets or untargets an entity for its wither skull attack
+ */
+public class WitherHeadTargetEvent extends EntityTargetLivingEntityEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;
     private WitherHead head;
-    private LivingEntity target;
 
-    public WitherHeadTargetEvent(Entity entity, LivingEntity target, WitherHead head) {
-        super(entity);
+    public WitherHeadTargetEvent(Entity entity, LivingEntity target, TargetReason reason, WitherHead head) {
+        super(entity, target, reason);
         this.head = head;
-        this.target = target;
     }
 
     /**
@@ -33,28 +34,6 @@ public class WitherHeadTargetEvent extends EntityEvent implements Cancellable {
 
     public void setCancelled(boolean cancel) {
         this.cancel = cancel;
-    }
-
-    /**
-     * Get the entity that this is targeting.
-     *
-     * @return The entity
-     */
-    public LivingEntity getTarget() {
-        return target;
-    }
-
-    /**
-     * Set the entity that you want the mob to target instead.
-     * It is possible to be null, null will cause the entity to be
-     * target-less.
-     * <p>
-     * Setting this to null is essentially the same as cancelling the event
-     *
-     * @param target The entity to target
-     */
-    public void setTarget(LivingEntity target) {
-        this.target = target;
     }
 
     @Override

--- a/src/main/java/org/bukkit/event/entity/WitherHeadTargetEvent.java
+++ b/src/main/java/org/bukkit/event/entity/WitherHeadTargetEvent.java
@@ -1,0 +1,63 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Wither.WitherHead;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+public class WitherHeadTargetEvent extends EntityEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancel = false;
+    private WitherHead head;
+    private LivingEntity target;
+
+    public WitherHeadTargetEvent(Entity entity, LivingEntity target, WitherHead head) {
+        super(entity);
+        this.head = head;
+        this.target = target;
+    }
+
+    public WitherHead getWitherHead() {
+        return head;
+    }
+
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+
+    /**
+     * Get the entity that this is targeting.
+     *
+     * @return The entity
+     */
+    public LivingEntity getTarget() {
+        return target;
+    }
+
+    /**
+     * Set the entity that you want the mob to target instead.
+     * It is possible to be null, null will cause the entity to be
+     * target-less.
+     * <p>
+     * Setting this to null is essentially the same as cancelling the event
+     *
+     * @param target The entity to target
+     */
+    public void setTarget(LivingEntity target) {
+        this.target = target;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/org/bukkit/event/entity/WitherHeadTargetEvent.java
+++ b/src/main/java/org/bukkit/event/entity/WitherHeadTargetEvent.java
@@ -4,13 +4,12 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Wither.WitherHead;
 import org.bukkit.event.Cancellable;
-import org.bukkit.event.HandlerList;
 
 /**
- * Called when a wither head targets or untargets an entity for its wither skull attack
+ * Called when a wither head targets or untargets an entity for its wither
+ * skull attack.
  */
 public class WitherHeadTargetEvent extends EntityTargetLivingEntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;
     private WitherHead head;
 
@@ -20,7 +19,7 @@ public class WitherHeadTargetEvent extends EntityTargetLivingEntityEvent impleme
     }
 
     /**
-     * Gets which head of the wither is targeting an entity
+     * Gets which head of the wither is targeting an entity.
      *
      * @return Which wither head is targeting an entity
      */
@@ -34,14 +33,5 @@ public class WitherHeadTargetEvent extends EntityTargetLivingEntityEvent impleme
 
     public void setCancelled(boolean cancel) {
         this.cancel = cancel;
-    }
-
-    @Override
-    public HandlerList getHandlers() {
-        return handlers;
-    }
-
-    public static HandlerList getHandlerList() {
-        return handlers;
     }
 }

--- a/src/main/java/org/bukkit/event/entity/WitherHeadTargetEvent.java
+++ b/src/main/java/org/bukkit/event/entity/WitherHeadTargetEvent.java
@@ -18,6 +18,11 @@ public class WitherHeadTargetEvent extends EntityEvent implements Cancellable {
         this.target = target;
     }
 
+    /**
+     * Get the enum representation of which head is targeting an entity
+     *
+     * @return Which wither head
+     */
     public WitherHead getWitherHead() {
         return head;
     }


### PR DESCRIPTION
**Issue:**
There is currently little to nothing that allows developers to alter Wither behavior and such.

**PR breakdown:**
This commit adds methods that would allow developers to control wither behavior whether it be shooting wither heads at certain locations or things, or just stopping them altogether.

**Justification:**
Currently with Bukkit there is no little to allow developers to write code to interface with Wither boss mobs. This means that developers are unable to specify (or retrieve) targets for the Wither on a per-head basis. Furthermore, there is no event or means to detect when a Wither selects a new target for any one of its three heads. This pull request also adds methods to enable developers to fire skulls from one of the three available heads to a location or LivingEntity, something which previously was not possible. This opens up a large number of possibilities for developers and enables finer control over Wither boss mobs than was previously possible.

**CraftBukkit PR:**  https://github.com/Bukkit/CraftBukkit/pull/1208
