### PR TITLE
[B+C] Add BlockMultiPlaceEvent to handle 2 or more blocks.

### DIFF
--- a/src/main/java/org/bukkit/event/block/BlockMultiPlaceEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockMultiPlaceEvent.java
@@ -1,0 +1,34 @@
+package org.bukkit.event.block;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Called when two or more blocks are placed by a player.
+ * <p>
+ * If a Block Multi Place event is cancelled, the blocks will not be placed.
+ */
+public class BlockMultiPlaceEvent extends BlockPlaceEvent {
+    protected final List<BlockState> blockStates = new ArrayList<BlockState>();
+
+    public BlockMultiPlaceEvent(final List<BlockState> blockStates, final Block placedAgainst, final ItemStack itemInHand, final Player thePlayer, final boolean canBuild) {
+        super(blockStates.get(0).getBlock(), blockStates.get(0), placedAgainst, itemInHand, thePlayer, canBuild);
+        this.blockStates.addAll(blockStates);
+    }
+
+    /**
+     * Gets an immutable list of BlockStates for all blocks which were replaced. Material type air
+     * mostly.
+     *
+     * @return Immutable list of BlockStates for all blocks which were replaced.
+     */
+    public List<BlockState> getBlockStates() {
+        return Collections.unmodifiableList(this.blockStates);
+    }
+}


### PR DESCRIPTION
### The Issue:

Currently, BlockPlaceEvent only supports a single block but there are
situations where 2 or more blocks need to be sent to plugins such as with
an ItemBed.
### Justification for this PR:

Provide a single block event that supports 2 or more blocks. This allows items such as ItemBed to be handled properly by plugins.
Note: The first block added to this event will be passed to BlockPlaceEvent.
### PR Breakdown:

After an item is processed in Item.onPlace, if 2 or more blocks were captured, a single BlockMultiPlaceEvent will be called for plugins. If this event is cancelled, all blockstates will be reverted.
### Testing Results and Materials:

N/A
### Relevant PR(s):

https://github.com/Bukkit/CraftBukkit/pull/1313
