### PR TITLE
[C+B] Add methods to control number of arrows on player.  Adds BUKKIT-3721

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -695,11 +695,13 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
     /**
      * Sets the amount of arrows sticking in a player's body.
      * <p>
-     * Can only use values between 0 and 127.
+     * Can only use values between 0 and 127, inclusive.
      *
      * @param arrows the amount of arrows to stick in the body
+     * @throws IllegalArgumentException if number is less than 0
+     * @throws IllegalArgumentException if number is greater than 127
      */
-    public void setVisibleArrows(int arrows);
+    public void setVisibleArrows(int arrows) throws IllegalArgumentException;
 
     /**
      * Returns the amount of arrows stuck in the player.

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -699,12 +699,12 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      *
      * @param arrows the amount of arrows to stick in the body
      */
-    public void setArrowsInPlayer(int arrows);
+    public void setVisibleArrows(int arrows);
 
     /**
      * Returns the amount of arrows stuck in the player.
      *
      * @return amount of arrows stuck in the player
      */
-    public int getArrowsInPlayer();
+    public int getVisibleArrows();
 }

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -691,4 +691,20 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      * @see Player#setHealthScaled(boolean)
      */
     public double getHealthScale();
+
+    /**
+     * Sets the players's current number of arrows sticking out of its body.
+     * <p>
+     * Can only use values between 0 and 127
+     *
+     * @param arrows the amount of arrows to stick in the body
+     */
+    public void setArrowsInPlayer(int arrows);
+
+    /**
+     * Returns the amount of arrows currently stuck in the player.
+     *
+     * @return amount of arrows stuck in the player
+     */
+    public int getArrowsInPlayer();
 }

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -698,8 +698,7 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      * Can only use values between 0 and 127, inclusive.
      *
      * @param arrows the amount of arrows to stick in the body
-     * @throws IllegalArgumentException if number is less than 0
-     * @throws IllegalArgumentException if number is greater than 127
+     * @throws IllegalArgumentException if arrows is outside the range [0, 127]
      */
     public void setVisibleArrows(int arrows) throws IllegalArgumentException;
 

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -693,16 +693,16 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
     public double getHealthScale();
 
     /**
-     * Sets the players's current number of arrows sticking out of its body.
+     * Sets the amount of arrows sticking in a player's body.
      * <p>
-     * Can only use values between 0 and 127
+     * Can only use values between 0 and 127.
      *
      * @param arrows the amount of arrows to stick in the body
      */
     public void setArrowsInPlayer(int arrows);
 
     /**
-     * Returns the amount of arrows currently stuck in the player.
+     * Returns the amount of arrows stuck in the player.
      *
      * @return amount of arrows stuck in the player
      */


### PR DESCRIPTION
**The Issue:**
There is currently no method of getting or altering the number of arrows displayed on the client as stuck in the player.

**Justification:**
Allows for developers to control the number of arrows on a player, whether it be to set it to certain values or to keep it at zero. As the implementation consists of calling pre-existing nms methods with no changes to nms itself, the upkeep of the implementation should be relatively simple.

**PR Breakdown:**
This PR, in conjuncture with its CraftBukkit PR counterpart, adds this functionality, allowing developers to take advantage of it as they please.

**CraftBukkit PR:**
https://github.com/Bukkit/CraftBukkit/pull/1217

**JIRA Ticket:**
https://bukkit.atlassian.net/browse/BUKKIT-3721
