### PR TITLE
[B] Add new FishSpecies. Fixes BUKKIT-5097

### DIFF
--- a/src/main/java/org/bukkit/FishSpecies.java
+++ b/src/main/java/org/bukkit/FishSpecies.java
@@ -1,0 +1,66 @@
+package org.bukkit;
+
+import java.util.Map;
+
+import com.google.common.collect.Maps;
+
+/**
+ * Represents the different species of fish.
+ */
+public enum FishSpecies {
+
+    /**
+     * Represents the common fish species.
+     */
+    GENERIC(0x0),
+    /**
+     * Represents salmon.
+     */
+    SALMON(0x1),
+    /**
+     * Represents clownfish.
+     */
+    CLOWNFISH(0x2),
+    /**
+     * Represents pufferfish.
+     */
+    PUFFERFISH(0x3),
+    ;
+
+    private final byte data;
+    private final static Map<Byte, FishSpecies> BY_DATA = Maps.newHashMap();
+
+    private FishSpecies(final int data) {
+        this.data = (byte) data;
+    }
+
+    /**
+     * Gets the associated data value representing this species
+     *
+     * @return A byte containing the data value of this fish species
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public byte getData() {
+        return data;
+    }
+
+    /**
+     * Gets the FishSpecies with the given data value
+     *
+     * @param data Data value to fetch
+     * @return The {@link FishSpecies} representing the given value, or null if
+     *         it doesn't exist
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public static FishSpecies getByData(final byte data) {
+        return BY_DATA.get(data);
+    }
+
+    static {
+        for (FishSpecies species : values()) {
+            BY_DATA.put(species.data, species);
+        }
+    }
+}

--- a/src/main/java/org/bukkit/FishSpecies.java
+++ b/src/main/java/org/bukkit/FishSpecies.java
@@ -8,7 +8,6 @@ import com.google.common.collect.Maps;
  * Represents the different species of fish.
  */
 public enum FishSpecies {
-
     /**
      * Represents the common fish species.
      */

--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -13,6 +13,7 @@ import org.bukkit.material.Chest;
 import org.bukkit.material.Coal;
 import org.bukkit.material.CocoaPlant;
 import org.bukkit.material.Command;
+import org.bukkit.material.CookedFish;
 import org.bukkit.material.Crops;
 import org.bukkit.material.DetectorRail;
 import org.bukkit.material.Diode;
@@ -36,6 +37,7 @@ import org.bukkit.material.PoweredRail;
 import org.bukkit.material.PressurePlate;
 import org.bukkit.material.Pumpkin;
 import org.bukkit.material.Rails;
+import org.bukkit.material.RawFish;
 import org.bukkit.material.RedstoneTorch;
 import org.bukkit.material.RedstoneWire;
 import org.bukkit.material.Sandstone;
@@ -329,8 +331,8 @@ public enum Material {
     FISHING_ROD(346, 1, 64),
     WATCH(347),
     GLOWSTONE_DUST(348),
-    RAW_FISH(349),
-    COOKED_FISH(350),
+    RAW_FISH(349, RawFish.class),
+    COOKED_FISH(350, CookedFish.class),
     INK_SACK(351, Dye.class),
     BONE(352),
     SUGAR(353),

--- a/src/main/java/org/bukkit/material/CookedFish.java
+++ b/src/main/java/org/bukkit/material/CookedFish.java
@@ -1,5 +1,6 @@
 package org.bukkit.material;
 
+import org.apache.commons.lang.Validate;
 import org.bukkit.FishSpecies;
 import org.bukkit.Material;
 
@@ -62,6 +63,8 @@ public class CookedFish extends MaterialData {
      * @param species New species of this fish
      */
     public void setSpecies(FishSpecies species) {
+        Validate.notNull(species, "FishSpecies cannot be null");
+
         setData(species.getData());
     }
 

--- a/src/main/java/org/bukkit/material/CookedFish.java
+++ b/src/main/java/org/bukkit/material/CookedFish.java
@@ -1,0 +1,77 @@
+package org.bukkit.material;
+
+import org.bukkit.FishSpecies;
+import org.bukkit.Material;
+
+/**
+ * Represents the different types of Cooked Fish.
+ */
+public class CookedFish extends MaterialData {
+    public CookedFish() {
+        super(Material.COOKED_FISH);
+    }
+
+    public CookedFish(FishSpecies species) {
+        this();
+        setSpecies(species);
+    }
+
+    /**
+     *
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public CookedFish(final int type) {
+        super(type);
+    }
+
+    public CookedFish(final Material type) {
+        super(type);
+    }
+
+    /**
+     *
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public CookedFish(final int type, final byte data) {
+        super(type, data);
+    }
+
+    /**
+     *
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public CookedFish(final Material type, final byte data) {
+        super(type, data);
+    }
+
+    /**
+     * Gets the current species of this fish
+     *
+     * @return FishSpecies of this fish
+     */
+    public FishSpecies getSpecies() {
+        return FishSpecies.getByData(getData());
+    }
+
+    /**
+     * Sets the species of this fish
+     *
+     * @param species New species of this fish
+     */
+    public void setSpecies(FishSpecies species) {
+        setData(species.getData());
+    }
+
+    @Override
+    public String toString() {
+        return getSpecies() + " " + super.toString();
+    }
+
+    @Override
+    public CookedFish clone() {
+        return (CookedFish) super.clone();
+    }
+}

--- a/src/main/java/org/bukkit/material/RawFish.java
+++ b/src/main/java/org/bukkit/material/RawFish.java
@@ -1,5 +1,6 @@
 package org.bukkit.material;
 
+import org.apache.commons.lang.Validate;
 import org.bukkit.FishSpecies;
 import org.bukkit.Material;
 
@@ -62,6 +63,8 @@ public class RawFish extends MaterialData {
      * @param species New species of this fish
      */
     public void setSpecies(FishSpecies species) {
+        Validate.notNull(species, "FishSpecies cannot be null");
+
         setData(species.getData());
     }
 

--- a/src/main/java/org/bukkit/material/RawFish.java
+++ b/src/main/java/org/bukkit/material/RawFish.java
@@ -1,0 +1,77 @@
+package org.bukkit.material;
+
+import org.bukkit.FishSpecies;
+import org.bukkit.Material;
+
+/**
+ * Represents the different types of Raw Fish.
+ */
+public class RawFish extends MaterialData {
+    public RawFish() {
+        super(Material.RAW_FISH);
+    }
+
+    public RawFish(FishSpecies species) {
+        this();
+        setSpecies(species);
+    }
+
+    /**
+     *
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public RawFish(final int type) {
+        super(type);
+    }
+
+    public RawFish(final Material type) {
+        super(type);
+    }
+
+    /**
+     *
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public RawFish(final int type, final byte data) {
+        super(type, data);
+    }
+
+    /**
+     *
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public RawFish(final Material type, final byte data) {
+        super(type, data);
+    }
+
+    /**
+     * Gets the current species of this fish
+     *
+     * @return FishSpecies of this fish
+     */
+    public FishSpecies getSpecies() {
+        return FishSpecies.getByData(getData());
+    }
+
+    /**
+     * Sets the species of this fish
+     *
+     * @param species New species of this fish
+     */
+    public void setSpecies(FishSpecies species) {
+        setData(species.getData());
+    }
+
+    @Override
+    public String toString() {
+        return getSpecies() + " " + super.toString();
+    }
+
+    @Override
+    public RawFish clone() {
+        return (RawFish) super.clone();
+    }
+}


### PR DESCRIPTION
##### The Issue:

Currently there is no FishSpecies enum for the new fish species which got added in Minecraft 1.7 (Salmon, Pufferfish and Clownfish)
##### Justification for this PR:

Plugin authors should be able to check the fish species without manually checking the data values.
##### PR Breakdown:

This pull request adds a new class called FishSpecies and new material data classes for raw and cooked fish.
#### Testing Results and Materials:

Testing was successful, while fishing the correct fish species was broadcasted to the server.
[source](http://pastebin.com/46u4e2Kh) || [compiled](https://dl.dropboxusercontent.com/u/29178507/Dev/FishSpecies-Test.jar) || [server log](http://pastebin.com/ue6S0TQc)
##### JIRA Ticket:

BUKKIT-5097 - https://bukkit.atlassian.net/browse/BUKKIT-5097
