### PR TITLE
[B] Effect, xp and clear commands can target incorrect players - Fixes BUKKIT-5356

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/ClearCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/ClearCommand.java
@@ -38,7 +38,7 @@ public class ClearCommand extends VanillaCommand {
 
         Player player = null;
         if (args.length > 0) {
-            player = Bukkit.getPlayer(args[0]);
+            player = Bukkit.getPlayerExact(args[0]);
         } else if (sender instanceof Player) {
             player = (Player) sender;
         }

--- a/src/main/java/org/bukkit/command/defaults/EffectCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/EffectCommand.java
@@ -43,7 +43,7 @@ public class EffectCommand extends VanillaCommand {
             return true;
         }
 
-        final Player player = sender.getServer().getPlayer(args[0]);
+        final Player player = sender.getServer().getPlayerExact(args[0]);
 
         if (player == null) {
             sender.sendMessage(ChatColor.RED + String.format("Player, %s, not found", args[0]));

--- a/src/main/java/org/bukkit/command/defaults/ExpCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/ExpCommand.java
@@ -40,7 +40,7 @@ public class ExpCommand extends VanillaCommand {
             }
 
             if (args.length > 1) {
-                player = Bukkit.getPlayer(args[1]);
+                player = Bukkit.getPlayerExact(args[1]);
             } else if (sender instanceof Player) {
                 player = (Player) sender;
             }


### PR DESCRIPTION
**The Issue:**
For 3 commands (effect, xp and clear) the player entered may not always be the player that receives the effect of the command. The code is told to find a player with the name, where it should find the exact player. One example is the clear command, an OP may accidentally remove a players inventory causing havoc.

Example: Two online players, "stunt" and "stuntguy3000". If i wanted to clear the inventory of stuntguy3000, if i were to type /clear stunt the inventory of "stunt" would be cleared. This is not a very big issue, however I have ran into the issue before. Once again, this also helps to mimic vanilla behavior.

**Justification for this PR:**
This PR prevents possible accidental mishaps, at the loss of being able to shortcut names (eg having to put stuntguy instead of stuntguy3000). It is crucial that the user entered is the user that receives the effect of the command, because the three commands which this effects can cause damage (mainly the clear inventory command).

This also helps to mimic vanilla behavior.

**JIRA Ticket:** https://bukkit.atlassian.net/browse/BUKKIT-5356

**Testing Material**
Compiled changes from local fork and tested.

**Associated Bukkit Ticket:** https://github.com/Bukkit/Bukkit/pull/1019
