### PR TITLE
[B+C] Add a hurtEntities setter and getter to FallingBlock. Adds BUKKIT-4752

### DIFF
--- a/src/main/java/org/bukkit/entity/FallingBlock.java
+++ b/src/main/java/org/bukkit/entity/FallingBlock.java
@@ -45,4 +45,11 @@ public interface FallingBlock extends Entity {
      * @param drop true to break into an item when obstructed
      */
     void setDropItem(boolean drop);
+
+    /**
+     * Set if the falling block will damage entities it falls on
+     *
+     * @param flag true to deal damage
+     */
+    void setHurtEntities(boolean flag);
 }

--- a/src/main/java/org/bukkit/entity/FallingBlock.java
+++ b/src/main/java/org/bukkit/entity/FallingBlock.java
@@ -47,9 +47,16 @@ public interface FallingBlock extends Entity {
     void setDropItem(boolean drop);
 
     /**
+     * Get if the falling block will damage entities it falls on
+     *
+     * @return true if the falling block will deal damage
+     */
+    boolean getDamageEntities();
+
+    /**
      * Set if the falling block will damage entities it falls on
      *
-     * @param flag true to deal damage
+     * @param damageEntities true to deal damage
      */
-    void setHurtEntities(boolean flag);
+    void setDamageEntities(boolean damageEntities);
 }


### PR DESCRIPTION
##### The Issue:

There is no current way to set FallingBlock's hurtEntities field without accessing NMS, so there is no way to, for instance, spawn a falling anvil that will damage the player.
##### Justification for this PR:

With this addition plugins will be able to set hurtEntities through Bukkit API.
##### PR Breakdown:

This PR adds two new methods (getDamageEntities and setDamageEntities) to the FallingBlock interface in Bukkit, and implements these methods in CraftFallingSand in CraftBukkit. Additionally it makes hurtEntities field public instead of private in EntityFallingSand.
##### Testing Results and Materials:

Test plugin code: https://gist.github.com/YaLTeR/6509037
Test plugin JAR: http://www.mediafire.com/?dwlcwv2n31zncjz

Test plugin commands:
/hetester nohurt - spawns an anvil ontop of you that does not hurt you.
/hetester hurt - spawns an anvil ontop of you that does hurt you (made using the API method from this PR).
##### Relevant PR(s):

B-927 - https://github.com/Bukkit/Bukkit/pull/927 - the new API method.
CB-1243 - https://github.com/Bukkit/CraftBukkit/pull/1243 - the new API method implementation.
##### JIRA Ticket:

BUKKIT-4752 - https://bukkit.atlassian.net/browse/BUKKIT-4752
