### PR TITLE
[B+C] Add breakBlock param to createExplosion - Fixes BUKKIT-5350

### DIFF
--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -627,6 +627,18 @@ public interface World extends PluginMessageRecipient, Metadatable {
     public boolean createExplosion(Location loc, float power, boolean setFire);
 
     /**
+     * Creates explosion at given coordinates with given power and optionally
+     * setting blocks on fire.
+     *
+     * @param loc Location to blow up
+     * @param power The power of explosion, where 4F is TNT
+     * @param setFire Whether or not to set blocks on fire
+     * @param breakBlocks Whether or not to have blocks be destroyed
+     * @return false if explosion was canceled, otherwise true
+     */
+    public boolean createExplosion(Location loc, float power, boolean setFire, boolean breakBlocks);
+
+    /**
      * Gets the {@link Environment} type of this world
      *
      * @return This worlds Environment type


### PR DESCRIPTION
**The Issue:**
Plugins should be able to create explosions, with locations, and specify if blocks should be modified.

**Justification for this PR:**
There is currently an API for creating explosions with no block damage, however that only allows x y z co-ordinates. It would be nice to be able to pass a Location and have this parameter.

**JIRA Ticket:**
https://bukkit.atlassian.net/browse/BUKKIT-5350

**Testing Material**

```
    public void onEnable() {
        getCommand("test").setExecutor(this);
    }

    public boolean onCommand(CommandSender s, Command cmd, String label, String[] args) {
        if (s instanceof Player) {
            Player p = (Player) s;

            p.getWorld().createExplosion(p.getLocation(), 1f, false, false);
                        // When executed, a explosion with no block damage is summoned.
        }
        return true;
    }
```

Associated CraftBukkit Ticket: https://github.com/Bukkit/CraftBukkit/pull/1328
Associated Bukkit Ticket: https://github.com/Bukkit/Bukkit/pull/1017
