### PR TITLE
[B] Remove Deprecation of playSound(Location,String, Float, Float) - Adds BUKKIT #5243

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -236,9 +236,7 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      * @param sound the internal sound name to play
      * @param volume the volume of the sound
      * @param pitch the pitch of the sound
-     * @deprecated Magic value
      */
-    @Deprecated
     public void playSound(Location location, String sound, float volume, float pitch);
 
     /**


### PR DESCRIPTION
Remove Deprecation of playSound(Location, String, Float, Float)

The Issue:
In CraftBukkit 1.7, when using playSound(location, customSoundString, volume, pitch), the IDE shows the method as deprecated. However this method is an important part of the new ResourcePack support for custom sounds.

Justification for the PR:
This simple PR lets people use this method to play custom sounds without errors in their IDEs.

PR Breakdown:
-Remove @Deprecated annotation
-Remove mention of deprecation from method details

Testing:
Tested on Eclipse IDE and the 'deprecated' warning was gone.

Similar PRs:
-I do not believe there are any.

JIRA ticket:
#5243 - https://bukkit.atlassian.net/browse/BUKKIT-5243?filter=-2

Thank you for considering this PR.
