### PR TITLE
Update OfflinePlayer.java

### DIFF
--- a/src/main/java/org/bukkit/OfflinePlayer.java
+++ b/src/main/java/org/bukkit/OfflinePlayer.java
@@ -32,7 +32,7 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
      * Bans or unbans this player
      *
      * @param banned true if banned
-     * @deprecated Use {@link org.bukkit.BanList#addBan(String, String, java.util.Date, String)} or {@link org.bukkit.BanList#unban(String)} to enhance functionality
+     * @deprecated Use {@link org.bukkit.BanList#addBan(String, String, java.util.Date, String)} or {@link org.bukkit.BanList#pardon(String)} to enhance functionality
      */
     @Deprecated
     public void setBanned(boolean banned);


### PR DESCRIPTION
The setBanned deprecated tag now links to the org.bukkit.BanList pardon method rather than the non-existent unban method
