### PR TITLE
Shouldn't the PlayerDeathEvent return a getPlayer instead of getEntity?

### DIFF
--- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
+++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
@@ -32,7 +32,7 @@ public class PlayerDeathEvent extends EntityDeathEvent {
     }
 
     @Override
-    public Player getEntity() {
+    public Player getPlayer() {
         return (Player) entity;
     }
 


### PR DESCRIPTION
The getEntity() method returns a Player, so why isn't it called getPlayer() like all other events? With the EntityDeathEvent it is normal that it has a "getEntity()" but I think the PlayerDeathEvent should have a getPlayer() method.
