### PR TITLE
[B+C] Add setKnockbackStrength for arrows. BUKKIT-5103

### DIFF
--- a/src/main/java/org/bukkit/entity/Arrow.java
+++ b/src/main/java/org/bukkit/entity/Arrow.java
@@ -3,4 +3,12 @@ package org.bukkit.entity;
 /**
  * Represents an arrow.
  */
-public interface Arrow extends Projectile {}
+public interface Arrow extends Projectile {
+	
+    /**
+   * Set the knockbackStrenght for an arrow. Must be nonnegative.
+   *
+   * @param knockbackStrength the punch level effect.
+   */
+  public void setKnockbackStrength(int knockbackStrength);	
+}

--- a/src/main/java/org/bukkit/entity/Arrow.java
+++ b/src/main/java/org/bukkit/entity/Arrow.java
@@ -5,10 +5,10 @@ package org.bukkit.entity;
  */
 public interface Arrow extends Projectile {
 	
-    /**
-   * Set the knockbackStrenght for an arrow. Must be nonnegative.
-   *
-   * @param knockbackStrength the punch level effect.
-   */
-  public void setKnockbackStrength(int knockbackStrength);	
+   /**
+    * Set the knockbackStrenght for an arrow. Must be nonnegative.
+    *
+    * @param knockbackStrength the punch level effect.
+    */
+   public void setKnockbackStrength(int knockbackStrength);
 }

--- a/src/main/java/org/bukkit/entity/Arrow.java
+++ b/src/main/java/org/bukkit/entity/Arrow.java
@@ -4,11 +4,18 @@ package org.bukkit.entity;
  * Represents an arrow.
  */
 public interface Arrow extends Projectile {
-	
-   /**
-    * Set the knockbackStrenght for an arrow. Must be nonnegative.
-    *
-    * @param knockbackStrength the punch level effect.
-    */
-   public void setKnockbackStrength(int knockbackStrength);
+
+	/**
+	 * Get the knockbackStrength for an arrow.
+	 * 
+	 * @return the knockbackStrength value.
+	 */
+	public int getKnockbackStrength();
+
+	/**
+	 * Set the knockbackStrength for an arrow. Must be nonnegative.
+	 * 
+	 * @param knockbackStrength the knockbackStrength value.
+	 */
+	public void setKnockbackStrength(int knockbackStrength);
 }


### PR DESCRIPTION
The Issue:
None: just add more stuff in the api.

Justification for this PR:
Less nms in plugins.

PR Breakdown:
Use the vanilla fonction setKnockbackStrength on arrow entity, must be positive (mc check that) and have no limits.

Relevant PR:
https://github.com/Bukkit/CraftBukkit/pull/1287

JIRA Ticket:
https://bukkit.atlassian.net/browse/BUKKIT-5103
