### PR TITLE
[B+C] Adds methods for displaying particle effects. Adds BUKKIT-3792

### DIFF
--- a/src/main/java/org/bukkit/Particle.java
+++ b/src/main/java/org/bukkit/Particle.java
@@ -1,0 +1,162 @@
+package org.bukkit;
+
+/**
+ * An enum of particle effects the server is able to send to players.
+ */
+public enum Particle {
+    /**
+     * A very large explosion.
+     */
+    HUGE_EXPLOSION,
+    /**
+     * A large explosion.
+     */
+    LARGE_EXPLOSION,
+    /**
+     * The sparks from fireworks.
+     */
+    FIREWORKS_SPARK,
+    /**
+     * Bubbles. Only displays underwater.
+     */
+    BUBBLES,
+    /**
+     * Underwater ambiance. Only displays underwater.
+     */
+    UNDERWATER,
+    /**
+     * The fog shown in the void.
+     */
+    VOID_FOG,
+    /**
+     * Tiny gray particles.
+     */
+    TOWN_AURA,
+    /**
+     * The critical hit particles.
+     */
+    CRITICAL,
+    /**
+     * Magical critical hit particles.
+     */
+    MAGIC_CRITICAL,
+    /**
+     * Small black smoke particles.
+     */
+    SMOKE,
+    /**
+     * Potion swirls.
+     */
+    POTION_SWIRL,
+    /**
+     * Semitransparent potion swirls.
+     */
+    POTION_SWIRL_TRANSPARENT,
+    /**
+     * A puff of white potion swirls.
+     */
+    SPELL,
+    /**
+     * A puff of white stars.
+     */
+    INSTANT_SPELL,
+    /**
+     * Purple particles from witches.
+     */
+    WITCH_MAGIC,
+    /**
+     * The musical note from note blocks.
+     */
+    NOTE,
+    /**
+     * Nether portal particles.
+     */
+    PORTAL,
+    /**
+     * Enchantment table glyphs.
+     */
+    FLYING_GLYPH,
+    /**
+     * Small gray smoke particles.
+     */
+    SMALL_SMOKE,
+    /**
+     * Flame particles from mob spawners.
+     */
+    FLAME,
+    /**
+     * The particles that pop out of lava.
+     */
+    LAVA_POP,
+    /**
+     * Footsteps which fade after several seconds.
+     */
+    FOOTSTEP,
+    /**
+     * Water splash particles.
+     */
+    SPLASH,
+    /**
+     * Large smoke particles.
+     */
+    LARGE_SMOKE,
+    /**
+     * White smoke particles.
+     */
+    CLOUD,
+    /**
+     * Colored dust used for redstone.
+     */
+    COLORED_DUST,
+    /**
+     * Snowball breaking particles.
+     */
+    SNOWBALL_BREAK,
+    /**
+     * Water dripping from the ceiling.
+     */
+    WATER_DRIP,
+    /**
+     * Lava dripping from the ceiling.
+     */
+    LAVA_DRIP,
+    /**
+     * Small white puffs.
+     */
+    SNOW_SHOVEL,
+    /**
+     * Slime jump particles.
+     */
+    SLIME,
+    /**
+     * Hearts from breeding animals.
+     */
+    HEART,
+    /**
+     * Thunderclouds indicating villager anger.
+     */
+    ANGRY_VILLAGER,
+    /**
+     * Green stars indicating villager happiness.
+     */
+    HAPPY_VILLAGER,
+    /**
+     * The wake created while fishing.
+     */
+    FISH_WAKE,
+    /**
+     * The particles generated when a tool breaks.
+     * Requires an item material to be specified.
+     */
+    ITEM_BREAK,
+    /**
+     * The particles generated when a block is broken.
+     * Requires a block material to be specified.
+     */
+    BLOCK_BREAK,
+    /**
+     * Dust textured like a specific block.
+     * Requires a block material to be specified.
+     */
+    BLOCK_DUST
+}

