### PR TITLE
Fixed PlayerFishEvent documentation

### DIFF
--- a/src/main/java/org/bukkit/event/player/PlayerFishEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerFishEvent.java
@@ -38,8 +38,8 @@ public class PlayerFishEvent extends PlayerEvent implements Cancellable {
 
     /**
      * Gets the entity caught by the player
-     *
-     * @return Entity caught by the player, null if fishing, bobber has gotten stuck in the ground or nothing has been caught
+     * If player has fished successfully, the result may be cast to {@link Item}.
+     * @return Entity caught by the player, Entity if fishing, and null if bobber has gotten stuck in the ground or nothing has been caught
      */
     public Entity getCaught() {
         return entity;


### PR DESCRIPTION
Method getCaught() actually returns an Item as Entity if fishing successful, not null.
