### PR TITLE
[B+C] Add API for respawning players. Adds BUKKIT-4029

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -721,4 +721,9 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      * @see Player#setHealthScaled(boolean)
      */
     public double getHealthScale();
+
+    /**
+     * Respawns the player if dead.
+     */
+    public void respawn();
 }


### PR DESCRIPTION
##### The Issue:

There is no way to respawn the player when he's dead.
##### Justification for this PR:

Existing methods to make the client skip the death screen are either clunky or use volatile internal code.
##### PR Breakdown:

A respawn() method is added to Player, which first checks whether or not they are actually dead and respawns them after verifying that they are not alive.

It calls PlayerRespawnEvent and everything if you wonder.

Adds respawn() method to Player.

``` java
    @Override
    public void respawn() {
        if (entity.dead) {
            server.getServer().getPlayerList().moveToWorld(getHandle(), 0, false);
        }
    }
```

You can also ask: why using this method and why I am sure it will work?
It is same code as from packet 205's handler, see https://github.com/Bukkit/mc-dev/blob/master/net/minecraft/server/PlayerConnection.java#L589
##### Testing:
##### Relevant PR(s):

Bukkit - https://github.com/Bukkit/Bukkit/pull/940  - Added API for this.
CraftBukkit - https://github.com/Bukkit/CraftBukkit/pull/1251 - Implemented new API method.
##### JIRA Ticket:

BUKKIT-4029 - https://bukkit.atlassian.net/browse/BUKKIT-4029
##### Pull Request Check List (For Your Use):

**General:**
- [x] Fits Bukkit's Goals
- [x] Leaky Ticket Ready
- [x] Code Meets Requirements
- [x] Code is Documented
- [x] Code Addresses Leaky Ticket
- [x] Followed Pull Request Format
- [x] Tested Code
- [x] Included Test Material and Source

**Example plugin:**

``` java
    // disables respawn screen
    @EventHandler(priority = EventPriority.LOWEST)
    public void onDeath(final PlayerDeathEvent ev) {
        Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, new Runnable() {
            public void run() {
                ev.getEntity().respawn();
            }
        });
    }
```
