### PR TITLE
[B+C] Addition argument to set title while creating custom inventory. Adds BUKKIT-4045

### DIFF
--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -619,6 +619,18 @@ public interface Server extends PluginMessageRecipient {
     Inventory createInventory(InventoryHolder owner, InventoryType type);
 
     /**
+     * Creates an empty inventory of the specified type. If the type is {@link InventoryType#CHEST},
+     * the new inventory has a size of 27; otherwise the new inventory has the normal size for
+     * its type.
+     *
+     * @param owner The holder of the inventory; can be null if there's no holder.
+     * @param type The type of inventory to create.
+     * @param title The title of the inventory, to be displayed when it is viewed.
+     * @return The new inventory.
+     */
+    Inventory createInventory(InventoryHolder owner, InventoryType type, String title);
+
+    /**
      * Creates an empty inventory of type {@link InventoryType#CHEST} with the specified size.
      *
      * @param owner The holder of the inventory; can be null if there's no holder.


### PR DESCRIPTION
##### The Issue:

There is no way to set title of custom inventory while creating it. On March 13 2013, Mojang added a way to set name for all containers using anvil. When block is placed and player opens it, you can see title set using anvil.
Today, there is still no way to do this using Bukkit API.
I am not talking about creating chest inventory, because there is already a way to do this, but not for custom inventory type.
##### Justification:

Allow developers to set custom inventory name. It's possible to do in vanilla Minecraft (even survival) and not using Bukkit.
##### PR Breakdown:

This PR is adding new method with additional argument allowing developers to set name of custom inventory type while creating it.
##### CraftBukkit PR:

[Bukkit/CraftBukkit#1244](https://github.com/Bukkit/CraftBukkit/pull/1244)
##### JIRA Ticket:

[JIRA Ticket #4045](https://bukkit.atlassian.net/browse/BUKKIT-4045)
