### PR TITLE
[B+C] Add getDamage method to Boat. Fixes BUKKIT-5325

### DIFF
--- a/src/main/java/org/bukkit/entity/Boat.java
+++ b/src/main/java/org/bukkit/entity/Boat.java
@@ -69,4 +69,11 @@ public interface Boat extends Vehicle {
      * @param workOnLand whether boats can work on land
      */
     public void setWorkOnLand(boolean workOnLand);
+
+    /**
+     * Gets the damage this boat has taken.
+     *
+     * @return The damage
+     */ 
+    public float getDamage();
 }


### PR DESCRIPTION
#### The Issue:

The Boat entity is missing the getDamage method found on the Minecart entity.
#### Justification for this PR:

The `getDamage` method should be exposed through Bukkit, to allow plugin authors to get the damage on Boats, just like Minecarts.
#### Testing Results and Materials:

I've created a small plugin called BoatTester, which you can download [here](https://www.dropbox.com/s/yuh8k1so03b1995/BoatTester.jar). Load the plugin, then repeatedly left-lick on a boat in Survival mode. Messages will appear in the chat, informing you of the current damage. You can view the source code [here](https://github.com/Aaron1011/BoatTester).
#### PR Breakdown:

This PR adds the methods `getDamage` method  to the Boat entity.
#### Relevant PR:

CB-1327 - https://github.com/Bukkit/CraftBukkit/pull/1327
#### JIRA Ticket:

BUKKIT-5325 - https://bukkit.atlassian.net/browse/BUKKIT-5325
