### PR TITLE
Add the getSlot method to BlockDispenseEvent. Adds BUKKIT-5142

### DIFF
--- a/src/main/java/org/bukkit/event/block/BlockDispenseEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockDispenseEvent.java
@@ -17,11 +17,21 @@ public class BlockDispenseEvent extends BlockEvent implements Cancellable {
     private boolean cancelled = false;
     private ItemStack item;
     private Vector velocity;
+    private int slot;
 
+    /**
+     * @deprecated Use {@link #BlockDispenseEvent(Block, ItemStack, Vector, int)} instead
+     */
+    @Deprecated
     public BlockDispenseEvent(final Block block, final ItemStack dispensed, final Vector velocity) {
+        this(block, dispensed, velocity, -1);
+    }
+
+    public BlockDispenseEvent(final Block block, final ItemStack dispensed, final Vector velocity, final int slot) {
         super(block);
         this.item = dispensed;
         this.velocity = velocity;
+        this.slot = slot;
     }
 
     /**
@@ -43,6 +53,15 @@ public class BlockDispenseEvent extends BlockEvent implements Cancellable {
     public void setItem(ItemStack item) {
         this.item = item;
     }
+
+    /**
+     * Gets the slot the item is being dispensed from. This returns -1 if the slot was not provided.
+     *
+     * @return The index of the slot being dispensed from, or -1 if not present
+     */
+     public int getSlot() {
+         return slot;
+     }
 
     /**
      * Gets the velocity.


### PR DESCRIPTION
#### The Issue:

Currently, there is no way to get which slot of a dispense/dropper was used from a `BlockDispenseEvent`. This makes it impossible for rollback plugins from determining how to reset a dispenser/dropper's inventory. 
#### Justification for this PR:

Adding the getSlot method allows plugin developers to detect which slot was used for dispensing an item. This can be used in a, for example, an antigrief/rollback plugin, which stores the slot used, and later adds the appropriate item to it.
#### PR Breakdown:

I've added a `slot` parameter to the constructor of `BlockDispenseEvent`, and added the `getSlot` method to return the specified slot.
#### Testing Results and Materials:

I've created a plugin called [SlotTester](https://www.dropbox.com/s/7i7k0urp5881bl7/SlotTester.jar). To use it, compile the CraftBukkit in the PR against my Bukkit PR listed in the Relevant PRs section. Load the plugin, then load and fire a dispenser of hopper. You will see "Slot: #" printed in the chat, where "#" is the number of the slot used, from 0 to 8. The source code can be viewed [here](https://github.com/Aaron1011/SlotTester).
#### Relevant PR(s):

CB-1332 - https://github.com/Bukkit/CraftBukkit/pull/1332
#### JIRA Ticket:

BUKKIT-5142 - https://bukkit.atlassian.net/browse/BUKKIT-5142
