### PR TITLE
[B+C] Add block state to BlockFromToEvent. Used to add BUKKIT-2374

### DIFF
--- a/src/main/java/org/bukkit/event/block/BlockFromToEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockFromToEvent.java
@@ -2,6 +2,7 @@ package org.bukkit.event.block;
 
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
@@ -15,18 +16,21 @@ public class BlockFromToEvent extends BlockEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     protected Block to;
     protected BlockFace face;
+    protected BlockState newState;
     protected boolean cancel;
 
-    public BlockFromToEvent(final Block block, final BlockFace face) {
+    public BlockFromToEvent(final Block block, final BlockFace face, final BlockState newState) {
         super(block);
         this.face = face;
+        this.newState = newState;
         this.cancel = false;
     }
 
-    public BlockFromToEvent(final Block block, final Block toBlock) {
+    public BlockFromToEvent(final Block block, final Block toBlock, final BlockState newState) {
         super(block);
         this.to = toBlock;
         this.face = BlockFace.SELF;
+        this.newState = newState;
         this.cancel = false;
     }
 
@@ -37,6 +41,15 @@ public class BlockFromToEvent extends BlockEvent implements Cancellable {
      */
     public BlockFace getFace() {
         return face;
+    }
+
+    /**
+     * Gets the state the block will have.
+     *
+     * @return The state that the block will have
+     */
+    public BlockState getNewState() {
+        return newState;
     }
 
     /**

--- a/src/main/java/org/bukkit/event/block/BlockFromToEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockFromToEvent.java
@@ -35,6 +35,26 @@ public class BlockFromToEvent extends BlockEvent implements Cancellable {
     }
 
     /**
+     * Old constructor with BlockFace
+     *
+     * @deprecated use {@link BlockFromToEvent(Block, BlockFace, BlockStatus)} instead.
+     */
+    @Deprecated
+    public BlockFromToEvent(final Block block, final BlockFace face) {
+        this(block, face, null);
+    }
+
+    /**
+     * Old constructor with Block
+     *
+     * @deprecated use {@link BlockFromToEvent(Block, Block, BlockStatus)} instead.
+     */
+    @Deprecated
+    public BlockFromToEvent(final Block block, final Block toBlock) {
+        this(block, toBlock, null);
+    }
+
+    /**
      * Gets the BlockFace that the block is moving to.
      *
      * @return The BlockFace that the block is moving to

--- a/src/main/java/org/bukkit/event/block/BlockFromToEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockFromToEvent.java
@@ -37,7 +37,7 @@ public class BlockFromToEvent extends BlockEvent implements Cancellable {
     /**
      * Old constructor with BlockFace
      *
-     * @deprecated use {@link BlockFromToEvent(Block, BlockFace, BlockStatus)} instead.
+     * @deprecated use {@link BlockFromToEvent(Block, BlockFace, BlockState)} instead.
      */
     @Deprecated
     public BlockFromToEvent(final Block block, final BlockFace face) {
@@ -47,7 +47,7 @@ public class BlockFromToEvent extends BlockEvent implements Cancellable {
     /**
      * Old constructor with Block
      *
-     * @deprecated use {@link BlockFromToEvent(Block, Block, BlockStatus)} instead.
+     * @deprecated use {@link BlockFromToEvent(Block, Block, BlockState)} instead.
      */
     @Deprecated
     public BlockFromToEvent(final Block block, final Block toBlock) {

--- a/src/main/java/org/bukkit/event/block/BlockFromToEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockFromToEvent.java
@@ -54,9 +54,9 @@ public class BlockFromToEvent extends BlockEvent implements Cancellable {
     }
 
     /**
-     * Gets the BlockState the new block will have.
+     * Gets the BlockState the new block will have or null if unknown.
      *
-     * @return The BlockState the new block will have
+     * @return The BlockState the new block will have or null if unknown
      */
     public BlockState getNewState() {
         return newState;

--- a/src/main/java/org/bukkit/event/block/BlockFromToEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockFromToEvent.java
@@ -19,6 +19,16 @@ public class BlockFromToEvent extends BlockEvent implements Cancellable {
     protected BlockState newState;
     protected boolean cancel;
 
+    @Deprecated
+    public BlockFromToEvent(final Block block, final BlockFace face) {
+        this(block, face, null);
+    }
+
+    @Deprecated
+    public BlockFromToEvent(final Block block, final Block toBlock) {
+        this(block, toBlock, null);
+    }
+
     public BlockFromToEvent(final Block block, final BlockFace face, final BlockState newState) {
         super(block);
         this.face = face;
@@ -35,26 +45,6 @@ public class BlockFromToEvent extends BlockEvent implements Cancellable {
     }
 
     /**
-     * Old constructor with BlockFace
-     *
-     * @deprecated use {@link BlockFromToEvent(Block, BlockFace, BlockState)} instead.
-     */
-    @Deprecated
-    public BlockFromToEvent(final Block block, final BlockFace face) {
-        this(block, face, null);
-    }
-
-    /**
-     * Old constructor with Block
-     *
-     * @deprecated use {@link BlockFromToEvent(Block, Block, BlockState)} instead.
-     */
-    @Deprecated
-    public BlockFromToEvent(final Block block, final Block toBlock) {
-        this(block, toBlock, null);
-    }
-
-    /**
      * Gets the BlockFace that the block is moving to.
      *
      * @return The BlockFace that the block is moving to
@@ -64,9 +54,9 @@ public class BlockFromToEvent extends BlockEvent implements Cancellable {
     }
 
     /**
-     * Gets the state the block will have.
+     * Gets the BlockState the new block will have.
      *
-     * @return The state that the block will have
+     * @return The BlockState the new block will have
      */
     public BlockState getNewState() {
         return newState;


### PR DESCRIPTION
**The Issue:**

Plugins can't stop infinite water sources. (2x2 area of water sources never depletes)
When water flows and sends a BlockFromToEvent there is no data about the changed
data value (generally decreased by 1 for water). Plugins can't tell if water is just flowing
or if a new source block is created.

**Justification for this PR:**

BlockFromToEvent now includes the new block state, so plugins can
see exactly what will happen.

**PR Breakdown:**

Changed constructors of BlockFromToEvent to include BlockStates

**Plugin Example:**

``` javascript
@EventHandler
public void onBlockFromTo(BlockFromToEvent event) {
    Block block = event.getBlock();
    Block toBlock = event.getToBlock();
    BlockState newState = event.getNewState();

    if (newState.getType() == Material.STATIONARY_WATER || newState.getType() == Material.WATER) {
         if (newState.getRawData() == 0) // Source block
        {
            event.setCancelled(true);
            plugin.getLogger().info("Canceled water duplication event");
        }
    }
}
```

**Relevant PR(s):**

CraftBukkit side of this PR
CB-1167 https://github.com/Bukkit/CraftBukkit/pull/1167

(By ticket creator Ben Stern, results in 404)
https://github.com/Bukkit/CraftBukkit/pull/877

**JIRA Ticket:**

BUKKIT-2374 - https://bukkit.atlassian.net/browse/BUKKIT-2374
