### PR TITLE
[B+C] Fire a new LockedChestDecayEvent when locked chests decay.  Adds BUKKIT-122

### DIFF
--- a/src/main/java/org/bukkit/event/block/LockedChestDecayEvent.java
+++ b/src/main/java/org/bukkit/event/block/LockedChestDecayEvent.java
@@ -1,0 +1,36 @@
+package org.bukkit.event.block;
+
+import org.bukkit.block.Block;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Called when a locked chest decays naturally.
+ * <p>
+ * If a Locked Chest Decay event is cancelled, the locked chest will not decay.
+ */
+public class LockedChestDecayEvent extends BlockEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancel = false;
+
+    public LockedChestDecayEvent(final Block block) {
+        super(block);
+    }
+
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}


### PR DESCRIPTION
##### The Issue:

There is currently no way to prevent locked chests from decaying.  This pull request is intended to allow plugin developers to do that.
##### Justification for this PR:

Although locked chests "are all but removed from the game at this point", they do not have the chest texture anymore, and BUKKIT-122 was closed as WONTFIX for these reasons, some people may want to still use locked chests:
- as decoration blocks (this is _my_ desired use case); or
- to do various fun things (e.g. the [LockedChestSurprise](http://dev.bukkit.org/bukkit-plugins/locked-chest-surprise/) plugin created by the reporter of BUKKIT-122).

I implemented a new `LockedChestDecayEvent` as locked chests are obviously not leaves, and I don't think existing plugins that listen for `LeavesDecayEvent` should have to check to see if a block is a locked chest.  If you all would prefer that I fire `LeavesDecayEvent` instead, I would be happy to update my code to do that instead.
##### PR Breakdown:

This pull request creates a new `LockedChestDecayEvent` that will be called by `net.minecraft.server.BlockLockedChest.java:a` when a locked chest decays.  This new event is a direct copy/paste of `LeavesDecayEvent.java`.

The CraftBukkit pull request:
- Adds `net.minecraft.server.BlockLockedChest.java` as it wasn't there before.
- Fires the new `LockedChestDecayEvent` when a locked chest decays.  The code that does this is a direct copy/paste from `BlockLeaves.java`.
##### Testing Results and Materials:

I created a plugin that cancels `LockedChestDecayEvent`s.  I then set up a new CraftBukkit server with [this `server.properties` file](http://pastie.org/8202165) (`online-mode` is set to false because the auth server was down for me.  I've also tested with it set to true.), installed the plugin, and gave myself a locked chest.  I then placed it and waited for it to decay.  The plugin caught the decay event, cancelled it, and the locked chest _did not_ decay.  I also tested with the plugin _not_ installed, and the locked chest _did_ decay.  No other plugins were installed, and no other configuration files were changed.

This plugin also has debugging output.

Plugin source:  http://code.s.zeid.me/lockedchestkeeper/src/ec3a6936ae2657c33bd88e9e234adca01c7f0e2d
Plugin binary:  http://code.s.zeid.me/lockedchestkeeper/downloads/LockedChests-0.1.jar
##### Relevant PR(s):

CB-1226 - https://github.com/Bukkit/CraftBukkit/pull/1226 - Fires the new `LockedChestDecayEvent`.
##### JIRA Ticket:

BUKKIT-122 - https://bukkit.atlassian.net/browse/BUKKIT-122
