### PR TITLE
[B+C] Add Ban Reason to "Vanilla" Bukkit - Fixes BUKKIT-4285

### DIFF
--- a/src/main/java/org/bukkit/OfflinePlayer.java
+++ b/src/main/java/org/bukkit/OfflinePlayer.java
@@ -34,6 +34,23 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
      * @param banned true if banned
      */
     public void setBanned(boolean banned);
+    
+    /**
+     * Bans or unbans this player
+     *
+     * @param banned true if banned
+     * @param banner who banned them
+     */
+    public void setBanned(boolean banned, String banner);
+    
+    /**
+     * Bans or unbans this player
+     *
+     * @param banned true if banned
+     * @param banner who banned them
+     * @param reason reason for banning
+     */
+    public void setBanned(boolean banned, String banner, String reason);
 
     /**
      * Checks if this player is whitelisted or not

--- a/src/main/java/org/bukkit/OfflinePlayer.java
+++ b/src/main/java/org/bukkit/OfflinePlayer.java
@@ -29,7 +29,7 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
     public boolean isBanned();
 
     /**
-     * Bans or unbans this player using default settings. For more settings use {@link #setBanned(boolean, String, String)}. Best for unbanning.
+     * Bans or unbans this player
      *
      * @param banned true if banned
      */

--- a/src/main/java/org/bukkit/OfflinePlayer.java
+++ b/src/main/java/org/bukkit/OfflinePlayer.java
@@ -36,7 +36,9 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
     public void setBanned(boolean banned);
 
     /**
-     * Bans or unbans this player using default reason. For more settings use {@link #setBanned(boolean, String, String)}. Banner will only be used if banning.
+     * Bans or unbans this player using default reason. To set a ban reason
+     * use {@link #setBanned(boolean, String, String)}. Banner will only be
+     * used if banning.
      *
      * @param banned true if banned
      * @param banner who banned them
@@ -44,7 +46,8 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
     public void setBanned(boolean banned, String banner);
 
     /**
-     * Bans or unbans this player. Banner and reason will only be used if banning.
+     * Bans or unbans this player. Banner and reason will only be used if
+     * passing true for banned.
      *
      * @param banned true if banned
      * @param banner who banned them

--- a/src/main/java/org/bukkit/OfflinePlayer.java
+++ b/src/main/java/org/bukkit/OfflinePlayer.java
@@ -29,22 +29,22 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
     public boolean isBanned();
 
     /**
-     * Bans or unbans this player
+     * Bans or unbans this player using default settings. For more settings use {@link #setBanned(boolean, String, String)}. Best for unbanning.
      *
      * @param banned true if banned
      */
     public void setBanned(boolean banned);
-    
+
     /**
-     * Bans or unbans this player
+     * Bans or unbans this player using default reason. For more settings use {@link #setBanned(boolean, String, String)}. Banner will only be used if banning.
      *
      * @param banned true if banned
      * @param banner who banned them
      */
     public void setBanned(boolean banned, String banner);
