### PR TITLE
[B+C] Add method for spawning falling blocks without data. Adds BUKKIT-5383

### DIFF
--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -704,6 +704,22 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Spawn a {@link FallingBlock} entity at the given {@link Location} of
+     * the specified {@link Material}. The material dictates what is falling.
+     * When the FallingBlock hits the ground, it will place that block.
+     * <p>
+     * The Material must be a block type, check with {@link Material#isBlock()
+     * material.isBlock()}. The Material may not be air.
+     *
+     * @param location The {@link Location} to spawn the FallingBlock
+     * @param material The block {@link Material} type
+     * @return The spawned {@link FallingBlock} instance
+     * @throws IllegalArgumentException if {@link Location} or {@link
+     *     Material} are null or {@link Material} is not a block
+     */
+    public FallingBlock spawnFallingBlock(Location location, Material material) throws IllegalArgumentException;
+
+    /**
+     * Spawn a {@link FallingBlock} entity at the given {@link Location} of
      * the specified blockId (converted to {@link Material})
      *
      * @param location The {@link Location} to spawn the FallingBlock


### PR DESCRIPTION
**The Issue:**

There is currently no way to spawn falling blocks without supplying a data byte. We are currently relying on the data byte's continued existence to spawn falling blocks with current methods.

**Justification for this PR:**

This would allow developers to spawn falling blocks without using a data byte. This means that, if in the future, the data byte is removed from blocks/items, plugins spawning falling blocks will still work as intended if kept up to date.

**PR Breakdown:**

This PR adds an additional method in org.bukkit.World and org.bukkit.craftbukkit.CraftWorld to spawn falling blocks without using a data byte.

**Testing Results and Materials:**

Test plugin code: https://gist.github.com/Lucariatias/72073e22cfb0fc29fd24
Download: https://bukkit.atlassian.net/secure/attachment/19604/FallingBlocksTest-1.0-SNAPSHOT.jar
How to use:

/testfallingblocks [material] - spawns a falling block of the given material 8 blocks above the spawn

**Relevant PR(s):**

B-1028 - https://github.com/Bukkit/Bukkit/pull/1028 - Adds world.spawnFallingBlock(Location, Material) to World interface
CB-1336 - https://github.com/Bukkit/CraftBukkit/pull/1336 - Implements world.spawnFallingBlock(Location, Material)

**JIRA Ticket:**

BUKKIT-5383 - https://bukkit.atlassian.net/browse/BUKKIT-5383

**Pull Request Check List (For Your Use):**

General:
- [x] Fits Bukkit's Goals
- [x] Leaky Ticket Ready
- [x] Code Meets Requirements
- [x] Code is Documented
- [x] Code Addresses Leaky Ticket
- [x] Followed Pull Request Format
- [x] Tested Code
- [x] Included Test Material and Source
