### PR TITLE
More accurately named method

### DIFF
--- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
+++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
@@ -30,9 +30,12 @@ public class PlayerDeathEvent extends EntityDeathEvent {
         this.newLevel = newLevel;
         this.deathMessage = deathMessage;
     }
-
+    
+    /**Get the player involved in this event
+     * @return Player involved in this event.
+     */
     @Override
-    public Player getEntity() {
+    public Player getPlayer() {
         return (Player) entity;
     }
 


### PR DESCRIPTION
Since the entity is caste as a player why name the method getEntity()? getPlayer() makes much more sense
