### PR TITLE
[B] Fix unexpected ChatPaginator.wordWrap(String, int) output in some conditions Fixes BUKKIT-5408

### DIFF
--- a/src/main/java/org/bukkit/util/ChatPaginator.java
+++ b/src/main/java/org/bukkit/util/ChatPaginator.java
@@ -88,16 +88,11 @@ public class ChatPaginator {
             }
 
             if (c == ' ' || c == '\n') {
-                if (line.length() == 0 && word.length() > lineLength) { // special case: extremely long word begins a line
+                if (line.length() == 0 && word.length() - lineColorChars > lineLength) { // special case: extremely long word begins a line
                     for (String partialWord : word.toString().split("(?<=\\G.{" + lineLength + "})")) {
                         lines.add(partialWord);
                     }
-                } else if (line.length() + word.length() - lineColorChars == lineLength) { // Line exactly the correct length...newline
-                    line.append(word);
-                    lines.add(line.toString());
-                    line = new StringBuilder();
-                    lineColorChars = 0;
-                } else if (line.length() + 1 + word.length() - lineColorChars > lineLength) { // Line too long...break the line
+                } else if (line.length() > 0 && line.length() + 1 + word.length() - lineColorChars > lineLength) { // Line too long...break the line
                     for (String partialWord : word.toString().split("(?<=\\G.{" + lineLength + "})")) {
                         lines.add(line.toString());
                         line = new StringBuilder(partialWord);

--- a/src/test/java/org/bukkit/util/ChatPaginatorTest.java
+++ b/src/test/java/org/bukkit/util/ChatPaginatorTest.java
@@ -1,0 +1,58 @@
+package org.bukkit.util;
+
+import static org.junit.Assert.*;
+
+import org.bukkit.ChatColor;
+import org.junit.Test;
+
+public class ChatPaginatorTest {
+    @Test
+    public void wordWrapTest() {
+        // Second word length is one too large to fit in the line
+        assertArrayEquals(new String[] {
+                ChatColor.WHITE + "foo",
+                ChatColor.WHITE + "bar"
+        }, ChatPaginator.wordWrap("foo bar", 6));
+
+        // Single-line wordWrapped text does not have ChatColor applied to it
+        assertArrayEquals(new String[] {
+                "foo bar"
+        }, ChatPaginator.wordWrap("foo bar", 7));
+
+        // Second word can't fit in first line; third word can't fit in second
+        assertArrayEquals(new String[] {
+                ChatColor.WHITE + "foo",
+                ChatColor.WHITE + "bar",
+                ChatColor.WHITE + "baz"
+        }, ChatPaginator.wordWrap("foo bar baz", 6));
+
+        // Third word can't fit in the first line
+        assertArrayEquals(new String[] {
+                ChatColor.WHITE + "foo bar",
+                ChatColor.WHITE + "baz"
+        }, ChatPaginator.wordWrap("foo bar baz", 7));
+
+        // Words that are too long are forcibly broken up mid-word into new lines
+        assertArrayEquals(new String[] {
+                ChatColor.WHITE + "foobar",
+                ChatColor.WHITE + "baz"
+        }, ChatPaginator.wordWrap("foobarbaz", 6));
+    }
+
+    @Test
+    public void wordWrapColorTest() {
+        // ChatColor at beginning of line to be applied to each line
+        // Additionally, "foo" without the ChatColor should be exactly the right line length
+        assertArrayEquals(new String[] {
+                ChatColor.GOLD + "foo",
+                ChatColor.GOLD + "bar"
+        }, ChatPaginator.wordWrap(ChatColor.GOLD + "foo bar", 3));
+
+        // Mid-word ChatColor to be applied to the next line
+        // Additionally, "foo" without the additional two ChatColors should be exactly the right line length
+        assertArrayEquals(new String[] {
+                ChatColor.GOLD + "fo" + ChatColor.YELLOW + "o",
+                ChatColor.YELLOW + "bar"
+        }, ChatPaginator.wordWrap(ChatColor.GOLD + "fo" + ChatColor.YELLOW + "o bar", 3));
+    }
+}


### PR DESCRIPTION
### The Issue

ChatPaginator.wordWrap(String, int) gives unexpected output under two specific sets of conditions.

**The first issue**
The general conditions for this to occur (as of [line 95](https://github.com/Bukkit/Bukkit/blob/master/src/main/java/org/bukkit/util/ChatPaginator.java#L95-99)) are as follows:
`lineLength` - `line.length()` - `word.length()` == 0

This will immediately append `word` to `line` without a space between them

**A specific example**

Calling `wordWrap("preciselytwenty-five chars and more!", 25);` will result in the following (omitting color codes):

```
{
    "preciselytwenty-fivechars", // Note the missing space
    "and more!"
}
```

**The second issue**
ChatColors are not accounted for when checking to see if a word is exceptionally long (see [line 91](https://github.com/Bukkit/Bukkit/blob/master/src/main/java/org/bukkit/util/ChatPaginator.java#L91))

**A specific example**

Calling `wordWrap(ChatColor.GOLD + "foo", 3);` will result in the following:

```
{
    "§6f", // This word should not have been broken up
    "§6oo"
}
```
### PR Breakdown

**The first issue**
The code causing this unexpected output, [lines 95-99](https://github.com/Bukkit/Bukkit/blob/master/src/main/java/org/bukkit/util/ChatPaginator.java#L95-99), appear to be redundant: their functionality is supplanted by the already-existing code in the additional "else if" and "else" statements later in this method.

This PR removes the aforementioned lines.

**The second issue**

`lineColorChars` is subtracted from `word.length()` in the check for an exceptionally-long-word
### Testing Results and Materials

Unit tests have been included in the PR.
### JIRA Ticket

https://bukkit.atlassian.net/browse/BUKKIT-5408