-    
+
     /**
-     * Bans or unbans this player
+     * Bans or unbans this player. Banner and reason will only be used if banning.
      *
      * @param banned true if banned
      * @param banner who banned them

--- a/src/main/java/org/bukkit/command/defaults/BanCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/BanCommand.java
@@ -29,11 +29,11 @@ public class BanCommand extends VanillaCommand {
         }
 
         if (args.length > 1){
-            StringBuilder reason = new StringBuilder();
-            for(int i = 1; i < args.length ; i++) {
-                reason.append(args[i]).append(" ");
+            StringBuilder reason = new StringBuilder(args[1]); 
+            for(int i = 2; i < args.length ; i++) {
+                reason.append(" ").append(args[i]);
             }
-            Bukkit.getOfflinePlayer(args[0]).setBanned(true,sender.getName(),reason.substring(0,reason.length()-1));
+            Bukkit.getOfflinePlayer(args[0]).setBanned(true,sender.getName(),reason.toString());
         } else {
             Bukkit.getOfflinePlayer(args[0]).setBanned(true,sender.getName());
         }

--- a/src/main/java/org/bukkit/command/defaults/BanCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/BanCommand.java
@@ -31,9 +31,9 @@ public class BanCommand extends VanillaCommand {
         if (args.length > 1){
             StringBuilder reason = new StringBuilder();
             for(String arg: args) {
-            	if(!arg.equals(args[0])) {
-                reason.append(arg + " ");
-            	}
+                if(!arg.equals(args[0])) {
+                    reason.append(arg + " ");
+                }
             }
             reason.replace(reason.lastIndexOf(" "), reason.lastIndexOf(" "), "");
             Bukkit.getOfflinePlayer(args[0]).setBanned(true, sender.getName(), reason.toString());

--- a/src/main/java/org/bukkit/command/defaults/BanCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/BanCommand.java
@@ -30,13 +30,10 @@ public class BanCommand extends VanillaCommand {
 
         if (args.length > 1){
             StringBuilder reason = new StringBuilder();
-            for(String arg: args) {
-                if(!arg.equals(args[0])) {
-                    reason.append(arg + " ");
-                }
+            for(int i=1; i<args.length; i++) {
+                reason.append(args[i]).append(" ");
             }
-            reason.replace(reason.lastIndexOf(" "), reason.lastIndexOf(" "), "");
-            Bukkit.getOfflinePlayer(args[0]).setBanned(true, sender.getName(), reason.toString());
+            Bukkit.getOfflinePlayer(args[0]).setBanned(true, sender.getName(), reason.substring(0, reason.length()-1));
         } else {
             Bukkit.getOfflinePlayer(args[0]).setBanned(true, sender.getName());
         }

--- a/src/main/java/org/bukkit/command/defaults/BanCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/BanCommand.java
@@ -34,9 +34,9 @@ public class BanCommand extends VanillaCommand {
             for(String arg: args) {
                 reason.append(arg + " ");
             }
-            Bukkit.getOfflinePlayer(args[0]).setBanned(true, reason, sender.getName());
+            Bukkit.getOfflinePlayer(args[0]).setBanned(true, sender.getName(), reason.toString());
         } else {
-            Bukkit.getOfflinePlayer(args[0]).setBanned(true);
+            Bukkit.getOfflinePlayer(args[0]).setBanned(true, sender.getName());
         }
         
 

--- a/src/main/java/org/bukkit/command/defaults/BanCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/BanCommand.java
@@ -30,12 +30,12 @@ public class BanCommand extends VanillaCommand {
 
         if (args.length > 1){
             StringBuilder reason = new StringBuilder();
-            for(int i=1; i<args.length; i++) {
+            for(int i=1;i<args.length;i++) {
                 reason.append(args[i]).append(" ");
             }
-            Bukkit.getOfflinePlayer(args[0]).setBanned(true, sender.getName(), reason.substring(0, reason.length()-1));
+            Bukkit.getOfflinePlayer(args[0]).setBanned(true,sender.getName(),reason.substring(0,reason.length()-1));
         } else {
-            Bukkit.getOfflinePlayer(args[0]).setBanned(true, sender.getName());
+            Bukkit.getOfflinePlayer(args[0]).setBanned(true,sender.getName());
         }
 
         Player player = Bukkit.getPlayer(args[0]);

--- a/src/main/java/org/bukkit/command/defaults/BanCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/BanCommand.java
@@ -32,7 +32,9 @@ public class BanCommand extends VanillaCommand {
         if (args.length > 2){
             StringBuilder reason = new StringBuilder();
             for(String arg: args) {
+            	if(!arg.equals(args[0])) { //skip adding player name to ban reason
                 reason.append(arg + " ");
+            	}
             }
             Bukkit.getOfflinePlayer(args[0]).setBanned(true, sender.getName(), reason.toString());
         } else {

--- a/src/main/java/org/bukkit/command/defaults/BanCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/BanCommand.java
@@ -28,11 +28,10 @@ public class BanCommand extends VanillaCommand {
             return false;
         }
 
-        // TA DAAAAAAA: Ban Reason support. Also, names :D
         if (args.length > 1){
             StringBuilder reason = new StringBuilder();
             for(String arg: args) {
-            	if(!arg.equals(args[0])) { //skip adding player name to ban reason
+            	if(!arg.equals(args[0])) {
                 reason.append(arg + " ");
             	}
             }
@@ -41,7 +40,6 @@ public class BanCommand extends VanillaCommand {
         } else {
             Bukkit.getOfflinePlayer(args[0]).setBanned(true, sender.getName());
         }
-        
 
         Player player = Bukkit.getPlayer(args[0]);
         if (player != null) {

--- a/src/main/java/org/bukkit/command/defaults/BanCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/BanCommand.java
@@ -1,6 +1,7 @@
 package org.bukkit.command.defaults;
 
 import java.util.List;
+import java.lang.StringBuilder;
 
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
@@ -27,8 +28,17 @@ public class BanCommand extends VanillaCommand {
             return false;
         }
 
-        // TODO: Ban Reason support
-        Bukkit.getOfflinePlayer(args[0]).setBanned(true);
+        // TA DAAAAAAA: Ban Reason support. Also, names :D
+        if (args.length > 2){
+            StringBuilder reason = new StringBuilder();
+            for(String arg: args) {
+                reason.append(arg + " ");
+            }
+            Bukkit.getOfflinePlayer(args[0]).setBanned(true, reason, sender.getName());
+        } else {
+            Bukkit.getOfflinePlayer(args[0]).setBanned(true);
+        }
+        
 
         Player player = Bukkit.getPlayer(args[0]);
         if (player != null) {

--- a/src/main/java/org/bukkit/command/defaults/BanCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/BanCommand.java
@@ -30,7 +30,7 @@ public class BanCommand extends VanillaCommand {
 
         if (args.length > 1){
             StringBuilder reason = new StringBuilder();
-            for(int i=1;i<args.length;i++) {
+            for(int i = 1; i < args.length ; i++) {
                 reason.append(args[i]).append(" ");
             }
             Bukkit.getOfflinePlayer(args[0]).setBanned(true,sender.getName(),reason.substring(0,reason.length()-1));

--- a/src/main/java/org/bukkit/command/defaults/BanCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/BanCommand.java
@@ -29,13 +29,14 @@ public class BanCommand extends VanillaCommand {
         }
 
         // TA DAAAAAAA: Ban Reason support. Also, names :D
-        if (args.length > 2){
+        if (args.length > 1){
             StringBuilder reason = new StringBuilder();
             for(String arg: args) {
             	if(!arg.equals(args[0])) { //skip adding player name to ban reason
                 reason.append(arg + " ");
             	}
             }
+            reason.replace(reason.lastIndexOf(" "), reason.lastIndexOf(" "), "");
             Bukkit.getOfflinePlayer(args[0]).setBanned(true, sender.getName(), reason.toString());
         } else {
             Bukkit.getOfflinePlayer(args[0]).setBanned(true, sender.getName());


### PR DESCRIPTION
**The Issue:**
Currently, there is no way to set the ban reason and banning player without using an external plugin.

**Justification:**
By having 1 less plugin to install this will increase (not by much) the server speed of many servers as they will no longer have to write to the databases that they use to store their own bans (which if they are using external servers, can become very laggy for muiltiple write requests)

**Breakdown:**
[C]This just added the required methods to keep current system working as well as new bans.
[B]This added the required changes to the ban command to parse reason and banning player.
[JD]This addresses changes to official javadoc for OfflinePlayer.setBanned - Closed

**Testing:**
Compiled server and started banning users with random reasons. Checked banned-players.txt for verification.
Also banned some with no reason to test if both options work.

**Relevant PR(s):**
https://github.com/Bukkit/CraftBukkit/pull/1250
https://github.com/Bukkit/Bukkit/pull/935
https://github.com/Bukkit/Bukkit-JavaDoc/pull/43 - Closed

**JIRA Ticket:**
https://bukkit.atlassian.net/browse/BUKKIT-4813 - Closed
https://bukkit.atlassian.net/browse/BUKKIT-4285 - Not mine but suits
