### PR TITLE
[B] Added .floor() method to Location - Adds BUKKIT-4827

### DIFF
--- a/src/main/java/org/bukkit/Location.java
+++ b/src/main/java/org/bukkit/Location.java
@@ -224,6 +224,19 @@ public class Location implements Cloneable {
     }
 
     /**
+     * Floors the x, y, and z values of the location.
+     * 
+     * @return the same location
+     */
+    public Location floor() {
+        x = locToBlock(x);
+        y = locToBlock(y);
+        z = locToBlock(z);
+
+        return this;
+    }
+
+    /**
      * Adds the location by another.
      *
      * @see Vector


### PR DESCRIPTION
The Issue:

No current method to convert Entity Location to a Block Location without having to either create a new Location or modify the Location with multiple conversion methods.

Justification for this PR:

This is a convenience method, similar to Location.getBlockX(), Location.getBlockY(), Location.getBlockZ() are convenience methods, except this method is a 1 liner and saves the data for use. Yes, a plugin developer could implement this in their own plugin, but they can also implement other convenience methods (like the three mentioned previously) too.

PR Breakdown:

Simply floors the x, y, and z values to the Location using Bukkit's already present NumberConversions() method and saves these values.

Testing Results and Materials:

Plugin source: http://pastebin.com/yrhNUXSK
Plugin jar: https://db.tt/yx1ubA9i
Plugin Output: http://pastebin.com/DFY3wc87

Relevant PR(s):

None that I could find.

JIRA Ticket:

BUKKIT-4827 - https://bukkit.atlassian.net/browse/BUKKIT-4827
