### PR TITLE
[B+C] Add method for getting target blocks using HashSet<Material> as opposed to HashSet<Byte> for transparent types. Adds BUKKIT-4799

### DIFF
--- a/src/main/java/org/bukkit/entity/LivingEntity.java
+++ b/src/main/java/org/bukkit/entity/LivingEntity.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.List;
 
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.potion.PotionEffect;
@@ -55,7 +56,7 @@ public interface LivingEntity extends Entity, Damageable {
      */
     @Deprecated
     public List<Block> getLineOfSight(HashSet<Byte> transparent, int maxDistance);
-    
+
     /**
      * Gets all blocks along the living entity's line of sight.
      * <p>
@@ -83,7 +84,7 @@ public interface LivingEntity extends Entity, Damageable {
      */
     @Deprecated
     public Block getTargetBlock(HashSet<Byte> transparent, int maxDistance);
-    
+
     /**
      * Gets the block that the living entity has targeted.
      *
@@ -110,7 +111,7 @@ public interface LivingEntity extends Entity, Damageable {
      */
     @Deprecated
     public List<Block> getLastTwoTargetBlocks(HashSet<Byte> transparent, int maxDistance);
-    
+
     /**
      * Gets the last two blocks along the living entity's line of sight.
      * <p>

--- a/src/main/java/org/bukkit/entity/LivingEntity.java
+++ b/src/main/java/org/bukkit/entity/LivingEntity.java
@@ -55,6 +55,21 @@ public interface LivingEntity extends Entity, Damageable {
      */
     @Deprecated
     public List<Block> getLineOfSight(HashSet<Byte> transparent, int maxDistance);
+    
+    /**
+     * Gets all blocks along the living entity's line of sight.
+     * <p>
+     * This list contains all blocks from the living entity's eye position
+     * to target inclusive.
+     *
+     * @param transparent HashSet containing all transparent block materials
+     *     (set to null for only air)
+     * @param maxDistance this is the maximum distance to scan (may be
+     *     limited by server by at least 100 blocks, no less)
+     * @return list containing all blocks along the living entity's line
+     *     of sight
+     */
+    public List<Block> getLineOfSight(HashSet<Material> transparent, int maxDistance);
 
     /**
      * Gets the block that the living entity has targeted.
@@ -68,6 +83,17 @@ public interface LivingEntity extends Entity, Damageable {
      */
     @Deprecated
     public Block getTargetBlock(HashSet<Byte> transparent, int maxDistance);
+    
+    /**
+     * Gets the block that the living entity has targeted.
+     *
+     * @param transparent HashSet containing all transparent block materials
+     *     (set to null for only air)
+     * @param maxDistance this is the maximum distance to scan
+     *     (may be limited by server by at least 100 blocks, no less)
+     * @return block that the living entity has targeted
+     */
+    public Block getTargetBlock(HashSet<Material> transparent, int maxDistance);
 
     /**
      * Gets the last two blocks along the living entity's line of sight.
@@ -84,6 +110,20 @@ public interface LivingEntity extends Entity, Damageable {
      */
     @Deprecated
     public List<Block> getLastTwoTargetBlocks(HashSet<Byte> transparent, int maxDistance);
+    
+    /**
+     * Gets the last two blocks along the living entity's line of sight.
+     * <p>
+     * The target block will be the last block in the list.
+     *
+     * @param transparent HashSet containing all transparent block materials
+     *     (set to null for only air)
+     * @param maxDistance this is the maximum distance to scan. This may be
+     *     further limited by the server, but never to less than 100 blocks
+     * @return list containing the last 2 blocks along the living entity's
+     *     line of sight
+     */
+    public List<Block> getLastTwoTargetBlocks(HashSet<Material> transparent, int maxDistance);
 
     /**
      * Throws an egg from the living entity.

--- a/src/main/java/org/bukkit/entity/LivingEntity.java
+++ b/src/main/java/org/bukkit/entity/LivingEntity.java
@@ -70,7 +70,7 @@ public interface LivingEntity extends Entity, Damageable {
      * @return list containing all blocks along the living entity's line
      *     of sight
      */
-    public List<Block> getLineOfSight(HashSet<Material> transparent, int maxDistance);
+    public List<Block> getSightLine(HashSet<Material> transparent, int maxDistance);
 
     /**
      * Gets the block that the living entity has targeted.
@@ -94,7 +94,7 @@ public interface LivingEntity extends Entity, Damageable {
      *     (may be limited by server by at least 100 blocks, no less)
      * @return block that the living entity has targeted
      */
-    public Block getTargetBlock(HashSet<Material> transparent, int maxDistance);
+    public Block getTargetedBlock(HashSet<Material> transparent, int maxDistance);
 
     /**
      * Gets the last two blocks along the living entity's line of sight.
@@ -124,7 +124,7 @@ public interface LivingEntity extends Entity, Damageable {
      * @return list containing the last 2 blocks along the living entity's
      *     line of sight
      */
-    public List<Block> getLastTwoTargetBlocks(HashSet<Material> transparent, int maxDistance);
+    public List<Block> getLastTwoTargetedBlocks(HashSet<Material> transparent, int maxDistance);
 
     /**
      * Throws an egg from the living entity.


### PR DESCRIPTION
**Issue:**

With magic values deprecated, there's no way to currently get a LivingEntity's target block or blocks in line of sight without making your own method to do so.

**Justification:**

This makes it so instead of writing out a method yourself to get a target block or line of sight to avoid using deprecated methods, you can call it as before, albeit using materials as opposed to bytes, and hence no magic values.

**PR Breakdown:**

This PR adds methods to get target blocks using HashSet for transparent blocks

**CraftBukkit PR:**

Bukkit/CraftBukkit#1246

**JIRA Ticket:**

[JIRA Ticket #4799](https://bukkit.atlassian.net/browse/BUKKIT-4799)