--- a/src/main/java/org/bukkit/Particle.java
+++ b/src/main/java/org/bukkit/Particle.java
@@ -158,5 +158,19 @@ public enum Particle {
      * Dust textured like a specific block.
      * Requires a block material to be specified.
      */
-    BLOCK_DUST
+    BLOCK_DUST;
+
+    /**
+     * Whether this particle requires a material to be specified.
+     */
+    public boolean usesMaterial() {
+        return this == ITEM_BREAK || this == BLOCK_BREAK || this == BLOCK_DUST;
+    }
+
+    /**
+     * Whether this particle makes use of the data portion of the material specified.
+     */
+    public boolean usesData() {
+        return this == BLOCK_BREAK || this == BLOCK_DUST;
+    }
 }

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -1184,6 +1184,19 @@ public interface World extends PluginMessageRecipient, Metadatable {
     public void showParticle(Location loc, Particle particle, MaterialData material, float offsetX, float offsetY, float offsetZ, float speed, int amount);
 
     /**
+     * Displays a particle at the provided Location in the World.
+     *
+     * @param loc the location to play the effect at
+     * @param particle the name of the particle to display
+     * @param offsetX the X axis random offset
+     * @param offsetY the Y axis random offset
+     * @param offsetZ the Z axis random offset
+     * @param speed the speed of the particles
+     * @param amount the number of particles to show
+     */
+    public void showParticle(Location loc, String particle, float offsetX, float offsetY, float offsetZ, float speed, int amount);
+
+    /**
      * Represents various map environment types that a world may be
      */
     public enum Environment {

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -13,6 +13,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.*;
 import org.bukkit.generator.BlockPopulator;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.material.MaterialData;
 import org.bukkit.metadata.Metadatable;
 import org.bukkit.plugin.messaging.PluginMessageRecipient;
 import org.bukkit.util.Vector;
@@ -1154,6 +1155,33 @@ public interface World extends PluginMessageRecipient, Metadatable {
      * @return True if rule exists
      */
     public boolean isGameRule(String rule);
+
+    /**
+     * Displays a particle at the provided Location in the World.
+     *
+     * @param loc the location to play the effect at
+     * @param particle the {@link Particle}
+     * @param offsetX the X axis random offset
+     * @param offsetY the Y axis random offset
+     * @param offsetZ the Z axis random offset
+     * @param speed the speed of the particles
+     * @param amount the number of particles to show
+     */
+    public void showParticle(Location loc, Particle particle, float offsetX, float offsetY, float offsetZ, float speed, int amount);
+
+    /**
+     * Displays a particle at the provided Location in the World.
+     *
+     * @param loc the location to play the effect at
+     * @param particle the {@link Particle}
+     * @param material the {@link MaterialData} of the particle, for some particles
+     * @param offsetX the X axis random offset
+     * @param offsetY the Y axis random offset
+     * @param offsetZ the Z axis random offset
+     * @param speed the speed of the particles
+     * @param amount the number of particles to show
+     */
+    public void showParticle(Location loc, Particle particle, MaterialData material, float offsetX, float offsetY, float offsetZ, float speed, int amount);
 
     /**
      * Represents various map environment types that a world may be

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -291,6 +291,19 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
     public void showParticle(Location loc, Particle particle, MaterialData material, float offsetX, float offsetY, float offsetZ, float speed, int amount);
 
     /**
+     * Displays a particle to just this player.
+     *
+     * @param loc the location to play the effect at
+     * @param particle the name of the particle to display
+     * @param offsetX the X axis random offset
+     * @param offsetY the Y axis random offset
+     * @param offsetZ the Z axis random offset
+     * @param speed the speed of the particles
+     * @param amount the number of particles to show
+     */
+    public void showParticle(Location loc, String particle, float offsetX, float offsetY, float offsetZ, float speed, int amount);
+
+    /**
      * Send a block change. This fakes a block change packet for a user at a
      * certain location. This will not actually change the world in any way.
      *

--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -10,12 +10,14 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Note;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.Statistic;
 import org.bukkit.WeatherType;
 import org.bukkit.command.CommandSender;
 import org.bukkit.conversations.Conversable;
 import org.bukkit.map.MapView;
+import org.bukkit.material.MaterialData;
 import org.bukkit.plugin.messaging.PluginMessageRecipient;
 import org.bukkit.scoreboard.Scoreboard;
 
@@ -260,6 +262,33 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      * @param data a data bit needed for some effects
      */
     public <T> void playEffect(Location loc, Effect effect, T data);
+
+    /**
+     * Displays a particle effect to just this player.
+     *
+     * @param loc the location to play the effect at
+     * @param particle the {@link Particle}
+     * @param offsetX the X axis random offset
+     * @param offsetY the Y axis random offset
+     * @param offsetZ the Z axis random offset
+     * @param speed the speed (or other parameter) of the particles
+     * @param amount the number of particles to show
+     */
+    public void showParticle(Location loc, Particle particle, float offsetX, float offsetY, float offsetZ, float speed, int amount);
+
+    /**
+     * Displays a particle effect to just this player.
+     *
+     * @param loc the location to play the effect at
+     * @param particle the {@link Particle}
+     * @param material the {@link MaterialData} of the particle, for some particles
+     * @param offsetX the X axis random offset
+     * @param offsetY the Y axis random offset
+     * @param offsetZ the Z axis random offset
+     * @param speed the speed (or other parameter) of the particles
+     * @param amount the number of particles to show
+     */
+    public void showParticle(Location loc, Particle particle, MaterialData material, float offsetX, float offsetY, float offsetZ, float speed, int amount);
 
     /**
      * Send a block change. This fakes a block change packet for a user at a


### PR DESCRIPTION
**The Issue:**

There is no method to display specific particle effects to the users like there are to play individual sounds (Sound) or special effects (Effect).

**Justification for this PR:**

A wide variety particle effects are not currently possible to display to players, and it would be useful to be able to display them.

**PR Breakdown:**

A new Particle enum is added to Bukkit, containing the known valid particle effect types. Two showParticles methods each are added to Player and World, to show a particle effect to a single player or nearby players, with or without material data.

The reason for making Particle its own class separate from Effect is twofold. First, the kind of data you need to show a Particle is largely different from that of an Effect. Second, to be parallel to Sound, which is also separate. Sounds and Particles are two kinds of effect to play to the player. The Effect enum contains several special predefined (by Minecraft) combinations of sounds and/or particles.

While this PR _could_ be considered complete, there are a few issues that should be addressed:
- How to document specific details about what each argument to showParticle does and to which particles (caveats, so on).
- Potentially adding range-limited methods (NMS's default limit is 16 blocks).
- Unit tests? Sound has no tests and Effect has a trivial, non-applicable test.
- Maybe better validation of MaterialData passed (ITEM_BREAK expects item, other two expect block). No crashes involved, just particles looking silly.
- More descriptive commit message. The current one is just basic info, the real goods are in this PR description.

This is kind of a long list, I know, but I wanted to at least get this initial version up and in the pipeline.

**Testing Results and Materials:**

Testing plugin code: https://gist.github.com/SpaceManiac/8837964
Testing plugin download: http://wombat.platymuus.com/dl/ParticleTest.jar

How to use:
/particles list - displays Particle.values()
/particles all - shows all particle types in sequence to only you
/particles [name] <material> <data> - shows one particle type to all players
All particles are spawned above the player's head (use third person view)

**Relevant PRs:**

CB-1334 - https://github.com/Bukkit/CraftBukkit/pull/1334 - Accompanying CraftBukkit PR

B-802 - https://github.com/Bukkit/Bukkit/pull/802 - Past effort to address this ticket
CB-1066 - https://github.com/Bukkit/CraftBukkit/pull/1066 - Past effort to address this ticket

**JIRA Ticket:**

BUKKIT-3792 - https://bukkit.atlassian.net/browse/BUKKIT-3792
