### PR TITLE
[B]Add EntityTeleportEvent cause. Adds BUKKIT-4745

### DIFF
--- a/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java
@@ -30,7 +30,7 @@ public class EntityPortalEvent extends EntityTeleportEvent {
         super(entity, from, to, cause);
         this.travelAgent = pta;
     }
-    
+
     /**
      * Sets whether or not the Travel Agent will be used.
      * <p>

--- a/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java
@@ -4,6 +4,7 @@ import org.bukkit.Location;
 import org.bukkit.TravelAgent;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 
 /**
  * Called when a non-player entity is about to teleport because it is in
@@ -16,8 +17,8 @@ public class EntityPortalEvent extends EntityTeleportEvent {
     protected boolean useTravelAgent = true;
     protected TravelAgent travelAgent;
 
-    public EntityPortalEvent(final Entity entity, final Location from, final Location to, final TravelAgent pta) {
-        super(entity, from, to);
+    public EntityPortalEvent(final Entity entity, final Location from, final Location to, final TravelAgent pta, TeleportCause cause) {
+        super(entity, from, to, cause);
         this.travelAgent = pta;
     }
 

--- a/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java
@@ -17,9 +17,6 @@ public class EntityPortalEvent extends EntityTeleportEvent {
     protected boolean useTravelAgent = true;
     protected TravelAgent travelAgent;
 
-    /*
-     * @Deprecated Super constructor deprecated: No teleport cause
-     */
     @Deprecated
     public EntityPortalEvent(final Entity entity, final Location from, final Location to, final TravelAgent pta) {
         super(entity, from, to);

--- a/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java
@@ -17,11 +17,20 @@ public class EntityPortalEvent extends EntityTeleportEvent {
     protected boolean useTravelAgent = true;
     protected TravelAgent travelAgent;
 
+    /*
+     * @Deprecated Super constructor deprecated: No teleport cause
+     */
+    @Deprecated
+    public EntityPortalEvent(final Entity entity, final Location from, final Location to, final TravelAgent pta) {
+        super(entity, from, to);
+        this.travelAgent = pta;
+    }
+
     public EntityPortalEvent(final Entity entity, final Location from, final Location to, final TravelAgent pta, TeleportCause cause) {
         super(entity, from, to, cause);
         this.travelAgent = pta;
     }
-
+    
     /**
      * Sets whether or not the Travel Agent will be used.
      * <p>

--- a/src/main/java/org/bukkit/event/entity/EntityPortalExitEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityPortalExitEvent.java
@@ -17,9 +17,6 @@ public class EntityPortalExitEvent extends EntityTeleportEvent {
     private Vector before;
     private Vector after;
 
-    /*
-     * @Deprecated Super constructor deprecated: No teleport cause
-     */
     @Deprecated
     public EntityPortalExitEvent(final Entity entity, final Location from, final Location to, final Vector before, final Vector after) {
         super(entity, from, to);

--- a/src/main/java/org/bukkit/event/entity/EntityPortalExitEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityPortalExitEvent.java
@@ -17,6 +17,16 @@ public class EntityPortalExitEvent extends EntityTeleportEvent {
     private Vector before;
     private Vector after;
 
+    /*
+     * @Deprecated Super constructor deprecated: No teleport cause
+     */
+    @Deprecated
+    public EntityPortalExitEvent(final Entity entity, final Location from, final Location to, final Vector before, final Vector after) {
+        super(entity, from, to);
+        this.before = before;
+        this.after = after;
+    }
+
     public EntityPortalExitEvent(final Entity entity, final Location from, final Location to, final Vector before, final Vector after, TeleportCause cause) {
         super(entity, from, to, cause);
         this.before = before;

--- a/src/main/java/org/bukkit/event/entity/EntityPortalExitEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityPortalExitEvent.java
@@ -3,21 +3,22 @@ package org.bukkit.event.entity;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.util.Vector;
 
 /**
  * Called before an entity exits a portal.
  * <p>
  * This event allows you to modify the velocity of the entity after they
- * have successfully exeted the portal.
+ * have successfully exited the portal.
  */
 public class EntityPortalExitEvent extends EntityTeleportEvent {
     private static final HandlerList handlers = new HandlerList();
     private Vector before;
     private Vector after;
 
-    public EntityPortalExitEvent(final Entity entity, final Location from, final Location to, final Vector before, final Vector after) {
-        super(entity, from, to);
+    public EntityPortalExitEvent(final Entity entity, final Location from, final Location to, final Vector before, final Vector after, TeleportCause cause) {
+        super(entity, from, to, cause);
         this.before = before;
         this.after = after;
     }

--- a/src/main/java/org/bukkit/event/entity/EntityTeleportEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityTeleportEvent.java
@@ -4,6 +4,7 @@ import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 
 /**
  * Thrown when a non-player entity (such as an Enderman) tries to teleport from one
@@ -14,12 +15,45 @@ public class EntityTeleportEvent extends EntityEvent implements Cancellable {
     private boolean cancel;
     private Location from;
     private Location to;
+    private TeleportCause cause = TeleportCause.UNKNOWN;
 
-    public EntityTeleportEvent(Entity what, Location from, Location to) {
+    public EntityTeleportEvent(Entity what, Location from, Location to, TeleportCause cause) {
         super(what);
         this.from = from;
         this.to = to;
         this.cancel = false;
+        this.cause = cause;
+    }
+
+    public TeleportCause getCause() {
+    	return cause;
+    }
+    
+    public enum TeleportCause {
+        /**
+         * Indicates the teleporation was caused by a player throwing an Ender Pearl
+         */
+        ENDER_PEARL,
+        /**
+         * Indicates the teleportation was caused by a player executing a command
+         */
+        COMMAND,
+        /**
+         * Indicates the teleportation was caused by a plugin
+         */
+        PLUGIN,
+        /**
+         * Indicates the teleportation was caused by a player entering a Nether portal
+         */
+        NETHER_PORTAL,
+        /**
+         * Indicates the teleportation was caused by a player entering an End portal
+         */
+        END_PORTAL,
+        /**
+         * Indicates the teleportation was caused by an event not covered by this enum
+         */
+        UNKNOWN;
     }
 
     public boolean isCancelled() {

--- a/src/main/java/org/bukkit/event/entity/EntityTeleportEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityTeleportEvent.java
@@ -17,9 +17,6 @@ public class EntityTeleportEvent extends EntityEvent implements Cancellable {
     private Location to;
     private TeleportCause cause = TeleportCause.UNKNOWN;
 
-    /*
-     * @Deprecated Added teleport cause 
-     */
     @Deprecated
     public EntityTeleportEvent(Entity what, Location from, Location to) {
         super(what);
@@ -38,33 +35,6 @@ public class EntityTeleportEvent extends EntityEvent implements Cancellable {
 
     public TeleportCause getCause() {
     	return cause;
-    }
-    
-    public enum TeleportCause {
-        /**
-         * Indicates the teleporation was caused by a player throwing an Ender Pearl
-         */
-        ENDER_PEARL,
-        /**
-         * Indicates the teleportation was caused by a player executing a command
-         */
-        COMMAND,
-        /**
-         * Indicates the teleportation was caused by a plugin
-         */
-        PLUGIN,
-        /**
-         * Indicates the teleportation was caused by a player entering a Nether portal
-         */
-        NETHER_PORTAL,
-        /**
-         * Indicates the teleportation was caused by a player entering an End portal
-         */
-        END_PORTAL,
-        /**
-         * Indicates the teleportation was caused by an event not covered by this enum
-         */
-        UNKNOWN;
     }
 
     public boolean isCancelled() {

--- a/src/main/java/org/bukkit/event/entity/EntityTeleportEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityTeleportEvent.java
@@ -17,6 +17,17 @@ public class EntityTeleportEvent extends EntityEvent implements Cancellable {
     private Location to;
     private TeleportCause cause = TeleportCause.UNKNOWN;
 
+    /*
+     * @Deprecated Added teleport cause 
+     */
+    @Deprecated
+    public EntityTeleportEvent(Entity what, Location from, Location to) {
+        super(what);
+        this.from = from;
+        this.to = to;
+        this.cancel = false;
+    }
+
     public EntityTeleportEvent(Entity what, Location from, Location to, TeleportCause cause) {
         super(what);
         this.from = from;


### PR DESCRIPTION
Issue
EntityTeleportEvent does not have any information about teleport cause, while PlayerTeleportEvent does.

Justification
This standardizes the capabilities of teleport events between players and entities. 

PR Breakdown
Added a teleport cause parameter to EntityTeleportEvent. Updated
relevant calls to constructors in child classes.

JIRA Ticket
https://bukkit.atlassian.net/browse/BUKKIT-4745
