### PR TITLE
[B] Allow inheritance of getHandlerList method. Fixes BUKKIT-4816

### DIFF
--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -538,7 +538,7 @@ public final class SimplePluginManager implements PluginManager {
 
     private HandlerList getEventListeners(Class<? extends Event> type) {
         try {
-            Method method = getRegistrationClass(type).getDeclaredMethod("getHandlerList");
+            Method method = getRegistrationClass(type).getMethod("getHandlerList");
             method.setAccessible(true);
             return (HandlerList) method.invoke(null);
         } catch (Exception e) {


### PR DESCRIPTION
The Issue:
getHandlerList must be declared by the event class and cannot be inherited

Justification:
Allowing inheritance of the method can reduce the amount of code in a plugin which has lots of custom events. There may be a reason why getDeclaredMethod is preferred but I couldn't think of one. Relates to my forum post (http://forums.bukkit.org/threads/custom-events.179064/)

JIRA Ticket:
https://bukkit.atlassian.net/browse/BUKKIT-4816
