### PR TITLE
[B] Improve consistency for usage message in effect command. Fixes BUKKIT-5375

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/EffectCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/EffectCommand.java
@@ -39,7 +39,7 @@ public class EffectCommand extends VanillaCommand {
         }
 
         if (args.length < 2) {
-            sender.sendMessage(getUsage());
+            sender.sendMessage(ChatColor.RED + "Usage: " + usageMessage);
             return true;
         }
 


### PR DESCRIPTION
**The Issue:**
When the usage message is sent to the player, It only sends the message, without specifying "Usage: "

**Justification for this PR:**
This PR helps with command usage & helps to provide consistency between commands.

**JIRA Ticket:**
https://bukkit.atlassian.net/browse/BUKKIT-5375

**Testing Material**
Compiled changes from local fork and tested.

Associated Bukkit PR: https://github.com/Bukkit/Bukkit/pull/1027
