### PR TITLE
[B] Reorder YAML Representers to prefer customs; Adds BUKKIT-4680

### DIFF
--- a/src/main/java/org/bukkit/configuration/file/YamlRepresenter.java
+++ b/src/main/java/org/bukkit/configuration/file/YamlRepresenter.java
@@ -8,13 +8,18 @@ import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.configuration.serialization.ConfigurationSerialization;
 
 import org.yaml.snakeyaml.nodes.Node;
+import org.yaml.snakeyaml.representer.Represent;
 import org.yaml.snakeyaml.representer.Representer;
 
 public class YamlRepresenter extends Representer {
 
     public YamlRepresenter() {
-        this.multiRepresenters.put(ConfigurationSection.class, new RepresentConfigurationSection());
-        this.multiRepresenters.put(ConfigurationSerializable.class, new RepresentConfigurationSerializable());
+        Map<Class<?>, Represent> reordered = new LinkedHashMap<Class<?>, Represent>();
+        reordered.put(ConfigurationSerializable.class, new RepresentConfigurationSerializable());
+        reordered.put(ConfigurationSection.class, new RepresentConfigurationSection());
+        reordered.putAll(this.multiRepresenters);
+        this.multiRepresenters.clear();
+        this.multiRepresenters.putAll(reordered);
     }
 
     private class RepresentConfigurationSection extends RepresentMap {


### PR DESCRIPTION
##### The Issue:

Currently, when inheriting a class or interface which SnakeYAML supplies a default Representer for (Number, List, Map, Set, Iterator, Object[], Date, Enum and Calendar *) implementing the ConfigurationSerializable interface will not allow customization of the serialization. The ConfigurationSerializable associated Representer will be ignored and the default one used instead.
##### Justification:

The ability to override the default representation will allow for increased formatting control in configuration files and increase intuitive developer interactions with the configuration serialization API by respecting the inheritance model Java is designed to support.
##### Breakdown:

[Bukkit does supply custom representers](https://github.com/Bukkit/Bukkit/blob/1.6.2-R0.1/src/main/java/org/bukkit/configuration/file/YamlRepresenter.java#L16-L17).  However, they are placed at the end of the collection and the [SnakeYAML code prioritizes them by order](http://code.google.com/p/snakeyaml/source/browse/src/main/java/org/yaml/snakeyaml/representer/BaseRepresenter.java?name=v1.9#49).

This commit reorders the representers to place the custom classes first in order to override the default representers.
##### Testing Results and Materials:

None yet.
##### Relevant PR(s):

None
##### JIRA Ticket:

[BUKKIT-4680](https://bukkit.atlassian.net/browse/BUKKIT-4680)
