### PR TITLE
[B] Added TeleportCause for /tp <x> <y> <z>. Fixes BUKKIT-5348.

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/TeleportCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/TeleportCommand.java
@@ -71,7 +71,7 @@ public class TeleportCommand extends VanillaCommand {
             playerLocation.setY(y);
             playerLocation.setZ(z);
 
-            player.teleport(playerLocation);
+            player.teleport(playerLocation, TeleportCause.COMMAND);
             Command.broadcastCommandMessage(sender, String.format("Teleported %s to %.2f, %.2f, %.2f", player.getDisplayName(), x, y, z));
         }
         return true;


### PR DESCRIPTION
## The Issue:

Currently, when teleporting with /tp x y z, the TeleportCause is not set, e.g. the default value is used instead of the expected TeleportCause.COMMAND. With the /tp player1 player2 syntax, the TeleportCause is already correctly set to TeleportCause.COMMAND.
## Justification for this PR:

With the Issue described above, plugins cannot for example filter out teleports caused by the /tp command correctly and react to them.
## PR Breakdown:

Adds the correct TeleportCause to the call of the Player.teleport method.
## JIRA Ticket:

BUKKIT-5348- https://bukkit.atlassian.net/browse/BUKKIT-5348
