### PR TITLE
[B+C] Added event for item frame dropping item. Fixes BUKKIT-5020

### DIFF
--- a/src/main/java/org/bukkit/event/hanging/HangingFrameRemoveItemEvent.java
+++ b/src/main/java/org/bukkit/event/hanging/HangingFrameRemoveItemEvent.java
@@ -1,0 +1,48 @@
+package org.bukkit.event.hanging;
+
+import org.bukkit.entity.Hanging;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+
+public class HangingFrameRemoveItemEvent extends HangingEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancelled;
+    private ItemStack item;
+    private Player player;
+
+    public HangingFrameRemoveItemEvent(Hanging itemFrame, Player remover, ItemStack item) {
+        super(itemFrame);
+        cancelled = false;
+        this.item = item;
+        this.player = remover;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        cancelled = cancel;
+    }
+
+    public ItemStack getItem() {
+        return item;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+}

--- a/src/main/java/org/bukkit/event/hanging/HangingFrameRemoveItemEvent.java
+++ b/src/main/java/org/bukkit/event/hanging/HangingFrameRemoveItemEvent.java
@@ -1,5 +1,6 @@
 package org.bukkit.event.hanging;
 
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Hanging;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
@@ -10,13 +11,13 @@ public class HangingFrameRemoveItemEvent extends HangingEvent implements Cancell
     private static final HandlerList handlers = new HandlerList();
     private boolean cancelled;
     private ItemStack item;
-    private Player player;
+    private Entity entity;
 
-    public HangingFrameRemoveItemEvent(Hanging itemFrame, Player remover, ItemStack item) {
+    public HangingFrameRemoveItemEvent(Hanging itemFrame, Entity remover, ItemStack item) {
         super(itemFrame);
         cancelled = false;
         this.item = item;
-        this.player = remover;
+        this.entity = remover;
     }
 
     @Override
@@ -38,11 +39,21 @@ public class HangingFrameRemoveItemEvent extends HangingEvent implements Cancell
         cancelled = cancel;
     }
 
+    /**
+     * Gets the item being dropped from the item frame
+     *
+     * @return The ItemStack being dropped from the frame.
+     */
     public ItemStack getItem() {
         return item;
     }
 
-    public Player getPlayer() {
-        return player;
+    /**
+     * Gets the entity responsible for causing the item to be removed.
+     *
+     * @return The entity that caused the item to drop from the frame.
+     */
+    public Entity getRemover() {
+        return entity;
     }
 }


### PR DESCRIPTION
##### The Issue:

Minecraft 1.7 drops the item in the item frame first, without this event, world protection plugins have no way to protect against players stealing from item frames.
##### Justification for this PR:

With this PR, plugins now have an event that is fired when an item frame tries to drop an item that can be blocked by canceling it.
##### PR Breakdown:

This PR adds the code for the event to bukkit, in addition an implementation in CraftBukkit is provided. 
##### Testing Results and Materials:

I wrote a simple plugin that will simply cancel all events for item frames dropping items.
A jar containing both the compiled and source files is provided here: https://googledrive.com/host/0BzuEkOAtffh-VVVpbHk4bkZYRFE/HangingEventTest.jar
##### Relevant PR(s):

CB-1276 - https://github.com/Bukkit/CraftBukkit/pull/1276 - CraftBukkit component
##### JIRA Ticket:

BUKKIT-5020 - https://bukkit.atlassian.net/browse/BUKKIT-5020
