### PR TITLE
[B] Adds method PlayerDeathEvent.getPlayer() - Adds BUKKIT-4885

### DIFF
--- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
+++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
@@ -37,7 +37,7 @@ public class PlayerDeathEvent extends EntityDeathEvent {
     public Player getPlayer(){
         return (Player) entity;
     }
-    
+
     @Deprecated
     @Override
     /**

--- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
+++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
@@ -31,7 +31,20 @@ public class PlayerDeathEvent extends EntityDeathEvent {
         this.deathMessage = deathMessage;
     }
 
+    /**
+     * @return Player involved in this event
+     */
+    public Player getPlayer(){
+    	return (Player) entity;
+    }
+    
+    
+    
+    @Deprecated
     @Override
+    /**
+     * Deprecated - replaced by getPlayer() as it more accuratley describes the method.
+     */
     public Player getEntity() {
         return (Player) entity;
     }

--- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
+++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
@@ -32,7 +32,8 @@ public class PlayerDeathEvent extends EntityDeathEvent {
     }
 
     /**
-     * @return Player involved in this event
+     * Gets the Player that died in this event
+     * @return Player that died in this event
      */
     public Player getPlayer(){
         return (Player) entity;

--- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
+++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
@@ -41,7 +41,7 @@ public class PlayerDeathEvent extends EntityDeathEvent {
     @Deprecated
     @Override
     /**
-     * Deprecated - replaced by getPlayer() as it more accuratley describes the method.
+     * @deprecated  replaced by getPlayer() as it more accuratley describes the method.
      */
     public Player getEntity() {
         return (Player) entity;

--- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
+++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
@@ -35,10 +35,8 @@ public class PlayerDeathEvent extends EntityDeathEvent {
      * @return Player involved in this event
      */
     public Player getPlayer(){
-    	return (Player) entity;
+        return (Player) entity;
     }
-    
-    
     
     @Deprecated
     @Override


### PR DESCRIPTION
## The Issue:

PlayerDeathEvent may be thought to not have a getPlayer method and the getEntity method may be confused as something that does not in fact return the Player involved in the event.
## Justification for this PR:

This commit deprecates the somewhat confusing and inaccurately named method PlayerDeathEvent.getEntity() and replaces it with a more accurately names PlayerDeathEvent.getPlayer() as this method always returns a player so it should be named getPlayer() to reduce confusion.
## PR Breakdown:

getEntity() - deprecated so still possible for un updated code and to help reduce confusion
getPlayer() - new method to replace getEntity to cause lest confusion and a more accurately named method as the getEntity method always returns a player.
## Testing Results and Materials:

Testing using a arbitrary bukkit plugin to ensure that the code was working.
## JIRA Tickets:

https://bukkit.atlassian.net/browse/BUKKIT-4885
