### PR TITLE
[C+B] Add the player sample list to ServerListPingEvent. Fixes BUKKIT-5121.

### DIFF
--- a/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
+++ b/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
@@ -1,7 +1,9 @@
 package org.bukkit.event.server;
 
 import java.net.InetAddress;
+import java.util.List;
 
+import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.bukkit.util.CachedServerIcon;
 
@@ -14,12 +16,23 @@ public class ServerListPingEvent extends ServerEvent {
     private String motd;
     private final int numPlayers;
     private int maxPlayers;
+    private List<Player> playerSample;
 
+    /**
+     * 
+     * @deprecated Use {@link #ServerListPingEvent(InetAddress, String, int, int, List)}
+     */
     public ServerListPingEvent(final InetAddress address, final String motd, final int numPlayers, final int maxPlayers) {
+        this(address, motd, numPlayers, maxPlayers, null);
+    }
+    
+    
+    public ServerListPingEvent(final InetAddress address, final String motd, final int numPlayers, final int maxPlayers, final List<Player> playerSample) {
         this.address = address;
         this.motd = motd;
         this.numPlayers = numPlayers;
         this.maxPlayers = maxPlayers;
+        this.playerSample = playerSample;
     }
 
     /**
@@ -74,6 +87,14 @@ public class ServerListPingEvent extends ServerEvent {
      */
     public void setMaxPlayers(int maxPlayers) {
         this.maxPlayers = maxPlayers;
+    }
+    
+    /**
+     * Get the list of players to be sent to the client. 
+     * @return The sample of players
+     */
+    public List<Player> getPlayerSample(){
+        return this.playerSample;
     }
 
     /**


### PR DESCRIPTION
##### The Issue:

Hovering over the the amount of players online in the server list does not display the message which shows players currently logged into the server.
##### Justification for this PR:

This pull request fixes an issue where CraftBukkit lacks something the vanilla server has, and adds a hook for plugins to customize the list returned.
##### PR Breakdown:

The added code creates a new field in ServerListPingEvent, `playerSample`, and one method to access it, `getPlayerSample`. 

This PR is accompanied by a companion CraftBukkit PR. 
##### Testing Results and Materials:

Tested with small plugin that removes from the player list people who request it. Everything works as expected.
https://gist.github.com/nightpool/7922846
##### CraftBukkit PR:

CB-1294 - https://github.com/Bukkit/CraftBukkit/pull/1294
##### JIRA Ticket:

BUKKIT-5121 - https://bukkit.atlassian.net/browse/BUKKIT-5121
