### PR TITLE
[B+C] Adds a new getTemperature(x,y,z) method, to allow for height to be included in calculations. Fixes BUKKIT-5315

### DIFF
--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -835,13 +835,13 @@ public interface World extends PluginMessageRecipient, Metadatable {
     /**
      * Gets the temperature for the given block coordinates.
      * <p>
-     * It is safe to run this method when the block does not exist, it will
-     * not create the block.
+     * If the block does not exist at the given coordinates, it will
+     * return an estimate based off the world seed.
      *
-     * @param x X coordinate of the block
-     * @param y Y coordinate of the block
-     * @param z Z coordinate of the block
-     * @return Temperature of the requested block
+     * @param x The X coordinate of the block
+     * @param y The Y coordinate of the block
+     * @param z The Z coordinate of the block
+     * @return The temperature of the requested block
      */
     public double getTemperature(int x, int y, int z);
 

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -826,8 +826,24 @@ public interface World extends PluginMessageRecipient, Metadatable {
      * @param x X coordinate of the block
      * @param z Z coordinate of the block
      * @return Temperature of the requested block
+     * @deprecated Does not take into account the height of the world. Use {@link
+     *     #getTemperature(int, int, int) getTemperature} instead.
      */
+    @Deprecated
     public double getTemperature(int x, int z);
+
+    /**
+     * Gets the temperature for the given block coordinates.
+     * <p>
+     * It is safe to run this method when the block does not exist, it will
+     * not create the block.
+     *
+     * @param x X coordinate of the block
+     * @param y Y coordinate of the block
+     * @param z Z coordinate of the block
+     * @return Temperature of the requested block
+     */
+    public double getTemperature(int x, int y, int z);
 
     /**
      * Gets the humidity for the given block coordinates.

--- a/src/main/java/org/bukkit/block/Block.java
+++ b/src/main/java/org/bukkit/block/Block.java
@@ -329,7 +329,7 @@ public interface Block extends Metadatable {
     boolean isLiquid();
 
     /**
-     * Gets the temperature of the biome of this block
+     * Gets the temperature of this block
      *
      * @return Temperature of this block
      */


### PR DESCRIPTION
The Issue:

Prior to mc 1.7, temperatures were constant across a biome. The old method of temperature detection knew this, and therefore only allowed checking the x and z coordinates. As of 1.7, the temperature varies based on the Y axis, and the bukkit API does not allow checking of this changed temperature.

Justification for this PR:

This PR allows for plugins to accurately grab the temperature information for a specific block.

PR Breakdown:

This PR adds a new getTemperature method with the y coordinate as an argument, deprecates the old method, and makes Block.getTemperature() use the new method.

Testing Results and Materials:

Using this simple plugin, "TempTest", https://dl.dropboxusercontent.com/u/20806998/TempTest.jar
I was able to check the temperature of different blocks by right clicking them. I tested this mainly by making it snow, then going up to a height where it was snowing and right clicking, versus the same column lower.

Relevant PR(s):

B-1010 - https://github.com/Bukkit/Bukkit/pull/1010
CB-1322 - https://github.com/Bukkit/CraftBukkit/pull/1322

JIRA Ticket:

BUKKIT-5315 - https://bukkit.atlassian.net/browse/BUKKIT-5315
