### PR TITLE
Add a message for invalid sublevel parameters - Fixes BUKKIT-4860

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/ScoreboardCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/ScoreboardCommand.java
@@ -164,6 +164,9 @@ public class ScoreboardCommand extends VanillaCommand {
                         sender.sendMessage("Cleared objective display slot '" + slotName + "'");
                     }
                 }
+            } else {
+                sender.sendMessage(ChatColor.RED + "Usage: /scoreboard objectives <list|add|remove|setdisplay>");
+                return false;
             }
         } else if (args[0].equalsIgnoreCase("players")) {
             if (args.length == 1) {
@@ -261,6 +264,9 @@ public class ScoreboardCommand extends VanillaCommand {
                         }
                     }
                 }
+            } else {
+                sender.sendMessage(ChatColor.RED + "/scoreboard players <set|add|remove|reset|list>");
+                return false;
             }
         } else if (args[0].equalsIgnoreCase("teams")) {
             if (args.length == 1) {
@@ -469,6 +475,9 @@ public class ScoreboardCommand extends VanillaCommand {
                     }
                     sender.sendMessage("Set option " + option + " for team " + team.getName() + " to " + value);
                 }
+            } else {
+                sender.sendMessage(ChatColor.RED + "/scoreboard teams <list|add|remove|empty|join|leave|option>");
+                return false;
             }
         } else {
             sender.sendMessage(ChatColor.RED + "Usage: /scoreboard <objectives|players|teams>");

--- a/src/main/java/org/bukkit/command/defaults/ScoreboardCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/ScoreboardCommand.java
@@ -265,12 +265,12 @@ public class ScoreboardCommand extends VanillaCommand {
                     }
                 }
             } else {
-                sender.sendMessage(ChatColor.RED + "/scoreboard players <set|add|remove|reset|list>");
+                sender.sendMessage(ChatColor.RED + "Usage: /scoreboard players <set|add|remove|reset|list>");
                 return false;
             }
         } else if (args[0].equalsIgnoreCase("teams")) {
             if (args.length == 1) {
-                sender.sendMessage(ChatColor.RED + "/scoreboard teams <list|add|remove|empty|join|leave|option>");
+                sender.sendMessage(ChatColor.RED + "Usage: /scoreboard teams <list|add|remove|empty|join|leave|option>");
                 return false;
             }
             if (args[1].equalsIgnoreCase("list")) {
@@ -476,7 +476,7 @@ public class ScoreboardCommand extends VanillaCommand {
                     sender.sendMessage("Set option " + option + " for team " + team.getName() + " to " + value);
                 }
             } else {
-                sender.sendMessage(ChatColor.RED + "/scoreboard teams <list|add|remove|empty|join|leave|option>");
+                sender.sendMessage(ChatColor.RED + "Usage: /scoreboard teams <list|add|remove|empty|join|leave|option>");
                 return false;
             }
         } else {


### PR DESCRIPTION
The Issue:
A message is not sent for a invalid /scoreboard parametre, example
          /scoreboard players stuntguy3000

Justification for this PR:
To alert players that they used invalid syntax

PR Breakdown:
Adds an else statement to the checks for valid syntax

https://bukkit.atlassian.net/browse/BUKKIT-4860
