### PR TITLE
[B+C] Add support for reading and modifying chunk inhabited times.  Adds BUKKIT-5319

### DIFF
--- a/src/main/java/org/bukkit/Chunk.java
+++ b/src/main/java/org/bukkit/Chunk.java
@@ -121,4 +121,18 @@ public interface Chunk {
      * @return true if the chunk has unloaded successfully, otherwise false
      */
     boolean unload();
+    
+    /**
+     * Gets chunk inhabited tick count.  Affects various mob spawns and drops.
+     * 
+     * @return The total ticks chunk loaded due to player presence
+     */
+    long getInhabitedTime();
+    
+    /**
+     * Set chunk inhabited tick count.  Affects various mob spawns and drops.
+     * 
+     * @param inhabitedTime The new inhabited time, in ticks
+     */
+    void setInhabitedTime(long inhabitedTime);
 }

--- a/src/main/java/org/bukkit/ChunkSnapshot.java
+++ b/src/main/java/org/bukkit/ChunkSnapshot.java
@@ -126,4 +126,11 @@ public interface ChunkSnapshot {
      * @return true if empty, false if not
      */
     boolean isSectionEmpty(int sy);
+    
+    /**
+     * Gets chunk inhabited tick count.  Affects various mob spawns and drops.
+     * 
+     * @return The total ticks chunk loaded due to player presence
+     */
+    long getInhabitedTime();
 }


### PR DESCRIPTION
## The Issue:

Since v1.6.x, vanilla minecraft has incorporated a feature for maintaining a cumulative total time that each chunk has been kept loaded due to player presence. This data is not currently accessible via the Bukkit API.
## Justification for this PR:

The data offers a number of opportunities for mod developers, as a number of vanilla behaviors are driven by it:
1) Odds of armor on skeletons and zombies
2) Changes for enchantments on mob equipment
In addition, one can see other mods benefiting from similar considerations - boosting the chances of certain mod-specific activities based on how long a given area has been 'inhabited': possibly causing more mobs to be 'drawn' to the popular area, and the like.

The option to manipulate the value is of interest, as well, for the same reasons. Mods which allow an area to gradually act like it is no longer inhabited after being vacated, or which should act as though it has been inhabited for a long time (despite being newly created or edited), are both appealing possibilities.
## PR Breakdown:

Bukkit PR provides get/set method for Chunk interface, as well as get interface for ChunkSnapshot.  CraftBukkit PR provides simple implementation of these interfaces: the Chunk implementation is trivial, as it simply fetches or modifies the corresponding field in n.m.s.Chunk.  The ChunkSnapshot implementation uses the Chunk getter to provide a captured value during the snapshot process.
## Testing Results and Materials:

Produced test mod (source at https://github.com/mikeprimm/TestMod/tree/BUKKIT-5319, binary at https://github.com/mikeprimm/TestMod/raw/BUKKIT-5319/TestMod-BUKKIT5319.jar), verified reading and writing of values for Chunks and reading from ChunkSnapshots.  
## Relevant PR(s):

Bukkit/Bukkit#1009 (https://github.com/Bukkit/Bukkit/pull/1009)
Bukkit/CraftBukkit#1321 (https://github.com/Bukkit/CraftBukkit/pull/1321)
## JIRA Ticket:

BUKKIT-5319 (https://bukkit.atlassian.net/browse/BUKKIT-5319)
