### PR TITLE
[B+C] Add fire example to BlockFadeEvent javadoc- Fixes Bukkit-4835

### DIFF
--- a/src/main/java/org/bukkit/event/block/BlockFadeEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockFadeEvent.java
@@ -12,6 +12,7 @@ import org.bukkit.event.HandlerList;
  * <ul>
  * <li>Snow melting due to being near a light source.</li>
  * <li>Ice melting due to being near a light source.</li>
+ * <li>Fire burning out after time, without destroying fuel block.</li>
  * </ul>
  * <p>
  * If a Block Fade event is cancelled, the block will not fade, melt or disappear.

--- a/src/main/java/org/bukkit/event/block/BlockFadeEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockFadeEvent.java
@@ -12,7 +12,6 @@ import org.bukkit.event.HandlerList;
  * <ul>
  * <li>Snow melting due to being near a light source.</li>
  * <li>Ice melting due to being near a light source.</li>
- * <li>Fire burning out after time, without destroying fuel block.</li>
  * </ul>
  * <p>
  * If a Block Fade event is cancelled, the block will not fade, melt or disappear.


### PR DESCRIPTION
#### Description:
##### The Issue:

BlockFadeEvent is already called for flammable blocks fading out, but not for inflammable.
##### Justification for this PR:

Inform developers that BlockFadeEvent is being used for fire out.
##### PR Breakdown:

Also modified javaDocs for BlockFadeEvent to add fire example.
##### Testing Results and Materials:

not needed
##### Relevant PR(s):

C-1253-https://github.com/Bukkit/CraftBukkit/pull/1253 - add BlockFadeEvent call
##### JIRA Ticket:

BUKKIT-4835 - https://bukkit.atlassian.net/browse/BUKKIT-4835
