### PR TITLE
[B] Added canceling of the VehicleMoveEvent

### DIFF
--- a/src/main/java/org/bukkit/event/vehicle/VehicleMoveEvent.java
+++ b/src/main/java/org/bukkit/event/vehicle/VehicleMoveEvent.java
@@ -2,13 +2,15 @@ package org.bukkit.event.vehicle;
 
 import org.bukkit.Location;
 import org.bukkit.entity.Vehicle;
+import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
 /**
  * Raised when a vehicle moves.
  */
-public class VehicleMoveEvent extends VehicleEvent {
+public class VehicleMoveEvent extends VehicleEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
+    private boolean cancelled;
     private final Location from;
     private final Location to;
 
@@ -37,6 +39,13 @@ public class VehicleMoveEvent extends VehicleEvent {
         return to;
     }
 
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
 
     @Override
     public HandlerList getHandlers() {


### PR DESCRIPTION
##### The Issue:

Currently, there is no way to cancel a vehicles movement.
##### Justification:

Some plugin developers(like me), need to prevent a Minecart from moving. If you teleported the Minecart, it would cause another VehicleMoveEvent making an infinite loop, which is bad.
##### Breakdown:

All this does is make the VehicleMoveEvent implement Cancellable and add the basic cancel stuff.
##### Testing Results and Materials:

Definitely works!
##### Relevant PR(s):

I found one but it wasn't following the proper guidelines.
##### JIRA Ticket:

BUKKIT-4753 - https://bukkit.atlassian.net/browse/BUKKIT-4753
