### PR TITLE
[B+C] Added setWorldGenerator

### DIFF
--- a/src/main/java/org/bukkit/Bukkit.java
+++ b/src/main/java/org/bukkit/Bukkit.java
@@ -678,4 +678,11 @@ public final class Bukkit {
     public static CachedServerIcon loadServerIcon(BufferedImage image) throws Exception {
         return server.loadServerIcon(image);
     }
+
+    /**
+     * @see Server#setWorldGenerator()
+     */
+    public static void setWorldGenerator(String worldName, String generatorName) {
+        server.setWorldGenerator(worldName, generatorName);
+    }
 }

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -782,4 +782,12 @@ public interface Server extends PluginMessageRecipient {
      *     ServerListPingEvent#setServerIcon(CachedServerIcon)}
      */
     CachedServerIcon loadServerIcon(BufferedImage image) throws IllegalArgumentException, Exception;
+
+    /**
+     * Sets the generator for the specified world
+     * 
+     * @param Name of the world on which the generator is set
+     * @param Name of the generator
+     */
+    public void setWorldGenerator(String worldName, String generatorName);
 }


### PR DESCRIPTION
The Issue:

It is currently not possible to modify on server start the generator of a world from within a plugin.

Justification for this PR:

This adds a function to set the world generator of a world. Useful when the server owner does not know how to modify Bukkit.yml. It will reduce setup and debug time for server owners and reduce support time for plugin developpers.

PR Breakdown:

The PR adds a function to set the generator of a world in the configuration and then saves the configuration.

Testing Results and Materials:

I have modified both Bukkit and CraftBukkit on my machine and added a call from my plugin to the new function in this format:
getServer().setWorldGenerator(worldname, this.getName());

I tested it without any worlds section in the configuration and it correctly created the section and generated the world accordingly.
I also tested it when there is an existing section and existing world with existing generator. It correctly replaced the generator and generated the world accordingly.

CB-1302 - https://github.com/Bukkit/CraftBukkit/pull/1302 - To create the element in the API too

JIRA Ticket:
BUKKIT-5208 - https://bukkit.atlassian.net/browse/BUKKIT-5208

Pull Request Check List (For Your Use):

General:
- [x] Fits Bukkit's Goals
- [x] Leaky Ticket Ready
- [x] Code Meets Requirements
- [x] Code is Documented
- [x] Code Addresses Leaky Ticket
- [x] Followed Pull Request Format
- [x] Tested Code
- [x] Included Test Material and Source

If Applicable:
- [ ] Importing New Minecraft Classes In Special Commit
- [x] Follows Minimal Diff Policy
- [x] Uses Proper CraftBukkit Comments
- [x Imports Are Ordered, Separated and Organised Properly
