### PR TITLE
[B+C] Added EntityPotionEffectChangeEvent. Adds BUKKIT-1535

### DIFF
--- a/src/main/java/org/bukkit/event/entity/EntityPotionEffectChangeEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityPotionEffectChangeEvent.java
@@ -1,0 +1,192 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.Location;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.potion.PotionEffect;
+
+/**
+ * Fired when a entity's potion effects change.
+ * <p>
+ * Causes for firing:
+ * <ul>
+ * <li>Beacon potion effect gained/lost</li>
+ * <li>Splash/edible potion effect gained/lost</li>
+ * <li>Plugin altered potion effect gained/lost</li>
+ * <li>Mob (Cave Spider, Zombie, Wither, etc) attacks entity</li>
+ * <li>The entity consumed a food item with vanilla effects (can trigger multiple events depending on item)</li>
+ * <li>The entity used a milk bucket to remove an effect</li>
+ * <li>The entity was cured of being a Zombie (triggers multiple events)</li>
+ * <li>The entity ate an Enchanted Golden Apple (triggers multiple events)</li>
+ * </ul>
+ */
+public class EntityPotionEffectChangeEvent extends EntityEvent implements Cancellable {
+    public static enum Cause {
+        /**
+         * Caused by vanilla Mob spawn, Enchantment effect, Mob attack, etc.
+         */
+        MOB,
+
+        /**
+         * Caused by a beacon block
+         */
+        BEACON,
+
+        /**
+         * Caused by a potion, splashed or consumed
+         */
+        POTION,
+
+        /**
+         * Cause by a food item
+         */
+        FOOD,
+
+        /**
+         * Caused by a golden apple
+         */
+        GOLDEN_APPLE,
+
+        /**
+         * Caused by an enchanted golden apple
+         */
+        ENCHANTED_GOLDEN_APPLE,
+
+        /**
+         * A plugin added the effect
+         */
+        PLUGIN_ADDED,
+
+        /**
+         * A plugin removed the effect
+         */
+        PLUGIN_REMOVED,
+
+        /**
+         * The effect expired (timer reached 0:00)
+         */
+        EXPIRED,
+
+        /**
+         * The effect was treated. Current examples:
+         * <p>
+         * <ul>
+         * <li>Player used milk bucket</li>
+         * <li>Villager cure process was started</li>
+         * </ul>
+         */
+        TREATED;
+    }
+
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancel = false;
+    private boolean ambient = false;
+    private PotionEffect effect;
+    private Cause cause;
+    private Location location;
+
+    /**
+     * Construct a new EntityPotionEffectChangeEvent
+     * @param who the entity being affected
+     * @param effect the effect
+     * @param cause the cause to be applied
+     * @param ambient true if ambient
+     * @param location the location of the event, if applicable
+     */
+    public EntityPotionEffectChangeEvent(LivingEntity who, PotionEffect effect, Cause cause, boolean ambient, Location location) {
+        super(who);
+        this.effect = effect;
+        this.cause = cause;
+        this.ambient = ambient;
+        this.location = location.clone();
+    }
+
+    /**
+     * Gets the source of the effect
+     * @return location of source
+     */
+    public Location getLocation() {
+        return location;
+    }
+
+    /**
+     * Gets the ambient flag for beacons. This will be false otherwise
+     * (unless set by a plugin)
+     * @return true if ambient
+     */
+    public boolean isAmbient() {
+        return ambient;
+    }
+
+    /**
+     * Sets the ambient flag
+     * @param ambient true if ambient
+     */
+    public void setAmbient(boolean ambient) {
+        this.ambient = ambient;
+    }
+
+    /**
+     * Gets the cause associated with this event
+     * @return the cause of the event
+     */
+    public Cause getCause() {
+        return cause;
+    }
+
+    /**
+     * Gets the potion effect applied to this event. Modifying this modifies
+     * the overall effect.
+     * <p>
+     * If the entity is going to lose the effect, modifying this has no
+     * effect.
+     * @return the potion effect
+     */
+    public PotionEffect getEffect() {
+        return effect;
+    }
+
+    /**
+     * Used to determine if the entity is gaining the effect.
+     * @return true if the entity is gaining the effect, false otherwise
+     */
+    public boolean isGainingEffect() {
+        switch (cause) {
+            case MOB:
+            case BEACON:
+            case POTION:
+            case FOOD:
+            case GOLDEN_APPLE:
+            case ENCHANTED_GOLDEN_APPLE:
+            case PLUGIN_ADDED:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    /**
+     * Sets the event as cancelled.
+     * <p>
+     * The event will only cancel if the entity is <b>gaining</b> the
+     * effect.
+     * @param cancel true to cancel, if valid
+     */
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}


### PR DESCRIPTION
**The Issue:**

There is no current way to handle when an entity (especially players) gain or lose a potion effect.

**Justification**

With this addition, plugins will be able to control further what potion effects players can have, or cannot have. This could be used within plot plugins to restrict beacons having an effect outside of the placed plot. Additional use can be to use beacon effect events to trigger adding additional effects.

**PR Breakdown:**

Thanks to @turt2live for handing me the PR.

This PR adds a new event for plugins to use. Within CraftBukkit there is implementation to handle gain/loss of effects.

**Testing Results / Materials:**

Plugin code used to test: https://github.com/gabizou/PotionsTest
Compiled Binary: https://dl.dropboxusercontent.com/u/9058563/PotionsTest.jar

Steps to apply cancel testing, type "/test". To revert, type "/test" again.

To apply a plugin-made effect, type "/test a"

**Associated PRs**

Bukkit: https://github.com/Bukkit/Bukkit/pull/1011
CraftBukkit [OLD]: https://github.com/Bukkit/CraftBukkit/pull/1324
CraftBukkit [NEW]: https://github.com/Bukkit/CraftBukkit/pull/1358

**JIRA Tickets**

Main ticket: https://bukkit.atlassian.net/browse/BUKKIT-5329
Subsequent (duplicate) tickets
https://bukkit.atlassian.net/browse/BUKKIT-2817
https://bukkit.atlassian.net/browse/BUKKIT-2361 
https://bukkit.atlassian.net/browse/BUKKIT-1535 
https://bukkit.atlassian.net/browse/BUKKIT-1778 
https://bukkit.atlassian.net/browse/BUKKIT-763
