### PR TITLE
[B] Allow permission-message to support chat formatting. Fixes BUKKIT-4857

### DIFF
--- a/src/main/java/org/bukkit/command/Command.java
+++ b/src/main/java/org/bukkit/command/Command.java
@@ -258,7 +258,7 @@ public abstract class Command {
      * @return Permission check failed message
      */
     public String getPermissionMessage() {
-        return permissionMessage;
+        return ChatColor.translateAlternateColorCodes('&', permissionMessage);
     }
 
     /**


### PR DESCRIPTION
The Issue:
In a plugin.yml the "permission-message" option does not support colour codes and chat formatting.

Justification for this PR:
Paragraphs providing justification for the PR

PR Breakdown:
Colourizing the permission-message

Testing Results and Materials:
As i am new to Maven this code has not been tested, so it may not provide the right results.

JIRA Ticket:

BUKKIT-4857 - https://bukkit.atlassian.net/browse/BUKKIT-4857
