### PR TITLE
[B] Allow external permission checking. Adds BUKKIT-4740

### DIFF
--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -688,7 +688,7 @@ public interface Server extends PluginMessageRecipient {
      *
      * @return The configured WarningState
      */
-    public WarningState getWarningState();
+    WarningState getWarningState();
 
     /**
      * Gets the instance of the item factory (for {@link ItemMeta}).

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -688,7 +688,7 @@ public interface Server extends PluginMessageRecipient {
      *
      * @return The configured WarningState
      */
-    WarningState getWarningState();
+    public WarningState getWarningState();
 
     /**
      * Gets the instance of the item factory (for {@link ItemMeta}).

--- a/src/main/java/org/bukkit/permissions/PermissibleBase.java
+++ b/src/main/java/org/bukkit/permissions/PermissibleBase.java
@@ -74,7 +74,7 @@ public class PermissibleBase implements Permissible {
             Permission perm = Bukkit.getServer().getPluginManager().getPermission(name);
 
             if (perm != null) {
-                return perm.getDefault().getValue(isOp());
+                return Bukkit.getServer().getPluginManager().getPermissionManager().checkPermission(this, perm);
             } else {
                 return Permission.DEFAULT_PERMISSION.getValue(isOp());
             }

--- a/src/main/java/org/bukkit/permissions/PermissionManager.java
+++ b/src/main/java/org/bukkit/permissions/PermissionManager.java
@@ -1,0 +1,25 @@
+package org.bukkit.permissions;
+
+/**
+ * Represents a plugin which handles permission checks for the server.
+ *
+ * This class should only be used if a plugin is explicitly granting
+ * or revoking access to permission nodes. It shouldn't be used for
+ * just "checking" permissions.
+ *
+ * The purpose of this class is to make life easier for permission
+ * plugin developers. Instead of using internals-breaking reflection
+ * or other hacky code to achieve their purposes, developers can just
+ * make their plugin hook into this class.
+ */
+public interface PermissionManager {
+
+    /**
+     * Used to check a permission.
+     * @param user The Permissible user to check the permission of.
+     * @param permission The permission to check for.
+     * @return Whether or not the specified Permissible has the given permission.
+     */
+    boolean checkPermission(Permissible user, Permission permission);
+
+}

--- a/src/main/java/org/bukkit/permissions/SuperPermissions.java
+++ b/src/main/java/org/bukkit/permissions/SuperPermissions.java
@@ -1,0 +1,12 @@
+package org.bukkit.permissions;
+
+/**
+ * Simple integrated permissions checker.
+ */
+public class SuperPermissions extends PermissionManager {
+
+    public boolean checkPermission(Permissible permissible, Permission permission) {
+        return permission.getDefault().getValue(permissible.isOp());
+    }
+
+}

--- a/src/main/java/org/bukkit/plugin/PluginManager.java
+++ b/src/main/java/org/bukkit/plugin/PluginManager.java
@@ -8,6 +8,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.permissions.Permissible;
 import org.bukkit.permissions.Permission;
+import org.bukkit.permissions.PermissionManager;
 
 /**
  * Handles all plugin management from the Server
@@ -272,4 +273,18 @@ public interface PluginManager {
      * @return True if event timings are to be used
      */
     public boolean useTimings();
+
+    /**
+     * Gets the current permission plugin.
+     * @return The permission plugin (SuperPermissions by default).
+     */
+    public PermissionManager getPermissionManager();
+
+    /**
+     * Sets the permission plugin to the one specified.
+     * @param manager The PermissionPlugin to make the permission handler.
+     * @throws IllegalArgumentException Thrown if plugin is null.
+     */
+    public void setPermissionManager(PermissionManager manager) throws IllegalArgumentException;
+
 }

--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -30,6 +30,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.permissions.Permissible;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
+import org.bukkit.permissions.PermissionManager;
 import org.bukkit.util.FileUtil;
 
 import com.google.common.collect.ImmutableSet;
@@ -49,6 +50,7 @@ public final class SimplePluginManager implements PluginManager {
     private final Map<String, Map<Permissible, Boolean>> permSubs = new HashMap<String, Map<Permissible, Boolean>>();
     private final Map<Boolean, Map<Permissible, Boolean>> defSubs = new HashMap<Boolean, Map<Permissible, Boolean>>();
     private boolean useTimings = false;
+    private PermissionManager permissionManager = new SuperPermissions();
 
     public SimplePluginManager(Server instance, SimpleCommandMap commandMap) {
         server = instance;
@@ -701,4 +703,15 @@ public final class SimplePluginManager implements PluginManager {
     public void useTimings(boolean use) {
         useTimings = use;
     }
+
+    public PermissionManager getPermissionManager() {
+        return permissionManager;
+    }
+
+    public void setPermissionManager(PermissionManager plugin) throws IllegalArgumentException {
+        if (plugin == null)
+            throw new IllegalArgumentException("Plugin cannot be null");
+        this.permissionManager = plugin;
+    }
+
 }

--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -709,8 +709,7 @@ public final class SimplePluginManager implements PluginManager {
     }
 
     public void setPermissionManager(PermissionManager plugin) throws IllegalArgumentException {
-        if (plugin == null)
-            throw new IllegalArgumentException("Plugin cannot be null");
+        Validate.notNull(plugin, "Plugin cannot be null");
         this.permissionManager = plugin;
     }
 


### PR DESCRIPTION
This pull request allows the permission-checking process to be modified externally by working _with_ the built-in permissions system instead of against it.
## Justification

Ever since Bukkit introduced permissions, working in permission checks has been a tricky task for permission plugin developers. Most of the time, it involves some nasty reflection or other direct modification.

The intent of this addition is to make handling the permission check externally easier by introducing the PermissionManager interface. This interface has one method, <strong><code>checkPermission(Permissible, Permission)</code></strong> which returns a boolean value. The <strong><code>PluginManager</code></strong> must also store a <strong><code>PermissionManager</code></strong>which can be accessed with the <strong><code>getPermissionManager()</code></strong> method or changed with the <strong><code>setPermissionManager(PermissionManager)</code></strong> method. When instantiated, the SimplePluginManager class will use the new SuperPermissions class which implements PermissionManager.

PermissibleBase handles the check (the 'weird' line break does not exist in the actual code):

``` java
Permission perm = Bukkit.getServer().getPluginManager().getPermission(name);

if (perm != null) {
    return Bukkit.getServer().getPluginManager()
            .getPermissionManager().checkPermission(this, perm);
} else {
    return Permission.DEFAULT_PERMISSION.getValue(isOp());
}
```

CraftBukkit is not affected in any way.

This should hopefully make life a lot easier for permission plugin developers and other people wanting to take over the permission-checking process.
## Example

If a permissions plugin wants to control permissions checks, they can implement <strong><code>PermissionManager</code></strong> to do it. For example:

``` java
public class MyPermissionPlugin extends JavaPlugin implements PermissionManager {

    public void onEnable () {
        this.getServer().getPluginManager().setPermissionManager(this);
    }

    public boolean checkPermission (Permissible user, Permission permission) {
        // Code for checking permissions goes here.
    }

}
```

Much simpler than reflection, right?

See the JIRA ticket here: https://bukkit.atlassian.net/browse/BUKKIT-4740
