### PR TITLE
[B+C] Implement method to get arrow itemstack and cancel item consume in EntityShootBowEvent. Adds BUKKIT-4686

### DIFF
--- a/src/main/java/org/bukkit/event/entity/EntityShootBowEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityShootBowEvent.java
@@ -96,7 +96,7 @@ public class EntityShootBowEvent extends EntityEvent implements Cancellable {
     }
 
     /**
-     * Set whether the projectile ItemStack will be consumed in this event; this has no effect to a skeleton
+     * Sets whether the projectile ItemStack will be consumed in this event; this has no effect to a skeleton
      * 
      * @param cancel true if you wish to cancel projectile consumption
      */

--- a/src/main/java/org/bukkit/event/entity/EntityShootBowEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityShootBowEvent.java
@@ -19,6 +19,15 @@ public class EntityShootBowEvent extends EntityEvent implements Cancellable {
     private boolean cancelled;
     private boolean consumeCancelled;
 
+    @Deprecated
+    public EntityShootBowEvent(final LivingEntity shooter, final ItemStack bow, final Projectile projectile, final float force) {
+        super(shooter);
+        this.bow = bow;
+        this.projectile = projectile;
+        this.force = force;
+        this.projectileStack = null;
+    }
+    
     public EntityShootBowEvent(final LivingEntity shooter, final ItemStack bow, final ItemStack projectileStack, final Projectile projectile, final float force) {
         super(shooter);
         this.bow = bow;
@@ -42,9 +51,9 @@ public class EntityShootBowEvent extends EntityEvent implements Cancellable {
     }
 
     /**
-     * Gets the projectile ItemStack fired by the bow; is null if the shooter is a skeleton
+     * Gets the projectile ItemStack fired by the bow
      * 
-     * @return the projectile ItemStack involved in this event, or null
+     * @return the projectile ItemStack involved in this event
      */
     public ItemStack getProjectileStack() {
         return projectileStack;
@@ -82,7 +91,7 @@ public class EntityShootBowEvent extends EntityEvent implements Cancellable {
      * 
      * @return if the stack is being consumed
      */
-    public boolean isStackConsumeCancelled() {
+    public boolean isConsumingStack() {
         return consumeCancelled;
     }
 
@@ -91,7 +100,7 @@ public class EntityShootBowEvent extends EntityEvent implements Cancellable {
      * 
      * @param cancel true if you wish to cancel projectile consumption
      */
-    public void setStackConsumeCancelled(boolean cancel) {
+    public void setConsumingStack(boolean cancel) {
         consumeCancelled = cancel;
     }
 

--- a/src/main/java/org/bukkit/event/entity/EntityShootBowEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityShootBowEvent.java
@@ -13,13 +13,16 @@ import org.bukkit.inventory.ItemStack;
 public class EntityShootBowEvent extends EntityEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private final ItemStack bow;
+    private final ItemStack projectileStack;
     private Entity projectile;
     private final float force;
     private boolean cancelled;
+    private boolean consumeCancelled;
 
-    public EntityShootBowEvent(final LivingEntity shooter, final ItemStack bow, final Projectile projectile, final float force) {
+    public EntityShootBowEvent(final LivingEntity shooter, final ItemStack bow, final ItemStack projectileStack, final Projectile projectile, final float force) {
         super(shooter);
         this.bow = bow;
+        this.projectileStack = projectileStack;
         this.projectile = projectile;
         this.force = force;
     }
@@ -36,6 +39,15 @@ public class EntityShootBowEvent extends EntityEvent implements Cancellable {
      */
     public ItemStack getBow() {
         return bow;
+    }
+
+    /**
+     * Gets the projectile ItemStack fired by the bow; is null if the shooter is a skeleton
+     * 
+     * @return the projectile ItemStack involved in this event, or null
+     */
+    public ItemStack getProjectileStack() {
+        return projectileStack;
     }
 
     /**
@@ -63,6 +75,24 @@ public class EntityShootBowEvent extends EntityEvent implements Cancellable {
      */
     public float getForce() {
         return force;
+    }
+
+    /**
+     * Gets whether the projectile ItemStack will be consumed in this event; this has no effect to a skeleton
+     * 
+     * @return if the stack is being consumed
+     */
+    public boolean isStackConsumeCancelled() {
+        return consumeCancelled;
+    }
+
+    /**
+     * Set whether the projectile ItemStack will be consumed in this event; this has no effect to a skeleton
+     * 
+     * @param cancel true if you wish to cancel projectile consumption
+     */
+    public void setStackConsumeCancelled(boolean cancel) {
+        consumeCancelled = cancel;
     }
 
     public boolean isCancelled() {


### PR DESCRIPTION
<b>The Issue:</b>

Currently it is not possible to get the projectiles itemstack or stop it being consumed in EntityShootBowEvent.

<b>Justification for this PR:</b>

This PR adds the above mentioned capabilities to the event, through 3 new methods. getProjectileStack(), setStackConsumeCancelled(boolean), and isStackConsumeCancelled(). This allows these 3 things to be done, which prior to now were just not plausible through the bukkit API.

The use case this was designed for, is CraftBook Elemental Arrows. They were conceptualized many months ago but never saw the light of day due to bukkit limitations. I needed to get lore and names off arrows, and somehow put them onto the appropriate arrow entities. This would allow me to get the stack, so that I can properly do this and finish the feature that has been sitting collecting dust for 6 months.

<b>PR Breakdown:</b>

This PR grabs a copy of the stack of the arrow before it is removed, and creates a clone of it. This clone is then given the count of 1 so that it is only a single arrow. This is then sent to the event.

The consume cancellation uses the 'flag' field, which currently is used by vanilla when the player is in creative or has the infinity enchantment. The PR is also capable or forcing a arrow to be consumed even in creative/infinity enchantment due to this.

<b>Testing Results and Materials:</b>

I created a small plugin that tests the features outlined in this PR. It is available here, http://pastebin.com/ghJ4LUNh

<b>Relevant PR(s):</b>

B-917 - https://github.com/Bukkit/Bukkit/pull/917
CB-1228 - https://github.com/Bukkit/CraftBukkit/pull/1228

<b>JIRA Ticket:</b>

BUKKIT-4686 - https://bukkit.atlassian.net/browse/BUKKIT-4686
