### PR TITLE
[B] Ambigous error message for abstract events.

### DIFF
--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -547,6 +547,10 @@ public final class SimplePluginManager implements PluginManager {
     }
 
     private Class<? extends Event> getRegistrationClass(Class<? extends Event> clazz) {
+		return getRegistrationClass(clazz, null);
+	}
+
+	private Class<? extends Event> getRegistrationClass(Class<? extends Event> clazz, String childClassName) {
         try {
             clazz.getDeclaredMethod("getHandlerList");
             return clazz;
@@ -554,9 +558,9 @@ public final class SimplePluginManager implements PluginManager {
             if (clazz.getSuperclass() != null
                     && !clazz.getSuperclass().equals(Event.class)
                     && Event.class.isAssignableFrom(clazz.getSuperclass())) {
-                return getRegistrationClass(clazz.getSuperclass().asSubclass(Event.class));
+                return getRegistrationClass(clazz.getSuperclass().asSubclass(Event.class), childClassName!=null ? childClassName : clazz.getName());
             } else {
-                throw new IllegalPluginAccessException("Unable to find handler list for event " + clazz.getName());
+                throw new IllegalPluginAccessException("Unable to find handler list for event " + childClassName);
             }
         }
     }


### PR DESCRIPTION
This clarifies the IllegalPluginAccessException that happens when you try to listen to an abstract event with the name of the child class to help the developer to find where he needs to fix his code.
Tested with simplified test case, shows output correctly:
`org.bukkit.plugin.IllegalPluginAccessException: Unable to find handler list for event org.bukkit.event.player.PlayerBucketEvent` 
instead of
`org.bukkit.plugin.IllegalPluginAccessException: Unable to find handler list for event org.bukkit.event.player.PlayerEvent`  
Closes [BUKKIT-4632](https://bukkit.atlassian.net/browse/BUKKIT-4632).
