### PR TITLE
Player Chat Event setFormat breaks when % is in message (Fixes Bukkit-5307)

### DIFF
--- a/src/main/java/org/bukkit/event/player/AsyncPlayerChatEvent.java
+++ b/src/main/java/org/bukkit/event/player/AsyncPlayerChatEvent.java
@@ -93,9 +93,8 @@ public class AsyncPlayerChatEvent extends PlayerEvent implements Cancellable {
      * @see String#format(String, Object...)
      */
     public void setFormat(final String format) throws IllegalFormatException, NullPointerException {
-        // Oh for a better way to do this!
         try {
-            String.format(format, player, message);
+            String.format(format, player, message.replace("%", "%%"));
         } catch (RuntimeException ex) {
             ex.fillInStackTrace();
             throw ex;

--- a/src/main/java/org/bukkit/event/player/PlayerChatEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerChatEvent.java
@@ -95,9 +95,8 @@ public class PlayerChatEvent extends PlayerEvent implements Cancellable {
      * @param format String.Format compatible format string
      */
     public void setFormat(final String format) {
-        // Oh for a better way to do this!
         try {
-            String.format(format, player, message);
+            String.format(format, player, message.replace("%", "%%"));
         } catch (RuntimeException ex) {
             ex.fillInStackTrace();
             throw ex;


### PR DESCRIPTION
The Issue:
String.format throws an IllegalFormatException when a % is in the message that is being formatted.

Justification for this PR:
This is a cheap workaround which fixes this bug.

https://bukkit.atlassian.net/browse/BUKKIT-5307
Relevant: http://stackoverflow.com/q/7429852/3106527
