### PR TITLE
[B+C] Add special event for breeding. Adds BUKKIT-5357

### DIFF
--- a/src/main/java/org/bukkit/event/entity/CreatureBreedSpawnEvent.java
+++ b/src/main/java/org/bukkit/event/entity/CreatureBreedSpawnEvent.java
@@ -1,0 +1,28 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.LivingEntity;
+
+/**
+ * Called when a creature spawns because of breeding.
+ */
+public class CreatureBreedSpawnEvent extends CreatureSpawnEvent {
+	private LivingEntity parent1;
+	private LivingEntity parent2;
+	
+	public CreatureBreedSpawnEvent(LivingEntity spawnee, LivingEntity parent1, LivingEntity parent2) {
+		super(spawnee, SpawnReason.BREEDING);
+		// TODO Auto-generated constructor stub
+		this.parent1 = parent1;
+		this.parent2 = parent2;
+	}
+
+	public LivingEntity getParent1() {
+		return parent1;
+	}
+
+	public LivingEntity getParent2() {
+		return parent2;
+	}
+	
+	
+}

--- a/src/main/java/org/bukkit/event/entity/CreatureBreedSpawnEvent.java
+++ b/src/main/java/org/bukkit/event/entity/CreatureBreedSpawnEvent.java
@@ -1,0 +1,27 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.LivingEntity;
+
+/**
+ * Called when a creature spawns because of breeding.
+ */
+public class CreatureBreedSpawnEvent extends CreatureSpawnEvent {
+	private LivingEntity parent1;
+	private LivingEntity parent2;
+	
+	public CreatureBreedSpawnEvent(LivingEntity spawnee, LivingEntity parent1, LivingEntity parent2) {
+		super(spawnee, SpawnReason.BREEDING);
+		this.parent1 = parent1;
+		this.parent2 = parent2;
+	}
+
+	public LivingEntity getParent1() {
+		return parent1;
+	}
+
+	public LivingEntity getParent2() {
+		return parent2;
+	}
+	
+	
+}


### PR DESCRIPTION
The Issue:

It could be interesting to have a special even for when a new LivingEntity is spawned because of breeding. It should contain references to both parents so that, for example, wool colour from both can be used in detemining the colour for the offspring.

Justification for this PR:

This adds CreatureBreedSpawnEvent, which extends CreatureSpawnEvent and is fired when a new creature is spawned because of breeding. This new event contains references to both parents, which can then be examined to alter the offspring or modified themselves.

PR Breakdown:

This adds CreatureBreedSpawnEvent.

Testing Results and Materials:

A custom CraftBukkit server was built with this, and a plugin was created with the patched Bukkit lib. This plugin captures this new event and, if the new entity is a sheep, it colours the wool according to the colour of the parents, blending it sort of like you get when mixing dyes in a workbench

Relevant PR(s):

[B+C]-1330 - https://github.com/Bukkit/CraftBukkit/pull/1330 - adds CraftBukkit support for the event

JIRA Ticket:

BUKKIT-5357 https://bukkit.atlassian.net/browse/BUKKIT-5357
