### PR TITLE
[B] Fix typo in ChannelNotRegisteredException. Fixes BUKKIT-5272

### DIFF
--- a/src/main/java/org/bukkit/plugin/messaging/ChannelNotRegisteredException.java
+++ b/src/main/java/org/bukkit/plugin/messaging/ChannelNotRegisteredException.java
@@ -10,6 +10,6 @@ public class ChannelNotRegisteredException extends RuntimeException {
     }
 
     public ChannelNotRegisteredException(String channel) {
-        super("Attempted to send a plugin message through an unregistered channel ('" + channel + "'.");
+        super("Attempted to send a plugin message through an unregistered channel ('" + channel + "').");
     }
 }


### PR DESCRIPTION
The Issue:
Small typo.

Justification for this PR:
Fix a typo?

https://bukkit.atlassian.net/browse/BUKKIT-5272
