### PR TITLE
[B] Improve whitelist command messages - Fixes BUKKIT-5427

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/WhitelistCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/WhitelistCommand.java
@@ -49,33 +49,51 @@ public class WhitelistCommand extends VanillaCommand {
             } else if (args[0].equalsIgnoreCase("list")) {
                 if (badPerm(sender, "list")) return true;
 
-                StringBuilder result = new StringBuilder();
+                if (Bukkit.getWhitelistedPlayers().size() == 0) {
+                    sender.sendMessage("No players have been white-listed");
+                } else {
+                    StringBuilder result = new StringBuilder();
 
-                for (OfflinePlayer player : Bukkit.getWhitelistedPlayers()) {
-                    if (result.length() > 0) {
-                        result.append(", ");
+                    for (OfflinePlayer player : Bukkit.getWhitelistedPlayers()) {
+                        if (result.length() > 0) {
+                            result.append(", ");
+                        }
+
+                        result.append(player.getName());
                     }
 
-                    result.append(player.getName());
+                    sender.sendMessage("White-listed players (" + Bukkit.getWhitelistedPlayers().size() + "): " + result.toString());
                 }
 
-                sender.sendMessage("White-listed players: " + result.toString());
                 return true;
             }
         } else if (args.length == 2) {
             if (args[0].equalsIgnoreCase("add")) {
                 if (badPerm(sender, "add")) return true;
 
-                Bukkit.getOfflinePlayer(args[1]).setWhitelisted(true);
+                OfflinePlayer target = Bukkit.getOfflinePlayer(args[1]);
 
-                Command.broadcastCommandMessage(sender, "Added " + args[1] + " to white-list");
+                if (target.isWhitelisted()) {
+                    sender.sendMessage(target.getName() + " is already on the white-list");
+                } else {
+                    target.setWhitelisted(true);
+
+                    Command.broadcastCommandMessage(sender, "Added " + args[1] + " to the white-list");
+                }
+
                 return true;
             } else if (args[0].equalsIgnoreCase("remove")) {
                 if (badPerm(sender, "remove")) return true;
 
-                Bukkit.getOfflinePlayer(args[1]).setWhitelisted(false);
+                OfflinePlayer target = Bukkit.getOfflinePlayer(args[1]);
 
-                Command.broadcastCommandMessage(sender, "Removed " + args[1] + " from white-list");
+                if (target.isWhitelisted()) {
+                    target.setWhitelisted(false);
+
+                    Command.broadcastCommandMessage(sender, "Removed " + target.getName() + " from the white-list");
+                } else {
+                    sender.sendMessage(target.getName() + " is not on the white-list");
+                }
                 return true;
             }
         }


### PR DESCRIPTION
**The Issue:**
The white-list command lacks a few features for server management, and can also cause some confusion. I believe the changes below would help solve these issues as explained below.

**Justification for this PR:**
This PR is aimed at helping ease of use with the white-list command, and removing potentially confusing components.

There is two main modifications that this PR presents:
- The listing of white-listed players

Currently when viewing the white-list, if no players have been added the list will be empty. This is not clean, and has the possibility for confusion as it gives the impression there should be white-listed players. Now, You would receive a clean straightforward message saying no players have been white-listed, or a list of players who have been white-listed (and also a handy count).
- Alerting the player when the specified target is, or is not on the white-list when trying to add/remove the target from the white-list

Mainly to prevent confusion, The current commands for adding and removing players, should tell the player if the target is, or is not already white-listed.

**Testing Results and Materials:**
The changes were compiled locally, then tested on a local server with two players. The tests confirm the changes work, and the command has intended use.

**JIRA Ticket:**
https://bukkit.atlassian.net/browse/BUKKIT-5427
