### PR TITLE
[B] Specify when a selected game mode is invalid. Fixes BUKKIT-5347

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/DefaultGameModeCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/DefaultGameModeCommand.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -44,8 +45,12 @@ public class DefaultGameModeCommand extends VanillaCommand {
                 mode = GameMode.CREATIVE;
             } else if (modeArg.equalsIgnoreCase("adventure") || modeArg.equalsIgnoreCase("a")) {
                 mode = GameMode.ADVENTURE;
-            } else {
+            } else if (modeArg.equalsIgnoreCase("survival") || modeArg.equalsIgnoreCase("s")) {
                 mode = GameMode.SURVIVAL;
+            } else {
+                sender.sendMessage(ChatColor.RED + "Invalid game mode specified.");
+                sender.sendMessage(ChatColor.RED + "Usage: " + usageMessage);
+                return false;
             }
         }
 

--- a/src/main/java/org/bukkit/command/defaults/GameModeCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/GameModeCommand.java
@@ -55,8 +55,12 @@ public class GameModeCommand extends VanillaCommand {
                     mode = GameMode.CREATIVE;
                 } else if (modeArg.equalsIgnoreCase("adventure") || modeArg.equalsIgnoreCase("a")) {
                     mode = GameMode.ADVENTURE;
-                } else {
+                } else if (modeArg.equalsIgnoreCase("survival") || modeArg.equalsIgnoreCase("s")) {
                     mode = GameMode.SURVIVAL;
+                } else {
+                    sender.sendMessage(ChatColor.RED + "Invalid game mode specified.");
+                    sender.sendMessage(ChatColor.RED + "Usage: " + usageMessage);
+                    return false;
                 }
             }
 


### PR DESCRIPTION
**The Issue:**
The current commands can provide confusion, as explained below.

**Justification for this PR:**
When the game mode command is run, and an invalid game mode is specified, it should state the error that was made, instead of defaulting to survival. 

The current command could display confusion as when a invalid game mode is specified, it would default to Survival and not what the user wanted.

**JIRA Ticket:**
https://bukkit.atlassian.net/browse/BUKKIT-5347
