### PR TITLE
[B] Make player argument optional

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/PlaySoundCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/PlaySoundCommand.java
@@ -10,7 +10,7 @@ public class PlaySoundCommand extends VanillaCommand {
     public PlaySoundCommand() {
         super("playsound");
         this.description = "Plays a sound to a given player";
-        this.usageMessage = "/playsound <sound> <player> [x] [y] [z] [volume] [pitch] [minimumVolume]";
+        this.usageMessage = "/playsound <sound> [player] [x] [y] [z] [volume] [pitch] [minimumVolume]";
         this.setPermission("bukkit.command.playsound");
     }
 
@@ -20,12 +20,19 @@ public class PlaySoundCommand extends VanillaCommand {
             return true;
         }
 
-        if (args.length < 2) {
+        if (args.length < 1) {
             sender.sendMessage(ChatColor.RED + "Usage: " + usageMessage);
             return false;
         }
+
         final String soundArg = args[0];
-        final String playerArg = args[1];
+        String playerArg = null;
+
+        if (args.length == 1) {
+            playerArg = sender.getName();
+        } else {
+            playerArg = args[1];
+        }
 
         final Player player = Bukkit.getPlayerExact(playerArg);
         if (player == null) {
@@ -43,7 +50,6 @@ public class PlaySoundCommand extends VanillaCommand {
         double minimumVolume = 0.0D;
 
         switch (args.length) {
-        default:
         case 8:
             minimumVolume = getDouble(sender, args[7], 0.0D, 1.0D);
         case 7:
@@ -56,8 +62,6 @@ public class PlaySoundCommand extends VanillaCommand {
             y = getRelativeDouble(y, sender, args[3]);
         case 3:
             x = getRelativeDouble(x, sender, args[2]);
-        case 2:
-            // Noop
         }
 
         final double fixedVolume = volume > 1.0D ? volume * 16.0D : 16.0D;

--- a/src/main/java/org/bukkit/command/defaults/PlaySoundCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/PlaySoundCommand.java
@@ -20,9 +20,16 @@ public class PlaySoundCommand extends VanillaCommand {
             return true;
         }
 
-        if (args.length < 1) {
-            sender.sendMessage(ChatColor.RED + "Usage: " + usageMessage);
-            return false;
+        if (sender instanceof Player) {
+            if (args.length < 1) {
+                sender.sendMessage(ChatColor.RED + "Usage: " + usageMessage);
+                return false;
+            }
+        } else {
+            if (args.length < 2) {
+                sender.sendMessage(ChatColor.RED + "Usage: /playsound <sound> <player> [x] [y] [z] [volume] [pitch] [minimumVolume]");
+                return false;
+            }
         }
 
         final String soundArg = args[0];


### PR DESCRIPTION
**The Issue:**
I believe for /playSound the player parameter should be optional, and default to the sender.

**Justification for this PR:**
This PR was made to help improve command usage (ease of use), to remove unnecessary code and mainly to improve command speed/efficiency. 

For example, If i wanted to test a certain sound (to see if it matches my needs or not), (I have a list of all of the sound names) I would get the sound name, then paste it in in-game into the command syntax. This is good and dandy, until you start demoing a lot of sounds. 

I would really have two options when sampling a lot of sounds
1) Have to back arrow and remove the sound ID in chat yourself
2) Modify the list to have the command syntax in place (As in, put **/playsound** in front and **stuntguy3000** behind the sound ID.

I currently do the 1st option, as the 2nd option is rather slow, tedious and It really messes up the look of the document. 

**In summary: This PR is designed to make the command easier and simpler to use, as well as increasing speed and efficiency.**

**Description of changes:**
Each change is commented. Scroll down to view.

**JIRA Ticket:**
https://bukkit.atlassian.net/browse/BUKKIT-5374

**Testing Material**
Compiled changes from local fork and tested each argument.

Associated Bukkit PR: https://github.com/Bukkit/Bukkit/pull/1026
