### PR TITLE
[B] Added method to check if Material is interactive. Adds BUKKIT-4747

### DIFF
--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -992,4 +992,50 @@ public enum Material {
                 return false;
         }
     }
+    
+    /**
+     * Check if the material is a block and is interactive
+     *
+     * @return True if this material is a block and is interactive
+     */
+    public boolean isInteractive() {
+        if (!isBlock()) {
+            return false;
+        }
+        switch (this) {
+            case DISPENSER:
+            case NOTE_BLOCK:
+            case BED_BLOCK:
+            case CHEST:
+            case WORKBENCH:
+            case FURNACE:
+            case BURNING_FURNACE:
+            case WOODEN_DOOR:
+            case LEVER:
+            case REDSTONE_ORE:
+            case STONE_BUTTON:
+            case JUKEBOX:
+            case CAKE_BLOCK:
+            case DIODE_BLOCK_ON:
+            case DIODE_BLOCK_OFF:
+            case TRAP_DOOR:
+            case FENCE_GATE:
+            case ENCHANTMENT_TABLE:
+            case BREWING_STAND:
+            case DRAGON_EGG:
+            case ENDER_CHEST:
+            case COMMAND:
+            case BEACON:
+            case WOOD_BUTTON:
+            case ANVIL:
+            case TRAPPED_CHEST:
+            case REDSTONE_COMPARATOR_ON:
+            case REDSTONE_COMPARATOR_OFF:
+            case HOPPER:
+            case DROPPER:
+                return true;
+            default:
+                return false;
+        }
+    }
 }

--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -992,7 +992,7 @@ public enum Material {
                 return false;
         }
     }
-    
+
     /**
      * Check if the material is a block and is interactive
      *


### PR DESCRIPTION
##### Justification:

Simple way to check if Material is interactive. If player interacts with block (chest, bed, door, anvil, comparator, lever etc.), you can easily test if material is interactive and for example cancel interaction.
Method does not check for blocks that need item for interaction, like grass block (use of bone meal creates tall grass), cauldron (use of empty bottle fill it with water or use of bucket with water fill cauldron), End Portal Frame (use of eye of ender activates portal), sapling (use of bone meal creates tree) etc.
##### PR Breakdown:

This PR is adding one new method that allows to test if Material is interactive, which means that player can interact with it by default.
##### JIRA Ticket:

[JIRA Ticket #4747](https://bukkit.atlassian.net/browse/BUKKIT-4747)
