### PR TITLE
[B+C] Add TeleportCause to EntityTeleportEvent. Adds BUKKIT-4745

### DIFF
--- a/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java
@@ -4,6 +4,7 @@ import org.bukkit.Location;
 import org.bukkit.TravelAgent;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 
 /**
  * Called when a non-player entity is about to teleport because it is in
@@ -16,8 +17,17 @@ public class EntityPortalEvent extends EntityTeleportEvent {
     protected boolean useTravelAgent = true;
     protected TravelAgent travelAgent;
 
+    /**
+     * @deprecated Use {@link #EntityPortalEvent(Entity, Location, Location, TravelAgent, TeleportCause)} instead
+     */
+    @Deprecated
     public EntityPortalEvent(final Entity entity, final Location from, final Location to, final TravelAgent pta) {
         super(entity, from, to);
+        this.travelAgent = pta;
+    }
+
+    public EntityPortalEvent(final Entity entity, final Location from, final Location to, final TravelAgent pta, final TeleportCause cause) {
+        super(entity, from, to, cause);
         this.travelAgent = pta;
     }
 

--- a/src/main/java/org/bukkit/event/entity/EntityPortalExitEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityPortalExitEvent.java
@@ -3,6 +3,7 @@ package org.bukkit.event.entity;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.util.Vector;
 
 /**
@@ -16,8 +17,18 @@ public class EntityPortalExitEvent extends EntityTeleportEvent {
     private Vector before;
     private Vector after;
 
+    /**
+     * @deprecated Use {@link #EntityPortalExitEvent(Entity, Location, Location, Vector, Vector, TeleportCause)} instead
+     */
+    @Deprecated
     public EntityPortalExitEvent(final Entity entity, final Location from, final Location to, final Vector before, final Vector after) {
         super(entity, from, to);
+        this.before = before;
+        this.after = after;
+    }
+
+    public EntityPortalExitEvent(final Entity entity, final Location from, final Location to, final Vector before, final Vector after, final TeleportCause cause) {
+        super(entity, from, to, cause);
         this.before = before;
         this.after = after;
     }

--- a/src/main/java/org/bukkit/event/entity/EntityTeleportEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityTeleportEvent.java
@@ -92,10 +92,6 @@ public class EntityTeleportEvent extends EntityEvent implements Cancellable {
          */
         ENDERMAN,
         /**
-         * Indicates the teleportation was caused by a plugin
-         */
-        PLUGIN,
-        /**
          * Indicates the teleportation was caused by an entity entering a
          * Nether portal
          */

--- a/src/main/java/org/bukkit/event/entity/EntityTeleportEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityTeleportEvent.java
@@ -14,12 +14,22 @@ public class EntityTeleportEvent extends EntityEvent implements Cancellable {
     private boolean cancel;
     private Location from;
     private Location to;
+    private TeleportCause cause;
 
+    /**
+     * @deprecated Use {@link #EntityTeleportEvent(Entity, Location, Location, TeleportCause)} instead
+     */
+    @Deprecated
     public EntityTeleportEvent(Entity what, Location from, Location to) {
+        this(what, from, to, TeleportCause.UNKNOWN);
+    }
+
+    public EntityTeleportEvent(Entity what, Location from, Location to, TeleportCause cause) {
         super(what);
         this.from = from;
         this.to = to;
         this.cancel = false;
+        this.cause = cause;
     }
 
     public boolean isCancelled() {
@@ -64,6 +74,43 @@ public class EntityTeleportEvent extends EntityEvent implements Cancellable {
      */
     public void setTo(Location to) {
         this.to = to;
+    }
+
+    /**
+     * Gets the cause for this entity teleportation
+     *
+     * @return Cause this entity teleported for
+     */
+    public TeleportCause getCause() {
+        return cause;
+    }
+
+    public enum TeleportCause {
+        /**
+         * Indicates the teleportation was caused by an Enderman teleporting
+         * himself
+         */
+        ENDERMAN,
+        /**
+         * Indicates the teleportation was caused by a plugin
+         */
+        PLUGIN,
+        /**
+         * Indicates the teleportation was caused by an entity entering a
+         * Nether portal
+         */
+        NETHER_PORTAL,
+        /**
+         * Indicates the teleportation was caused by an entity entering an End
+         * portal
+         */
+        END_PORTAL,
+        /**
+         * Indicates the teleportation was caused by an event not covered by
+         * this enum
+         */
+        UNKNOWN,
+        ;
     }
 
     @Override


### PR DESCRIPTION
Based on PR by @Obliv
### The Issue:

EntityTeleportEvent does not have any information about teleport cause, while PlayerTeleportEvent does.
### Justification for this PR:

This standardizes the capabilities of teleport events between players and entities.
### PR Breakdown:
##### Bukkit

Added a teleport cause parameter to EntityTeleportEvent. Updated relevant calls to constructors in child classes.
##### CraftBukkit

Updated calls to EntityTeleportEvent and sub-events
### Testing Results and Materials:

Test Plugin: [Code on Github](https://github.com/Ribesg/TestPlugin/tree/BUKKIT-4745) - [Latest build on Jenkins](http://ci.ribesg.fr/view/Bukkit-PRs/job/PR-BUKKIT-4745/lastSuccessfulBuild/artifact/out/TestPlugin.jar)
We're not allowed to link CB builds here, you'll have to clone & build it youself:

``` bash
git clone https://github.com/Ribesg/Bukkit.git -b BUKKIT-4745 && mvn install
git clone https://github.com/Ribesg/CraftBukkit.git -b BUKKIT-4745 && mvn package
```
### Relevant PR(s):

CB-1311 - https://github.com/Bukkit/CraftBukkit/pull/1311 - Associated CraftBukkit PR
B-931 - https://github.com/Bukkit/Bukkit/pull/931 - Original PR
### JIRA Ticket:

BUKKIT-4745 - https://bukkit.atlassian.net/browse/BUKKIT-4745
