### PR TITLE
[B] Ban command falsely kicking players - Fixes BUKKIT-5355

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/BanCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/BanCommand.java
@@ -30,7 +30,7 @@ public class BanCommand extends VanillaCommand {
         // TODO: Ban Reason support
         Bukkit.getOfflinePlayer(args[0]).setBanned(true);
 
-        Player player = Bukkit.getPlayer(args[0]);
+        Player player = Bukkit.getPlayerExact(args[0]);
         if (player != null) {
             player.kickPlayer("Banned by admin.");
         }


### PR DESCRIPTION
**The Issue:**
When banning players that are offline, It will look for any player that has the name starting with the offline player that was banned, instead of looking for the player that was banned.

Example Senaro (My username is stuntguy3000):
/ban stunt
    -> User "stunt" is banned
    -> User "stuntguy3000" is falsly kicked with ban message, however is not banned.

**Justification for this PR:**
This PR prevents possible confusion (on a Players end) if they were to be kicked for a ban, when they were not actually banned.

This command should be taken as strictly as op and pardon are.

**JIRA Ticket:**
https://bukkit.atlassian.net/browse/BUKKIT-5355

**Testing Material**
Compiled changes from local fork and tested.
