### PR TITLE
[B+C] Add setCritical and isCritical methods to Arrow.java, Adds BUKKIT-5113

### DIFF
--- a/src/main/java/org/bukkit/entity/Arrow.java
+++ b/src/main/java/org/bukkit/entity/Arrow.java
@@ -3,4 +3,20 @@ package org.bukkit.entity;
 /**
  * Represents an arrow.
  */
-public interface Arrow extends Projectile {}
+public interface Arrow extends Projectile {
+
+    /**
+     * Determines if this projectile is critical.
+     *
+     * @return true if it is critical.
+     */
+    public boolean isCritical();
+
+    /**
+     * Set whether or not this arrow should be critical.
+     *
+     * @param critical whether or not it should be critical.
+     */
+    public void setCritical(boolean critical);
+
+}


### PR DESCRIPTION
<b>The Issue:</b>

At the moment, the only way to create a "critical" arrow is by actually grabbing a bow and arrow, then drawing the string back all the way. There's no current method to force an arrow to become critical.

<b>Justification for this PR</b>

This pull request adds .setCritical(boolean critical) to arrows so you can force an arrow to be critical or not. It also adds a way to check if an arrow is already critical with .isCritical().

<b>PR Breakdown:</b>

By utilizing the .a(boolean flag) method in EntityArrow.java (from net/minecraft/server), the new .setCritical method provides a way to force a spawned-in arrow, or any arrow at all, to be "critical", which includes the particle effects and extra damage, as if you were using full force with a bow.

The new .isCritical method returns whether or not an arrow is already critical, by using EntityArrow.java's .f() method.

<b>Testing Results and Materials:</b>

I made a simple plugin, and it did exactly as expected. The compiled plugin and the source are provided here.
https://dl.dropboxusercontent.com/u/188921928/CriticalArrowTest.jar

When you use a bow to shoot a critical shot, the server announces that. You can also use /critarrow to shoot critical arrows.

<b>Relevant PR(s):</b>

CB-1291 - https://github.com/Bukkit/CraftBukkit/pull/1291

<b>JIRA Ticket:</b>

BUKKIT-5113 - https://bukkit.atlassian.net/browse/BUKKIT-5113
