### PR TITLE
[B+C+JD] Renamed velocity to direction in World.spawnArrow. Fixes BUKKIT-4838

### DIFF
--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -291,12 +291,12 @@ public interface World extends PluginMessageRecipient, Metadatable {
      * Creates an {@link Arrow} entity at the given {@link Location}
      *
      * @param location Location to spawn the arrow
-     * @param velocity Velocity to shoot the arrow in
+     * @param direction Direction to shoot the arrow in
      * @param speed Speed of the arrow. A recommend speed is 0.6
      * @param spread Spread of the arrow. A recommend spread is 12
      * @return Arrow entity spawned as a result of this method
      */
-    public Arrow spawnArrow(Location location, Vector velocity, float speed, float spread);
+    public Arrow spawnArrow(Location location, Vector direction, float speed, float spread);
 
     /**
      * Creates a tree at the given {@link Location}


### PR DESCRIPTION
**The Issue:**
Parameter velocity is actually a direction parameter. Speed is a separate parameter.

**Justification for this PR:**
Ambiguity of the meaning of the velocity parameter, and it is not named as what it actually is.

**PR Breakdown:**
[B+C+JD]: Changes any mention of velocity in `World.spawnArrow` to direction.

**Testing Results and Materials:**
Untested. Each change individually can operate on its own and does not break other components, and is fully backwards/forwards compatible.

**Relevant PR(s):**
C-1252 https://github.com/Bukkit/CraftBukkit/pull/1252 - Cross-repository change.
JD-44 https://github.com/Bukkit/Bukkit-JavaDoc/pull/44 - Cross-repository change.

**JIRA Ticket:**
BUKKIT-4838 https://bukkit.atlassian.net/browse/BUKKIT-4838
