### PR TITLE
[B] Use command block's world for /gamerule. Fixes BUKKIT-3274

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/GameRuleCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/GameRuleCommand.java
@@ -3,6 +3,8 @@ package org.bukkit.command.defaults;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang.Validate;
 import org.bukkit.ChatColor;
+import org.bukkit.block.Block;
+import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.util.StringUtil;
@@ -60,6 +62,14 @@ public class GameRuleCommand extends VanillaCommand {
             World world = ((HumanEntity) sender).getWorld();
             if (world != null) {
                 return world;
+            }
+        } else if (sender instanceof BlockCommandSender) {
+            Block block = ((BlockCommandSender) sender).getBlock();
+            if (block != null) {
+                World world = block.getWorld();
+                if (world != null) {
+                    return world;
+                }
             }
         }
 

--- a/src/main/java/org/bukkit/command/defaults/GameRuleCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/GameRuleCommand.java
@@ -64,13 +64,7 @@ public class GameRuleCommand extends VanillaCommand {
                 return world;
             }
         } else if (sender instanceof BlockCommandSender) {
-            Block block = ((BlockCommandSender) sender).getBlock();
-            if (block != null) {
-                World world = block.getWorld();
-                if (world != null) {
-                    return world;
-                }
-            }
+            return ((BlockCommandSender) sender).getBlock().getWorld();
         }
 
         return Bukkit.getWorlds().get(0);

--- a/src/main/java/org/bukkit/command/defaults/GameRuleCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/GameRuleCommand.java
@@ -3,7 +3,6 @@ package org.bukkit.command.defaults;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang.Validate;
 import org.bukkit.ChatColor;
-import org.bukkit.block.Block;
 import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;


### PR DESCRIPTION
### Issue

In vanilla, gamerules are global, across all worlds. Maps created for vanilla that use command blocks expect this behavior, which is broken when they are placed on a world that is not the default world (world #0).
### Breakdown

This commit fixes the /gamerule behavior for custom vanilla maps using command blocks when they are not on the default world.
It does not fix the issue of gamerules for non-default worlds not being changeable from the console; however, that is not covered by the Leaky ticket.
### Justification

This change mitigates the _unexpected behavior_ of a command block's /gamerule command not affecting the environment immediately around it.
### Links

Several of these tickets were closed as "Incomplete" or "Cannot Reproduce" due to the authors providing insufficent background, namely that the world was not world #0.
https://bukkit.atlassian.net/browse/BUKKIT-3274
https://bukkit.atlassian.net/browse/BUKKIT-3479
https://bukkit.atlassian.net/browse/BUKKIT-3276
https://bukkit.atlassian.net/browse/BUKKIT-3707
### Testing

Note that the Nether in these tests could be replaced by any secondary world provided by a plugin that does not override the `/gamerule` command.
1. Place `craftbukkit-1.6.2-R0.1.jar` and `craftbukkit-PR916.jar` in the same directory.
2. Start the BETA BUILD server, and join with a client.
3. Use the server console to op the client, then enter creative mode.
4. Grab obsidian, a flint & steel, and a lever, and execute `/give <player> 137`.
5. Place a command block, then power it with the lever.
6. Shut down the server, and edit `server.properties` so that `enable-command-block=true`.
7. Restart the server with the BETA BUILD, and rejoin with the same client.
8. Place another command block next to the first one, and another lever (such that neither lever powers both).
9. Fill the first block with: `gamerule keepInventory true`. Fill the second block with: `gamerule keepInventory false`. Place levers next to each command block. Call these blocks **A** (true) and **B** (false).
10. Pull the lever for **A**, and execute `/kill`. Note that you keep your items. Repeat this with **B**. Note that the items drop.
11. Build, light, and enter a Nether Portal.
12. Create an equivalent setup in the Nether. Call the `keepInventory true` command block **C** and the `false` block **D**.
13. Pull the lever for **C**, then execute `/kill` - note that you **do not keep your items**.
14. Back in the Overworld, acquire some items through the Creative menu, and execute `/kill` again. Note that you **KEEP your items** - despite that the last command block you triggered in the Overworld was **B** (which turned off keepInventory). This shows that the **C** command block, in the nether, affected the overworld.
15. Stop the server, start the PULL REQUEST BUILD server, and rejoin.
16. Repeat step 10 and verify that the results are the same.
17. Enter the Nether, and repeat step 10 with blocks **C** and **D**, reentering the Nether after each death. The expected result should be shown.

Results:
- Blocks **A** and **B** behave the same across both builds.
- Blocks **C** and **D** gain the desired behavior with this change.
