### PR TITLE
[B+C] Add new tree types for mega redwoods and tall birches. Adds BUKKIT-5042

### DIFF
--- a/src/main/java/org/bukkit/TreeType.java
+++ b/src/main/java/org/bukkit/TreeType.java
@@ -57,4 +57,12 @@ public enum TreeType {
      * Dark Oak tree.
      */
     DARK_OAK,
+    /**
+     * Mega redwood tree; 4 blocks wide and tall
+     */
+    MEGA_REDWOOD,
+    /**
+     * Tall birch tree
+     */
+    TALL_BIRCH,
 }


### PR DESCRIPTION
The Issue:
Minecraft 1.7 introduced new tree types. While the ACACIA and DARK_OAK were added to TreeType, mega redwood and tall birch were not.

Justification for this PR:
It should be possible for plugins to generate all tree types.

PR Breakdown:
This PR just adds the constants to the TreeType enum, the implementation is handled in the CB PR.

Testing Results and Materials:
See CB PR

Relevant PR:
CB-1277 - https://github.com/Bukkit/CraftBukkit/pull/1277

JIRA Ticket:
BUKKIT-5042 - https://bukkit.atlassian.net/browse/BUKKIT-5042
