### PR TITLE
[B+C] Add EntityBornEvent. Adds BUKKIT-3391

### DIFF
--- a/src/main/java/org/bukkit/event/entity/EntityBornEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityBornEvent.java
@@ -1,0 +1,71 @@
+package org.bukkit.event.entity;
+
+import java.util.List;
+
+import org.bukkit.entity.Ageable;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Called when an Ageable entity is born
+ * <p />
+ * If an EntityBornEvent is cancelled the parents will not breed, no child is produced,
+ * and no experience is dropped.
+ */
+public class EntityBornEvent extends EntityEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private final List<Ageable> parents;
+    private int experienceToDrop;
+    private boolean cancel;
+
+    public EntityBornEvent(Ageable what, List<Ageable> parents, int experienceToDrop) {
+        super(what);
+        this.parents = parents;
+        this.experienceToDrop = experienceToDrop;
+        this.cancel = false;
+    }
+
+    /**
+     * Gets the parents of child that would be produced by this event.
+     *
+     * @return Ageable the child entity's parents
+     */
+    public List<Ageable> getParents() {
+        return parents;
+    }
+
+    /**
+     * Gets the amount of experience to drop if this event is successful.
+     *
+     * @return int experience points to drop.
+     */
+    public int getExperienceToDrop() {
+        return experienceToDrop;
+    }
+
+    /**
+     * Sets the amount of experience to drop if this event is successful.
+     *
+     * @param experienceToDrop the amount of experience to drop of this event is successful.
+     */
+    public void setExperienceToDrop(int experienceToDrop) {
+        this.experienceToDrop = experienceToDrop;
+    }
+
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}


### PR DESCRIPTION
##### The Issue:

Currently there is no event to determine when two Ageable entities breed, thus no way to modify the experience gained in this event nor control over the parents and the child entities.
##### Justification for this PR:

Plugin authors should be able to modify how much experience is gained when breeding and cancel breeding attempts.
##### PR Breakdown:

This pull request adds a new event which is called when two Ageable entities breed.
#### Testing Results and Materials:

Testing was successful, first breeding attempt resulting in a baby piggy, second breeding attempt was cancelled and no baby pig was spawned.
[source](http://pastie.org/private/xlusrr6ndegzqykr2nq) || [compiled](https://dl.dropboxusercontent.com/u/29178507/Dev/EntityBornEventTest.jar) || [server log](http://pastie.org/private/tlrlzlkv1mzqwuicjx8uq)
##### Relevant PR(s):

B-909 - https://github.com/Bukkit/Bukkit/pull/909 - Accompanying PR  
CB-1209 - https://github.com/Bukkit/CraftBukkit/pull/1209 - Accompanying PR

This pull request was originally submitted by @andrepl
https://github.com/Bukkit/Bukkit/pull/791 https://github.com/Bukkit/CraftBukkit/pull/1053
##### JIRA Ticket:

BUKKIT-3391 - https://bukkit.atlassian.net/browse/BUKKIT-3391
