### PR TITLE
It's "Minecraft" not "MineCraft"

### DIFF
--- a/src/main/java/org/bukkit/Sound.java
+++ b/src/main/java/org/bukkit/Sound.java
@@ -3,7 +3,7 @@ package org.bukkit;
 /**
  * An Enum of Sounds the server is able to send to players.
  * <p>
- * WARNING: At any time, sounds may be added/removed from this Enum or even MineCraft itself! There is no guarantee the sounds will play.
+ * WARNING: At any time, sounds may be added/removed from this Enum or even Minecraft itself! There is no guarantee the sounds will play.
  * There is no guarantee values will not be removed from this Enum. As such, you should not depend on the ordinal values of this class.
  */
 public enum Sound {


### PR DESCRIPTION
"Minecraft" was mispelt "MineCraft".
