### PR TITLE
[B] Added Location.to{World,Local}{Axis,}(Vector). Adds BUKKIT-5338

### DIFF
--- a/src/main/java/org/bukkit/Location.java
+++ b/src/main/java/org/bukkit/Location.java
@@ -563,9 +563,11 @@ public class Location implements Cloneable {
      * location into the world reference frame.
      * <p>
      * The following conditions apply:
-     * <li>X axis points to the left</li>
-     * <li>Y axis points upward</li>
-     * <li>Z axis points forward</li>
+     * <ul>
+     * <li>X axis points to the left
+     * <li>Y axis points upward
+     * <li>Z axis points forward
+     * </ul>
      *
      * @param axis a local-coordinate axis
      * @return a world-coordinate axis
@@ -605,9 +607,11 @@ public class Location implements Cloneable {
      * location.
      * <p>
      * The following conditions apply:
-     * <li>X axis points to the left</li>
-     * <li>Y axis points upward</li>
-     * <li>Z axis points forward</li>
+     * <ul>
+     * <li>X axis points to the left
+     * <li>Y axis points upward
+     * <li>Z axis points forward
+     * </ul>
      *
      * @param axis a world-coordinate axis
      * @return a local-coordinate axis
@@ -647,9 +651,11 @@ public class Location implements Cloneable {
      * location into the world reference frame.
      * <p>
      * The following conditions apply:
-     * <li>X axis points to the left</li>
-     * <li>Y axis points upward</li>
-     * <li>Z axis points forward</li>
+     * <ul>
+     * <li>X axis points to the left
+     * <li>Y axis points upward
+     * <li>Z axis points forward
+     * </ul>
      *
      * @param position a local-coordinate position
      * @return a world-coordinate position
@@ -663,9 +669,11 @@ public class Location implements Cloneable {
      * location.
      * <p>
      * The following conditions apply:
-     * <li>X axis points to the left</li>
-     * <li>Y axis points upward</li>
-     * <li>Z axis points forward</li>
+     * <ul>
+     * <li>X axis points to the left
+     * <li>Y axis points upward
+     * <li>Z axis points forward
+     * </ul>
      *
      * @param position a world-coordinate position
      * @return a local-coordinate position

--- a/src/main/java/org/bukkit/Location.java
+++ b/src/main/java/org/bukkit/Location.java
@@ -557,4 +557,106 @@ public class Location implements Cloneable {
     public static int locToBlock(double loc) {
         return NumberConversions.floor(loc);
     }
+
+    /**
+     * Transforms an axis from the local reference frame described by this
+     * location into the world reference frame.
+     * <p>
+     * x=left, y=up, z=forward
+     *
+     * @param axis a local-coordinate axis
+     * @return a world-coordinate axis
+     */
+    public Vector toWorldAxis(Vector axis) {
+        final double yaw = Math.toRadians(this.getYaw());
+        final double pitch = Math.toRadians(this.getPitch());
+
+        final double cosYaw = Math.cos(yaw);
+        final double sinYaw = Math.sin(yaw);
+        final double cosPitch = Math.cos(pitch);
+        final double sinPitch = Math.sin(pitch);
+
+        final Vector forward = new Vector(
+                -sinYaw*cosPitch,
+                -sinPitch,
+                cosYaw*cosPitch
+        );
+        final Vector up = new Vector(
+                -sinYaw*sinPitch,
+                cosPitch,
+                cosYaw*sinPitch
+        );
+        final Vector left = new Vector(
+                cosYaw,
+                0,
+                sinYaw
+        );
+
+        return left.multiply(axis.getX()).add(up.multiply(axis.getY())).add(forward.multiply(axis.getZ()));
+    }
+
+    /**
+     * Transforms an axis from the world reference frame into the local reference frame described by this
+     * location.
+     * <p>
+     * x=left, y=up, z=forward
+     *
+     * @param axis a world-coordinate axis
+     * @return a local-coordinate axis
+     */
+    public Vector toLocalAxis(Vector axis) {
+        final double yaw = Math.toRadians(this.getYaw());
+        final double pitch = Math.toRadians(this.getPitch());
+
+        final double cosYaw = Math.cos(yaw);
+        final double sinYaw = Math.sin(yaw);
+        final double cosPitch = Math.cos(pitch);
+        final double sinPitch = Math.sin(pitch);
+
+        final Vector xAxis = new Vector(
+                cosYaw,
+                -sinYaw*sinPitch,
+                -sinYaw*cosPitch
+        );
+
+        final Vector yAxis = new Vector(
+                0,
+                cosPitch,
+                -sinPitch
+        );
+
+        final Vector zAxis = new Vector(
+                sinYaw,
+                cosYaw*sinPitch,
+                cosYaw*cosPitch
+        );
+
+        return xAxis.multiply(axis.getX()).add(yAxis.multiply(axis.getY())).add(zAxis.multiply(axis.getZ()));
+    }
+
+    /**
+     * Transforms a position from the local reference frame described by this
+     * location into the world reference frame.
+     * <p>
+     * x=left, y=up, z=forward
+     *
+     * @param position a local-coordinate position
+     * @return a world-coordinate position
+     */
+    public Vector toWorld(Vector position) {
+        return toWorldAxis(position).add(toVector());
+    }
+
+    /**
+     * Transforms a position from the world reference frame into the local reference frame described by this
+     * location.
+     * <p>
+     * x=left, y=up, z=forward
+     *
+     * @param position a world-coordinate position
+     * @return a local-coordinate position
+     */
+    public Vector toLocal(Vector position) {
+        return toLocalAxis(position.clone().subtract(toVector()));
+    }
 }

--- a/src/main/java/org/bukkit/Location.java
+++ b/src/main/java/org/bukkit/Location.java
@@ -562,7 +562,10 @@ public class Location implements Cloneable {
      * Transforms an axis from the local reference frame described by this
      * location into the world reference frame.
      * <p>
-     * x=left, y=up, z=forward
+     * The following conditions apply:
+     * <li>X axis points to the left</li>
+     * <li>Y axis points upward</li>
+     * <li>Z axis points forward</li>
      *
      * @param axis a local-coordinate axis
      * @return a world-coordinate axis
@@ -576,20 +579,22 @@ public class Location implements Cloneable {
         final double cosPitch = Math.cos(pitch);
         final double sinPitch = Math.sin(pitch);
 
-        final Vector forward = new Vector(
-                -sinYaw*cosPitch,
-                -sinPitch,
-                cosYaw*cosPitch
-        );
-        final Vector up = new Vector(
-                -sinYaw*sinPitch,
-                cosPitch,
-                cosYaw*sinPitch
-        );
         final Vector left = new Vector(
                 cosYaw,
                 0,
                 sinYaw
+        );
+
+        final Vector up = new Vector(
+                -sinYaw * sinPitch,
+                cosPitch,
+                cosYaw * sinPitch
+        );
+
+        final Vector forward = new Vector(
+                -sinYaw * cosPitch,
+                -sinPitch,
+                cosYaw * cosPitch
         );
 
         return left.multiply(axis.getX()).add(up.multiply(axis.getY())).add(forward.multiply(axis.getZ()));
@@ -599,7 +604,10 @@ public class Location implements Cloneable {
      * Transforms an axis from the world reference frame into the local reference frame described by this
      * location.
      * <p>
-     * x=left, y=up, z=forward
+     * The following conditions apply:
+     * <li>X axis points to the left</li>
+     * <li>Y axis points upward</li>
+     * <li>Z axis points forward</li>
      *
      * @param axis a world-coordinate axis
      * @return a local-coordinate axis
@@ -615,8 +623,8 @@ public class Location implements Cloneable {
 
         final Vector xAxis = new Vector(
                 cosYaw,
-                -sinYaw*sinPitch,
-                -sinYaw*cosPitch
+                -sinYaw * sinPitch,
+                -sinYaw * cosPitch
         );
 
         final Vector yAxis = new Vector(
@@ -627,8 +635,8 @@ public class Location implements Cloneable {
 
         final Vector zAxis = new Vector(
                 sinYaw,
-                cosYaw*sinPitch,
-                cosYaw*cosPitch
+                cosYaw * sinPitch,
+                cosYaw * cosPitch
         );
 
         return xAxis.multiply(axis.getX()).add(yAxis.multiply(axis.getY())).add(zAxis.multiply(axis.getZ()));
@@ -638,7 +646,10 @@ public class Location implements Cloneable {
      * Transforms a position from the local reference frame described by this
      * location into the world reference frame.
      * <p>
-     * x=left, y=up, z=forward
+     * The following conditions apply:
+     * <li>X axis points to the left</li>
+     * <li>Y axis points upward</li>
+     * <li>Z axis points forward</li>
      *
      * @param position a local-coordinate position
      * @return a world-coordinate position
@@ -651,7 +662,10 @@ public class Location implements Cloneable {
      * Transforms a position from the world reference frame into the local reference frame described by this
      * location.
      * <p>
-     * x=left, y=up, z=forward
+     * The following conditions apply:
+     * <li>X axis points to the left</li>
+     * <li>Y axis points upward</li>
+     * <li>Z axis points forward</li>
      *
      * @param position a world-coordinate position
      * @return a local-coordinate position

--- a/src/test/java/org/bukkit/LocationTransformTest.java
+++ b/src/test/java/org/bukkit/LocationTransformTest.java
@@ -1,0 +1,72 @@
+package org.bukkit;
+
+import org.bukkit.util.Vector;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class LocationTransformTest {
+    @Test
+    public void testTransform() throws Exception {
+        final Location[] references = {
+                new Location(null, 1, 2, 3, 4, 5),
+                new Location(null, 5, 4, 3, 2, 1),
+                new Location(null, 827, 2834, 65981, 36, 51),
+        };
+
+        final Vector[] vectors =  {
+                new Vector(2323, 666, 42),
+                new Vector(123, 456, 789),
+                new Vector(1e-6, 0, 1e-6),
+                new Vector(1e6, 0, 1e6),
+                new Vector(1234, 567, 89),
+        };
+
+        for (Location reference : references) {
+            testTransform(reference);
+            for (Vector vector : vectors) {
+                testTransform(reference, vector);
+            }
+        }
+
+        for (Vector vector : vectors) {
+            testTransform(vector);
+        }
+    }
+
+    private void testTransform(Vector vector) {
+        // Test conformity with the untransformed coordinate system
+        final Location reference = new Location(null, 0, 0, 0, 0, 0);
+        assertVectorEquals(vector, reference.toLocalAxis(vector));
+        assertVectorEquals(vector, reference.toWorldAxis(vector));
+        assertVectorEquals(vector, reference.toLocal(vector));
+        assertVectorEquals(vector, reference.toWorld(vector));
+    }
+
+    private void testTransform(Location reference, Vector vector) {
+        // Test inverse functions
+        assertVectorEquals(vector, reference.toWorldAxis(reference.toLocalAxis(vector)));
+        assertVectorEquals(vector, reference.toLocalAxis(reference.toWorldAxis(vector)));
+        assertVectorEquals(vector, reference.toWorld(reference.toLocal(vector)));
+        assertVectorEquals(vector, reference.toLocal(reference.toWorld(vector)));
+    }
+
+    private void testTransform(Location reference) {
+        // Test conformity with Location.getDirection()
+        assertVectorEquals(reference.getDirection(), reference.toWorldAxis(new Vector(0, 0, 1)));
+    }
+
+    /**
+     * Tests vector equality more accurately than {@link org.bukkit.util.Vector#equals(Object)}
+     *
+     * @param expected expected value
+     * @param actual the value to check against <code>expected</code>
+     */
+    private void assertVectorEquals(Vector expected, Vector actual) {
+        assertThat(actual.getX(), is(closeTo(expected.getX(), 1e-9)));
+        assertThat(actual.getY(), is(closeTo(expected.getY(), 1e-9)));
+        assertThat(actual.getZ(), is(closeTo(expected.getZ(), 1e-9)));
+    }
+}

--- a/src/test/java/org/bukkit/LocationTransformTest.java
+++ b/src/test/java/org/bukkit/LocationTransformTest.java
@@ -51,6 +51,7 @@ public class LocationTransformTest {
         assertVectorEquals(vector, reference.toLocalAxis(reference.toWorldAxis(vector)));
         assertVectorEquals(vector, reference.toWorld(reference.toLocal(vector)));
         assertVectorEquals(vector, reference.toLocal(reference.toWorld(vector)));
+        assertThat(reference.toWorldAxis(vector).length(), is(closeTo(vector.length(), 1e-12)));
     }
 
     private void testTransform(Location reference) {


### PR DESCRIPTION
#### The Issue

The Location class currently lacks methods for transforming between coordinate systems easily.
#### Justification for this PR

This PR allows developers to do the affine transformation to and from a local coordinate system that rotates and moves with the reference Location, whereby new Location(*, 0, 0, 0, 0, 0) does no transformation at all.

This implies that:
- Positive y is up
- Positive z (south, i.e. yaw=0) is forward
- Positive x (east, which is left of south) is left
- getDirection() is equivalent to toWorldAxis(new Vector(0,0,1))

This can be used to render effects adjacent to the player or creature and to spawn projectiles in a consistent pattern relative to the player's view.
#### PR Breakdown

The toWorld\* methods transform from local coordinates to world coordinates.
The toLocal\* methods transform from world coordinates to local coordinates.
The *Axis methods deal with axes instead of positions.
#### Testing Results and Materials

Unit tests are included and should be sufficient to ensure that the new methods are working.
#### Relevant PR(s)

[B-1012](https://github.com/Bukkit/Bukkit/issues/1012)
#### JIRA Ticket

[BUKKIT-5338](https://bukkit.atlassian.net/browse/BUKKIT-5338)
