### PR TITLE
[B] Fix chat formatting bug

### DIFF
--- a/src/main/java/org/bukkit/command/Command.java
+++ b/src/main/java/org/bukkit/command/Command.java
@@ -345,7 +345,7 @@ public abstract class Command {
         }
 
         Set<Permissible> users = Bukkit.getPluginManager().getPermissionSubscriptions(Server.BROADCAST_CHANNEL_ADMINISTRATIVE);
-        String colored = ChatColor.GRAY + "" + ChatColor.ITALIC + "[" + result + ChatColor.GRAY + "]";
+        String colored = ChatColor.GRAY + "" + ChatColor.ITALIC + "[" + result + ChatColor.GRAY + ChatColor.ITALIC + "]";
 
         if (sendToSource && !(source instanceof ConsoleCommandSender)) {
             source.sendMessage(message);

--- a/src/main/java/org/bukkit/command/Command.java
+++ b/src/main/java/org/bukkit/command/Command.java
@@ -345,7 +345,7 @@ public abstract class Command {
         }
 
         Set<Permissible> users = Bukkit.getPluginManager().getPermissionSubscriptions(Server.BROADCAST_CHANNEL_ADMINISTRATIVE);
-        String colored = ChatColor.GRAY + "" + ChatColor.ITALIC + "[" + result + "]";
+        String colored = ChatColor.GRAY + "" + ChatColor.ITALIC + "[" + result + ChatColor.GRAY + "]";
 
         if (sendToSource && !(source instanceof ConsoleCommandSender)) {
             source.sendMessage(message);


### PR DESCRIPTION
The Issue:
For example, the /reload command, sends coloured message, however (as shown in the screenshot below) these colours are carried over to the ending "[" of the message. Making it unorganised

Justification for this PR:
The current message handling is unorganised. Example: http://puu.sh/4RmzV.png

PR Breakdown:
Self explanatory.

Testing Results and Materials:
I have not tested the code, but there is no reason for this to not work as it is straight forward.

https://bukkit.atlassian.net/browse/BUKKIT-4849
