### PR TITLE
[B] Escape Unicode characters when dumping YAML. Fixes BUKKIT-1466

### DIFF
--- a/src/main/java/org/bukkit/configuration/file/YamlConfiguration.java
+++ b/src/main/java/org/bukkit/configuration/file/YamlConfiguration.java
@@ -30,6 +30,7 @@ public class YamlConfiguration extends FileConfiguration {
 
     @Override
     public String saveToString() {
+        yamlOptions.setAllowUnicode(false);
         yamlOptions.setIndent(options().indent());
         yamlOptions.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
         yamlRepresenter.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);


### PR DESCRIPTION
# The issue:

Bukkit's YAML library, SnakeYaml, defaults to outputting unescaped Unicode characters. This causes Bukkit to produce YAML files with characters replaced by question marks.
# Justification for this PR:

Implementing this change would ease plugin developers' work to support languages that use "special characters" and symbols.
# PR breakdown:

From SnakeYaml's documentation for setAllowUnicode():

> Specify whether to emit non-ASCII printable Unicode characters (to support ASCII terminals). The default value is true.

Setting this to false causes the Unicode characters to be escaped, and in turn Bukkit to produce a valid and loadable YAML file.
# Testing results and materials:

Loading this YAML file http://pastie.org/8380939 before applying this PR results in the following content once saveConfig() is invoked: http://pastie.org/8380940. Once the PR is applied, no apparent changes are made to the file upon saving.
# JIRA ticket

https://bukkit.atlassian.net/browse/BUKKIT-1466
