### PR TITLE
[C+B] Material.DRAGON_EGG.hasGravity should return true. Fixes BUKKIT-5255

### DIFF
--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -1026,6 +1026,7 @@ public enum Material {
             case SAND:
             case GRAVEL:
             case ANVIL:
+            case DRAGON_EGG:
                 return true;
             default:
                 return false;


### PR DESCRIPTION
**The issue**
The Material.DRAGON_EGG.hasGravity() method currently returns false but should return true. See [wiki](http://minecraft.gamepedia.com/Dragon_Egg#Behavior).

**Justification for this PR**
Does it really need one?

**PR Breakdown**
Add the dragon egg to the list of blocks having gravity.

**Testing Results and Materials**
[Source](https://gist.github.com/8453276) - [Plugin](https://www.dropbox.com/s/reeuhjeg0s9rzgf/TestPlugin-1.0.jar)

**JIRA Ticket**
https://bukkit.atlassian.net/browse/BUKKIT-5255

**Associated Bukkit PR**
[Link](https://github.com/Bukkit/CraftBukkit/pull/1318)
