### PR TITLE
[B+C] Add player unique ID to (Async)PlayerPreLoginEvent. Adds BUKKIT-5108

### DIFF
--- a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
+++ b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
@@ -144,7 +144,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
     }
 
     /**
-     * Gets the players unique ID.
+     * Gets the player's unique ID.
      *
      * @return The unique ID
      */

--- a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
+++ b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
@@ -1,6 +1,7 @@
 package org.bukkit.event.player;
 
 import java.net.InetAddress;
+import java.util.UUID;
 
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -15,13 +16,20 @@ public class AsyncPlayerPreLoginEvent extends Event {
     private String message;
     private final String name;
     private final InetAddress ipAddress;
+    private final UUID uniqueId;
 
+    @Deprecated
     public AsyncPlayerPreLoginEvent(final String name, final InetAddress ipAddress) {
+        this(name, ipAddress, null);
+    }
+
+    public AsyncPlayerPreLoginEvent(final String name, final InetAddress ipAddress, final UUID uniqueId) {
         super(true);
         this.result = Result.ALLOWED;
         this.message = "";
         this.name = name;
         this.ipAddress = ipAddress;
+        this.uniqueId = uniqueId;
     }
 
     /**
@@ -133,6 +141,15 @@ public class AsyncPlayerPreLoginEvent extends Event {
      */
     public InetAddress getAddress() {
         return ipAddress;
+    }
+
+    /**
+     * Gets the players unique ID.
+     *
+     * @return The unique ID
+     */
+    public UUID getUniqueId() {
+        return uniqueId;
     }
 
     @Override

--- a/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java
@@ -113,7 +113,7 @@ public class PlayerPreLoginEvent extends Event {
     }
 
     /**
-     * Gets the players unique ID.
+     * Gets the player's unique ID.
      *
      * @return The unique ID
      */

--- a/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java
@@ -1,6 +1,7 @@
 package org.bukkit.event.player;
 
 import java.net.InetAddress;
+import java.util.UUID;
 
 import org.bukkit.Warning;
 import org.bukkit.event.Event;
@@ -18,12 +19,19 @@ public class PlayerPreLoginEvent extends Event {
     private String message;
     private final String name;
     private final InetAddress ipAddress;
+    private final UUID uniqueId;
 
+    @Deprecated
     public PlayerPreLoginEvent(final String name, final InetAddress ipAddress) {
+        this(name, ipAddress, null);
+    }
+
+    public PlayerPreLoginEvent(final String name, final InetAddress ipAddress, final UUID uniqueId) {
         this.result = Result.ALLOWED;
         this.message = "";
         this.name = name;
         this.ipAddress = ipAddress;
+        this.uniqueId = uniqueId;
     }
 
     /**
@@ -102,6 +110,15 @@ public class PlayerPreLoginEvent extends Event {
     @Override
     public HandlerList getHandlers() {
         return handlers;
+    }
+
+    /**
+     * Gets the players unique ID.
+     *
+     * @return The unique ID
+     */
+    public UUID getUniqueId() {
+        return uniqueId;
     }
 
     public static HandlerList getHandlerList() {


### PR DESCRIPTION
[B+C] Add player unique ID to AsyncPlayerPreLoginEvent. Adds BUKKIT-5108

The Issue:
Mojang is slowly migrating the identification of players from their name to their unique ID. For plugins it could be useful to have this UniqueID in a very early state of the connection process.

Justification for this PR:
AsyncPlayerPreLoginEvent is called in a very early state of the connection process. So it would be best to add the UniqueID to AsyncPlayerPreLoginEvent.
For instance a ban plugin could use the UniqueID to be aware of the future possibility to change user names.

PR Breakdown:
Added a new field and getter method for UniqueID. Also deprecated the old constructor and created a new one with the additional parameter.

Testing Results and Materials:
See CB PR

Relevant PR:
CB-1289 - https://github.com/Bukkit/CraftBukkit/pull/1289

JIRA Ticket:
BUKKIT-5108 - https://bukkit.atlassian.net/browse/BUKKIT-5108
