### PR TITLE
[B] Strip OSX special characters from sign text. Fixes BUKKIT-5102

### DIFF
--- a/src/main/java/org/bukkit/event/block/SignChangeEvent.java
+++ b/src/main/java/org/bukkit/event/block/SignChangeEvent.java
@@ -19,7 +19,11 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
     public SignChangeEvent(final Block theBlock, final Player thePlayer, final String[] theLines) {
         super(theBlock);
         this.player = thePlayer;
-        this.lines = theLines;
+        lines = new String[theLines.length];
+
+        for (int i = 0; i < theLines.length; i++) {
+            setLine(i, theLines[i]);
+        }
     }
 
     /**
@@ -62,7 +66,13 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
      *     or < 0
      */
     public void setLine(int index, String line) throws IndexOutOfBoundsException {
-        lines[index] = line;
+        StringBuilder builder = new StringBuilder();
+        for (char c : line.toCharArray()) {
+            if (c < 0xF700 || c > 0xF747) {
+                builder.append(c);
+            }
+        }
+        lines[index] = builder.toString();
     }
 
     public boolean isCancelled() {


### PR DESCRIPTION
**The Issue**
On Mac OSX clients, pressing of certain special keys (including the arrow keys, F keys and several more) inserts special characters into sign text (while being edited, of course). This causes an issue with plugins attempting to parse the text, as they aren't expecting these characters, and may not match where it should. These characters are invisible to the client.

**Justification for this PR**
This PR fixes the issue by removing the special characters when the sign is created.

**PR Breakdown**
When a SignChangeEvent is called, it iterates through the lines and removes characters between 0xF000 and 0xF747. These characters are inserted by Mac, cannot be seen and break things.

**Testing results and materials**
I tested this by attempting to create an Essentials sign on both the latest version of Craftbukkit, and running this one, pressing the down arrow before closing the editor. Without this commit, the sign isn't recognized by the plugin and acts as a normal sign. With this commit, the special characters are skipped and the plugin behaves normally.

**Relevant PRs**
https://github.com/Bukkit/CraftBukkit/issues/1285 (closed )

**JIRA Ticket**
BUKKIT-5102 - https://bukkit.atlassian.net/browse/BUKKIT-5102
