### PR TITLE
[B+C] Add a way to get and set flower pot contents. Fixes BUKKIT-5316

### DIFF
--- a/src/main/java/org/bukkit/block/FlowerPot.java
+++ b/src/main/java/org/bukkit/block/FlowerPot.java
@@ -1,0 +1,24 @@
+package org.bukkit.block;
+
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Represents a flower pot.
+ */
+public interface FlowerPot extends BlockState {
+
+    /**
+     * Get the material in the flower pot
+     * 
+     * @return item ItemStack for the block currently in the flower pot.
+     */
+    ItemStack getContents();
+
+    /**
+     * Set the contents of the flower pot
+     * 
+     * @param itemStack ItemStack of the block to put in the flower pot.
+     */
+    void setContents(ItemStack itemStack);
+
+}

--- a/src/main/java/org/bukkit/block/FlowerPot.java
+++ b/src/main/java/org/bukkit/block/FlowerPot.java
@@ -1,6 +1,6 @@
 package org.bukkit.block;
 
-import org.bukkit.inventory.ItemStack;
+import org.bukkit.material.MaterialData;
 
 /**
  * Represents a flower pot.
@@ -10,15 +10,15 @@ public interface FlowerPot extends BlockState {
     /**
      * Get the material in the flower pot
      * 
-     * @return item ItemStack for the item currently in the flower pot (material is AIR if it is empty).
+     * @return item MaterialData for the item currently in the flower pot (material is AIR if it is empty).
      */
-    ItemStack getContents();
+    MaterialData getContents();
 
     /**
      * Set the contents of the flower pot
      * 
-     * @param itemStack ItemStack of the item to put in the flower pot or null/material as AIR to empty it.
+     * @param materialData MaterialData of the item to put in the flower pot or null/material as AIR to empty it.
      */
-    void setContents(ItemStack itemStack);
+    void setContents(MaterialData materialData);
 
 }

--- a/src/main/java/org/bukkit/block/FlowerPot.java
+++ b/src/main/java/org/bukkit/block/FlowerPot.java
@@ -10,14 +10,14 @@ public interface FlowerPot extends BlockState {
     /**
      * Get the material in the flower pot
      * 
-     * @return item ItemStack for the block currently in the flower pot.
+     * @return item ItemStack for the item currently in the flower pot (material is AIR if it is empty).
      */
     ItemStack getContents();
 
     /**
      * Set the contents of the flower pot
      * 
-     * @param itemStack ItemStack of the block to put in the flower pot.
+     * @param itemStack ItemStack of the item to put in the flower pot or null/material as AIR to empty it.
      */
     void setContents(ItemStack itemStack);
 


### PR DESCRIPTION
##### The Issue:

With new flowers in Minecraft 1.7, Mojang changed the way content of flower pot is saved. This made it impossible to get and set flower pot content correctly.
##### Justification:

System that exist right now (org.bukkit.material.FlowerPot) is outdated and it works only for versions o Minecraft lower than Minecraft 1.7. Flower pot contents is now saved using NBT data.
##### PR Breakdown:

This PR adds a Flower Pot Block State interface that allows plugins to get and set flower pot contents.
##### Bukkit PR:

[Bukkit/CraftBukkit#1333](https://github.com/Bukkit/CraftBukkit/pull/1333)
##### JIRA Ticket:

[JIRA Ticket #5368](https://bukkit.atlassian.net/browse/BUKKIT-5368) (Duplicate of [JIRA Ticket #5316](https://bukkit.atlassian.net/browse/BUKKIT-5316))
