### PR TITLE
Added isRepairable() to Material.java

### DIFF
--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -529,6 +529,69 @@ public enum Material {
         return id < 256;
     }
 
+	/**
+	 * Checks if this Material is repairable.
+	 * 
+	 * @return true if this Material is repairable.
+	 */
+	public boolean isRepairable() {
+		switch (this) {
+			case DIAMOND_AXE:
+			case DIAMOND_HOE:
+			case DIAMOND_PICKAXE:
+			case DIAMOND_SPADE:
+			case DIAMOND_SWORD:
+			case DIAMOND_HELMET:
+			case DIAMOND_CHESTPLATE:
+			case DIAMOND_LEGGINGS:
+			case DIAMOND_BOOTS:
+			case CHAINMAIL_HELMET:
+			case CHAINMAIL_CHESTPLATE:
+			case CHAINMAIL_LEGGINGS:
+			case CHAINMAIL_BOOTS:
+			case GOLD_AXE:
+			case GOLD_HOE:
+			case GOLD_PICKAXE:
+			case GOLD_SPADE:
+			case GOLD_SWORD:
+			case GOLD_HELMET:
+			case GOLD_CHESTPLATE:
+			case GOLD_LEGGINGS:
+			case GOLD_BOOTS:
+			case IRON_AXE:
+			case IRON_HOE:
+			case IRON_PICKAXE:
+			case IRON_SPADE:
+			case IRON_SWORD:
+			case IRON_HELMET:
+			case IRON_CHESTPLATE:
+			case IRON_LEGGINGS:
+			case IRON_BOOTS:
+			case STONE_AXE:
+			case STONE_HOE:
+			case STONE_PICKAXE:
+			case STONE_SPADE:
+			case STONE_SWORD:
+			case LEATHER_HELMET:
+			case LEATHER_CHESTPLATE:
+			case LEATHER_LEGGINGS:
+			case LEATHER_BOOTS:
+			case WOOD_AXE:
+			case WOOD_HOE:
+			case WOOD_PICKAXE:
+			case WOOD_SPADE:
+			case WOOD_SWORD:
+			case SHEARS:
+			case BOW:
+			case FISHING_ROD:
+			case CARROT_STICK:
+			case FLINT_AND_STEEL:
+				return true;
+			default:
+				return false;
+		}
+	}
+
     /**
      * Checks if this Material is edible.
      *


### PR DESCRIPTION
The Issue:

Developers cannot simply check if a Material is repairable.

Justification for this PR:

Plugins often have to check if the item's durability is correct, so players can't cheat the system (e.g. Player sells DIAMOND_SWORD with very little durability left for the same price as a full durability DIAMOND_SWORD). They can't however just check durability, because some blocks (e.g. WOOL) use it to determine properties other than durability. This fixes that issue by giving Developers a way to tell if the item they are dealing with has repairable durability (e.g. DIAMOND_SWORD), or if the durability is used as data (e.g. WOOL).

PR Breakdown:

This adds "isRepairable()" to Material.java. This returns true if the item can be repaired. Items can be repaired in two ways: Anvils and Crafting Tables. This is detailed at http://minecraft.gamepedia.com/Item_repair.

Testing Results and Materials:
None needed.
