### PR TITLE
 [B+C] Allow entities to be set as explosion source. Fixes BUKKIT-4888

### DIFF
--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -610,14 +610,14 @@ public interface World extends PluginMessageRecipient, Metadatable {
      * Creates explosion at given coordinates with given power, setting the source
      * of the explosion, and optionally setting blocks on fire or breaking blocks
      *
-     * @param source Source entity
-     * @param x X coordinate
-     * @param y Y coordinate
-     * @param z Z coordinate
-     * @param power The power of explosion, where 4F is TNT
-     * @param setFire Whether or not to set blocks on fire
-     * @param breakBlocks Whether or not to have blocks be destroyed
-     * @return false if explosion was canceled, otherwise true
+     * @param source source entity
+     * @param x x coordinate of the explosion
+     * @param y y coordinate of the explosion
+     * @param z z coordinate of the explosion
+     * @param power the power of explosion, where 4F is TNT
+     * @param setFire whether or not to set blocks on fire
+     * @param breakBlocks whether or not to have blocks be destroyed
+     * @return true if the explosion was successful, false otherwise
      */
     public boolean createExplosion(Entity source, double x, double y, double z, float power, boolean setFire, boolean breakBlocks);
 

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -607,6 +607,21 @@ public interface World extends PluginMessageRecipient, Metadatable {
     public boolean createExplosion(double x, double y, double z, float power, boolean setFire, boolean breakBlocks);
 
     /**
+     * Creates explosion at given coordinates with given power and optionally
+     * setting blocks on fire or breaking blocks.
+     *
+     * @param source Source entity
+     * @param x X coordinate
+     * @param y Y coordinate
+     * @param z Z coordinate
+     * @param power The power of explosion, where 4F is TNT
+     * @param setFire Whether or not to set blocks on fire
+     * @param breakBlocks Whether or not to have blocks be destroyed
+     * @return false if explosion was canceled, otherwise true
+     */
+    public boolean createExplosion(Entity source, double x, double y, double z, float power, boolean setFire, boolean breakBlocks);
+
+    /**
      * Creates explosion at given coordinates with given power
      *
      * @param loc Location to blow up

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -608,9 +608,10 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Creates explosion at given coordinates with given power, setting the source
-     * of the explosion, and optionally setting blocks on fire or breaking blocks
+     * of the explosion, and optionally setting blocks on fire or breaking blocks.
      *
-     * @param source source entity
+     * @param source source entity. If the entity is null, the explosion doesn't
+     *               have a source.
      * @param x x coordinate of the explosion
      * @param y y coordinate of the explosion
      * @param z z coordinate of the explosion

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -611,7 +611,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
      * of the explosion, and optionally setting blocks on fire or breaking blocks.
      *
      * @param source source entity. If the entity is null, the explosion doesn't
-     *               have a source.
+     *               have a source (equivalent to {@link #createExplosion(double, double, double, float, boolean, boolean) createExplosion})
      * @param x x coordinate of the explosion
      * @param y y coordinate of the explosion
      * @param z z coordinate of the explosion

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -607,8 +607,8 @@ public interface World extends PluginMessageRecipient, Metadatable {
     public boolean createExplosion(double x, double y, double z, float power, boolean setFire, boolean breakBlocks);
 
     /**
-     * Creates explosion at given coordinates with given power and optionally
-     * setting blocks on fire or breaking blocks.
+     * Creates explosion at given coordinates with given power, setting the source
+     * of the explosion, and optionally setting blocks on fire or breaking blocks
      *
      * @param source Source entity
      * @param x X coordinate


### PR DESCRIPTION
**The Issue:**

There is currently no way to set the source of an explosion created within the World class, using the createExplosion method set.

**Justification:**

Previously, when using the world.createExplosion() method set, there was no way to set the source of the entity.  This became an issue when plugins wish to create an explosion which, when killing another player, would display the death message "Player X was killed by Player Y".  Furthermore, in the DeathEvent preceding the death, event.getEntity().getKiller() would return null, when it would be more applicable to return the Player who created the explosion.

**PR Breakdown:**

This PR, along with the related CraftBukkit PR, will allow developers to set the source of an explosion created using the createExplosion() method set in the World class.  Since this PR only adds a new overloaded method to do this, it will not break plugins currently using the createExplosion() method.

**Testing:**

Testing was done using the following code to test explosions with every entity, and the resulting death messages and .getKiller() return value.  Everything I found works as expected, except the fact that the entity passed into the method isn't damaged by the explosion, due to the way the explosion looks for nearby entities.
https://gist.github.com/EEwing/2e3691fc6f780fdf9c33

**JIRA Ticket:**

https://bukkit.atlassian.net/browse/BUKKIT-4888

**Related PRs:**

CraftBukkit side: https://github.com/Bukkit/CraftBukkit/pull/1340
