### PR TITLE
Some improvements to inventory API

### DIFF
--- a/src/main/java/org/bukkit/Bukkit.java
+++ b/src/main/java/org/bukkit/Bukkit.java
@@ -574,6 +574,13 @@ public final class Bukkit {
     }
 
     /**
+     * @see Server#createInventory(InventoryHolder owner, InventoryType type, String title)
+     */
+    public static Inventory createInventory(InventoryHolder owner, InventoryType type, String title) {
+        return server.createInventory(owner, type, title);
+    }
+
+    /**
      * @see Server#createInventory(InventoryHolder owner, int size)
      */
     public static Inventory createInventory(InventoryHolder owner, int size) {

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -18,6 +18,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.server.ServerListPingEvent;
 import org.bukkit.help.HelpMap;
+import org.bukkit.inventory.BrewerInventory;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
@@ -640,7 +641,10 @@ public interface Server extends PluginMessageRecipient {
     /**
      * Creates an empty inventory of the specified type. If the type is {@link
      * InventoryType#CHEST}, the new inventory has a size of 27; otherwise the
-     * new inventory has the normal size for its type.
+     * new inventory has the normal size for its type. The new inventory can be
+     * cast to the subinterface appropriate to its type - for example, if you pass
+     * {@link InventoryType#BREWING}, then the new inventory can be cast to
+     * {@link BrewerInventory}.
      *
      * @param owner The holder of the inventory; can be null if there's no
      *     holder.
@@ -652,7 +656,10 @@ public interface Server extends PluginMessageRecipient {
     /**
      * Creates an empty inventory of the specified type with the specified title. If the type is {@link
      * InventoryType#CHEST}, the new inventory has a size of 27; otherwise the
-     * new inventory has the normal size for its type.
+     * new inventory has the normal size for its type. The new inventory can be
+     * cast to the subinterface appropriate to its type - for example, if you pass
+     * {@link InventoryType#BREWING}, then the new inventory can be cast to
+     * {@link BrewerInventory}.
      *
      * @param owner The holder of the inventory; can be null if there's no
      *     holder.

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -650,6 +650,20 @@ public interface Server extends PluginMessageRecipient {
     Inventory createInventory(InventoryHolder owner, InventoryType type);
 
     /**
+     * Creates an empty inventory of the specified type with the specified title. If the type is {@link
+     * InventoryType#CHEST}, the new inventory has a size of 27; otherwise the
+     * new inventory has the normal size for its type.
+     *
+     * @param owner The holder of the inventory; can be null if there's no
+     *     holder.
+     * @param type The type of inventory to create.
+     * @param title The title of the inventory, to be displayed when it is
+     *     viewed.
+     * @return The new inventory.
+     */
+    Inventory createInventory(InventoryHolder owner, InventoryType type, String title);
+
+    /**
      * Creates an empty inventory of type {@link InventoryType#CHEST} with the
      * specified size.
      *

--- a/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -43,8 +43,29 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, Permissible, Inv
      * @param prop The property.
      * @param value The value to set the property to.
      * @return True if the property was successfully set.
+     * @deprecated In favour of {@link #setWindowIntegerProperty(Property, int)}.
      */
     public boolean setWindowProperty(InventoryView.Property prop, int value);
+
+    /**
+     * If the player currently has an inventory window open, this method will
+     * set a property of that window, such as the state of a progress bar.
+     *
+     * @param <T> The type of the property, as specified by the {@link Property} constant.
+     * @param prop The property.
+     * @param value The value to set the property to.
+     * @return True if the property was successfully set.
+     */
+    public <T> boolean setWindowProperty(InventoryView.Property prop, T value);
+
+    /**
+     * If the player currently has an inventory window open, this method will
+     * fetch a property of that window, such as the state of a progress bar.
+     *
+     * @param prop The property to fetch
+     * @return The current value of the property, or null if unsupported
+     */
+    public Object getWindowProperty(InventoryView.Property prop);
 
     /**
      * Gets the inventory view the player is currently viewing. If they do not

--- a/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -46,6 +46,7 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, Permissible, Inv
      * @return True if the property was successfully set.
      * @deprecated In favour of {@link #setWindowIntegerProperty(Property, int)}.
      */
+    @Deprecated
     public boolean setWindowProperty(InventoryView.Property prop, int value);
 
     /**

--- a/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -2,6 +2,7 @@ package org.bukkit.entity;
 
 import org.bukkit.GameMode;
 import org.bukkit.Location;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.InventoryView;
@@ -94,7 +95,9 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, Permissible, Inv
      *     no inventory will be opened and null will be returned.
      * @return The newly opened inventory view, or null if it could not be
      *     opened.
+     * @deprecated In favour of {@link #openCrafting(InventoryType, Location, boolean)}
      */
+    @Deprecated
     public InventoryView openWorkbench(Location location, boolean force);
 
     /**
@@ -107,8 +110,29 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, Permissible, Inv
      *     location, no inventory will be opened and null will be returned.
      * @return The newly opened inventory view, or null if it could not be
      *     opened.
+     * @deprecated In favour of {@link #openCrafting(InventoryType, Location, boolean)}
      */
+    @Deprecated
     public InventoryView openEnchanting(Location location, boolean force);
+
+    /**
+     * Opens an empty crafting inventory window with the player's inventory
+     * on the bottom. The window functions as a normal crafting screen of the
+     * specified type.
+     *
+     * Supported types are those for which {@link InventoryType#isCraftingType()}
+     * returns true.
+     *
+     * @param type The type of crafting inventory to open.
+     * @param location The location to attach it to. If null, the player's
+     *     location is used.
+     * @param force If false, and there is no crafting block of the appropriate
+     *     type at the location, no inventory will be opened and null will be returned.
+     * @return The newly opened inventory view, or null if it could not be
+     *     opened.
+     * @throws IllegalArgumentException if the passed type is not a supported crafting type
+     */
+    public InventoryView openCrafting(InventoryType type, Location location, boolean force);
 
     /**
      * Opens an inventory window to the specified inventory view.

--- a/src/main/java/org/bukkit/event/inventory/InventoryType.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryType.java
@@ -33,7 +33,7 @@ public enum InventoryType {
     /**
      * A workbench inventory, with 9 CRAFTING slots and a RESULT slot.
      */
-    WORKBENCH(10,"Crafting", CraftingInventory.class),
+    WORKBENCH(10,"Crafting", CraftingInventory.class, true),
     /**
      * A player's crafting inventory, with 4 CRAFTING slots and a RESULT slot.
      * Also implies that the 4 ARMOR slots are accessible.
@@ -43,7 +43,7 @@ public enum InventoryType {
      * An enchantment table inventory, with one CRAFTING slot and three
      * enchanting buttons.
      */
-    ENCHANTING(1,"Enchanting", EnchantingInventory.class),
+    ENCHANTING(1,"Enchanting", EnchantingInventory.class, true),
     /**
      * A brewing stand inventory, with one FUEL slot and three CRAFTING slots.
      */
@@ -70,7 +70,7 @@ public enum InventoryType {
     /**
      * An anvil inventory, with 2 CRAFTING slots and 1 RESULT slot
      */
-    ANVIL(3, "Repairing", AnvilInventory.class),
+    ANVIL(3, "Repairing", AnvilInventory.class, true),
     /**
      * A beacon inventory, with 1 CRAFTING slot
      */
@@ -95,11 +95,17 @@ public enum InventoryType {
     private final int size;
     private final String title;
     private final Class<? extends Inventory> invenInterface;
+    private final boolean isCrafting;
 
-    private InventoryType(int defaultSize, String defaultTitle, Class<? extends Inventory> iface) {
+    private InventoryType(int defaultSize, String defaultTitle, Class<? extends Inventory> iface, boolean isCraft) {
         size = defaultSize;
         title = defaultTitle;
         invenInterface = iface;
+        isCrafting = isCraft;
+    }
+
+    private InventoryType(int defaultSize, String defaultTitle, Class<? extends Inventory> iface) {
+        this(defaultSize, defaultTitle, iface, false);
     }
 
     public int getDefaultSize() {
@@ -112,6 +118,10 @@ public enum InventoryType {
 
     public Class<? extends Inventory> getInventoryClass() {
         return invenInterface;
+    }
+
+    public boolean isCraftingType() {
+        return isCrafting;
     }
 
     public enum SlotType {

--- a/src/main/java/org/bukkit/event/inventory/InventoryType.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryType.java
@@ -69,6 +69,17 @@ public enum InventoryType {
      * A hopper inventory, with 5 slots of type CONTAINER.
      */
     HOPPER(5, "Item Hopper"),
+    /**
+     * A horse inventory, with 2 slots of type ARMOR.
+     * Used by all horses that don't have a chest attached.
+     * The second armor slot may not be visible in the GUI.
+     */
+    HORSE(2, "Horse"),
+    /**
+     * A horse inventory, with 2 slots of type ARMOR and 15 slots of type CONTAINER.
+     * The second armor slot is not visible in the GUI.
+     */
+    HORSE_PACK(17, "Horse"),
     ;
 
     private final int size;

--- a/src/main/java/org/bukkit/event/inventory/InventoryType.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryType.java
@@ -1,5 +1,6 @@
 package org.bukkit.event.inventory;
 
+import org.bukkit.Material;
 import org.bukkit.inventory.AnvilInventory;
 import org.bukkit.inventory.BeaconInventory;
 import org.bukkit.inventory.BrewerInventory;
@@ -33,7 +34,7 @@ public enum InventoryType {
     /**
      * A workbench inventory, with 9 CRAFTING slots and a RESULT slot.
      */
-    WORKBENCH(10,"Crafting", CraftingInventory.class, true),
+    WORKBENCH(10,"Crafting", CraftingInventory.class, Material.WORKBENCH),
     /**
      * A player's crafting inventory, with 4 CRAFTING slots and a RESULT slot.
      * Also implies that the 4 ARMOR slots are accessible.
@@ -43,7 +44,7 @@ public enum InventoryType {
      * An enchantment table inventory, with one CRAFTING slot and three
      * enchanting buttons.
      */
-    ENCHANTING(1,"Enchanting", EnchantingInventory.class, true),
+    ENCHANTING(1,"Enchanting", EnchantingInventory.class, Material.ENCHANTMENT_TABLE),
     /**
      * A brewing stand inventory, with one FUEL slot and three CRAFTING slots.
      */
@@ -70,7 +71,7 @@ public enum InventoryType {
     /**
      * An anvil inventory, with 2 CRAFTING slots and 1 RESULT slot
      */
-    ANVIL(3, "Repairing", AnvilInventory.class, true),
+    ANVIL(3, "Repairing", AnvilInventory.class, Material.ANVIL),
     /**
      * A beacon inventory, with 1 CRAFTING slot
      */
@@ -95,17 +96,17 @@ public enum InventoryType {
     private final int size;
     private final String title;
     private final Class<? extends Inventory> invenInterface;
-    private final boolean isCrafting;
+    private final Material craftBench;
 
-    private InventoryType(int defaultSize, String defaultTitle, Class<? extends Inventory> iface, boolean isCraft) {
+    private InventoryType(int defaultSize, String defaultTitle, Class<? extends Inventory> iface, Material craft) {
         size = defaultSize;
         title = defaultTitle;
         invenInterface = iface;
-        isCrafting = isCraft;
+        craftBench = craft;
     }
 
     private InventoryType(int defaultSize, String defaultTitle, Class<? extends Inventory> iface) {
-        this(defaultSize, defaultTitle, iface, false);
+        this(defaultSize, defaultTitle, iface, null);
     }
 
     public int getDefaultSize() {
@@ -120,8 +121,23 @@ public enum InventoryType {
         return invenInterface;
     }
 
+    /**
+     * Check if this inventory is a crafting inventory.
+     *
+     * @return True if this type of inventory is used for crafting
+     */
     public boolean isCraftingType() {
-        return isCrafting;
+        return craftBench != null;
+    }
+
+    /**
+     * If this inventory is a crafting inventory, this returns the Material type
+     * of the block associated with it.
+     *
+     * @return The associated block type, or null if not a crafting inventory
+     */
+    public Material getCraftingType() {
+        return craftBench;
     }
 
     public enum SlotType {

--- a/src/main/java/org/bukkit/event/inventory/InventoryType.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryType.java
@@ -61,7 +61,7 @@ public enum InventoryType {
      */
     CREATIVE(9,"Creative", Inventory.class),
     /**
-     * The merchant inventory, with 2 TRADE-IN slots, and 1 RESULT slot.
+     * The merchant inventory, with 2 CRAFTING slots, and 1 RESULT slot.
      */
     MERCHANT(3,"Villager", MerchantInventory.class),
     /**
@@ -109,14 +109,30 @@ public enum InventoryType {
         this(defaultSize, defaultTitle, iface, null);
     }
 
+    /**
+     * Get the default size of inventories of this type. Most inventories are always their default
+     * size, but some may support other sizes as well.
+     *
+     * @return The default size
+     */
     public int getDefaultSize() {
         return size;
     }
 
+    /**
+     * Get the default title for inventories of this type.
+     *
+     * @return The default title
+     */
     public String getDefaultTitle() {
         return title;
     }
 
+    /**
+     * Get the class used to represent inventories of this type.
+     *
+     * @return The inventory class
+     */
     public Class<? extends Inventory> getInventoryClass() {
         return invenInterface;
     }

--- a/src/main/java/org/bukkit/event/inventory/InventoryType.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryType.java
@@ -1,5 +1,15 @@
 package org.bukkit.event.inventory;
 
+import org.bukkit.inventory.AnvilInventory;
+import org.bukkit.inventory.BeaconInventory;
+import org.bukkit.inventory.BrewerInventory;
+import org.bukkit.inventory.CraftingInventory;
+import org.bukkit.inventory.EnchantingInventory;
+import org.bukkit.inventory.FurnaceInventory;
+import org.bukkit.inventory.HorseInventory;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.MerchantInventory;
+
 /**
  * These constants specify the style and appearance of an inventory, not its use.
  * Thus, any inventory which uses the basic nine-per-row layout is of type CHEST, for example.
@@ -9,92 +19,94 @@ public enum InventoryType {
      * A chest inventory, with 0, 9, 18, 27, 36, 45, or 54 slots of type
      * CONTAINER.
      */
-    CHEST(27,"Chest"),
+    CHEST(27,"Chest", Inventory.class),
     /**
      * A dispenser inventory, with 9 slots of type CONTAINER.
      */
-    DISPENSER(9,"Dispenser"),
+    DISPENSER(9,"Dispenser", Inventory.class),
     /**
      * A dropper inventory, with 9 slots of type CONTAINER.
      * @deprecated Will be replaced with {@link InventoryType#DISPENSER}
      */
     @Deprecated
-    DROPPER(9, "Dropper"),
+    DROPPER(9, "Dropper", Inventory.class),
     /**
      * A furnace inventory, with a RESULT slot, a CRAFTING slot, and a FUEL
      * slot.
      */
-    FURNACE(3,"Furnace"),
+    FURNACE(3,"Furnace", FurnaceInventory.class),
     /**
      * A workbench inventory, with 9 CRAFTING slots and a RESULT slot.
      */
-    WORKBENCH(10,"Crafting"),
+    WORKBENCH(10,"Crafting", CraftingInventory.class),
     /**
      * A player's crafting inventory, with 4 CRAFTING slots and a RESULT slot.
      * Also implies that the 4 ARMOR slots are accessible.
      */
-    CRAFTING(5,"Crafting"),
+    CRAFTING(5,"Crafting", CraftingInventory.class),
     /**
      * An enchantment table inventory, with one CRAFTING slot and three
      * enchanting buttons.
      */
-    ENCHANTING(1,"Enchanting"),
+    ENCHANTING(1,"Enchanting", EnchantingInventory.class),
     /**
      * A brewing stand inventory, with one FUEL slot and three CRAFTING slots.
      */
-    BREWING(4,"Brewing"),
+    BREWING(4,"Brewing", BrewerInventory.class),
     /**
      * A player's inventory, with 9 QUICKBAR slots, 27 CONTAINER slots, and 4
      * ARMOR slots. The ARMOUR slots may not be visible to the player, though.
      */
-    PLAYER(36,"Player"),
+    PLAYER(36,"Player", Inventory.class),
     /**
      * The creative mode inventory, with only 9 QUICKBAR slots and nothing
      * else. (The actual creative interface with the items is client-side and
      * cannot be altered by the server.)
      */
-    CREATIVE(9,"Creative"),
+    CREATIVE(9,"Creative", Inventory.class),
     /**
      * The merchant inventory, with 2 TRADE-IN slots, and 1 RESULT slot.
      */
-    MERCHANT(3,"Villager"),
+    MERCHANT(3,"Villager", MerchantInventory.class),
     /**
      * The ender chest inventory, with 27 slots.
      * @deprecated Will be replaced with {@link InventoryType#CHEST}
      */
     @Deprecated
-    ENDER_CHEST(27,"Ender Chest"),
+    ENDER_CHEST(27,"Ender Chest", Inventory.class),
     /**
      * An anvil inventory, with 2 CRAFTING slots and 1 RESULT slot
      */
-    ANVIL(3, "Repairing"),
+    ANVIL(3, "Repairing", AnvilInventory.class),
     /**
      * A beacon inventory, with 1 CRAFTING slot
      */
-    BEACON(1, "container.beacon"),
+    BEACON(1, "container.beacon", BeaconInventory.class),
     /**
      * A hopper inventory, with 5 slots of type CONTAINER.
      */
-    HOPPER(5, "Item Hopper"),
+    HOPPER(5, "Item Hopper", Inventory.class),
     /**
      * A horse inventory, with 2 slots of type ARMOR.
      * Used by all horses that don't have a chest attached.
      * The second armor slot may not be visible in the GUI.
      */
-    HORSE(2, "Horse"),
+    HORSE(2, "Horse", HorseInventory.class),
     /**
      * A horse inventory, with 2 slots of type ARMOR and 15 slots of type CONTAINER.
      * The second armor slot is not visible in the GUI.
      */
-    HORSE_PACK(17, "Horse"),
+    HORSE_PACK(17, "Horse", HorseInventory.class),
     ;
 
     private final int size;
     private final String title;
+    private final Class<? extends Inventory> invenInterface;
 
-    private InventoryType(int defaultSize, String defaultTitle) {
+    private InventoryType(int defaultSize, String defaultTitle, Class<? extends Inventory> iface) {
         size = defaultSize;
         title = defaultTitle;
+        invenInterface = iface;
     }
 
     public int getDefaultSize() {
@@ -103,6 +115,10 @@ public enum InventoryType {
 
     public String getDefaultTitle() {
         return title;
+    }
+
+    public Class<? extends Inventory> getInventoryClass() {
+        return invenInterface;
     }
 
     public enum SlotType {

--- a/src/main/java/org/bukkit/event/inventory/InventoryType.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryType.java
@@ -1,7 +1,10 @@
 package org.bukkit.event.inventory;
 
+/**
+ * These constants specify the style and appearance of an inventory, not its use.
+ * Thus, any inventory which uses the basic nine-per-row layout is of type CHEST, for example.
+ */
 public enum InventoryType {
-
     /**
      * A chest inventory, with 0, 9, 18, 27, 36, 45, or 54 slots of type
      * CONTAINER.
@@ -13,7 +16,9 @@ public enum InventoryType {
     DISPENSER(9,"Dispenser"),
     /**
      * A dropper inventory, with 9 slots of type CONTAINER.
+     * @deprecated Will be replaced with {@link InventoryType#DISPENSER}
      */
+    @Deprecated
     DROPPER(9, "Dropper"),
     /**
      * A furnace inventory, with a RESULT slot, a CRAFTING slot, and a FUEL
@@ -55,7 +60,9 @@ public enum InventoryType {
     MERCHANT(3,"Villager"),
     /**
      * The ender chest inventory, with 27 slots.
+     * @deprecated Will be replaced with {@link InventoryType#CHEST}
      */
+    @Deprecated
     ENDER_CHEST(27,"Ender Chest"),
     /**
      * An anvil inventory, with 2 CRAFTING slots and 1 RESULT slot

--- a/src/main/java/org/bukkit/event/inventory/InventoryType.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryType.java
@@ -10,11 +10,8 @@ import org.bukkit.inventory.HorseInventory;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.MerchantInventory;
 
-/**
- * These constants specify the style and appearance of an inventory, not its use.
- * Thus, any inventory which uses the basic nine-per-row layout is of type CHEST, for example.
- */
 public enum InventoryType {
+
     /**
      * A chest inventory, with 0, 9, 18, 27, 36, 45, or 54 slots of type
      * CONTAINER.
@@ -26,9 +23,7 @@ public enum InventoryType {
     DISPENSER(9,"Dispenser", Inventory.class),
     /**
      * A dropper inventory, with 9 slots of type CONTAINER.
-     * @deprecated Will be replaced with {@link InventoryType#DISPENSER}
      */
-    @Deprecated
     DROPPER(9, "Dropper", Inventory.class),
     /**
      * A furnace inventory, with a RESULT slot, a CRAFTING slot, and a FUEL
@@ -70,9 +65,7 @@ public enum InventoryType {
     MERCHANT(3,"Villager", MerchantInventory.class),
     /**
      * The ender chest inventory, with 27 slots.
-     * @deprecated Will be replaced with {@link InventoryType#CHEST}
      */
-    @Deprecated
     ENDER_CHEST(27,"Ender Chest", Inventory.class),
     /**
      * An anvil inventory, with 2 CRAFTING slots and 1 RESULT slot

--- a/src/main/java/org/bukkit/event/inventory/InventoryType.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryType.java
@@ -44,11 +44,11 @@ public enum InventoryType {
      * An enchantment table inventory, with one CRAFTING slot and three
      * enchanting buttons.
      */
-    ENCHANTING(1,"Enchanting", EnchantingInventory.class, Material.ENCHANTMENT_TABLE),
+    ENCHANTING(1,"Enchant", EnchantingInventory.class, Material.ENCHANTMENT_TABLE),
     /**
      * A brewing stand inventory, with one FUEL slot and three CRAFTING slots.
      */
-    BREWING(4,"Brewing", BrewerInventory.class),
+    BREWING(4,"Brewing Stand", BrewerInventory.class),
     /**
      * A player's inventory, with 9 QUICKBAR slots, 27 CONTAINER slots, and 4
      * ARMOR slots. The ARMOUR slots may not be visible to the player, though.
@@ -71,11 +71,11 @@ public enum InventoryType {
     /**
      * An anvil inventory, with 2 CRAFTING slots and 1 RESULT slot
      */
-    ANVIL(3, "Repairing", AnvilInventory.class, Material.ANVIL),
+    ANVIL(3, "Repair & Name", AnvilInventory.class, Material.ANVIL),
     /**
      * A beacon inventory, with 1 CRAFTING slot
      */
-    BEACON(1, "container.beacon", BeaconInventory.class),
+    BEACON(1, "", BeaconInventory.class),
     /**
      * A hopper inventory, with 5 slots of type CONTAINER.
      */
@@ -90,7 +90,7 @@ public enum InventoryType {
      * A horse inventory, with 2 slots of type ARMOR and 15 slots of type CONTAINER.
      * The second armor slot is not visible in the GUI.
      */
-    HORSE_PACK(17, "Horse", HorseInventory.class),
+    HORSE_PACK(17, "Donkey", HorseInventory.class),
     ;
 
     private final int size;

--- a/src/main/java/org/bukkit/inventory/BrewerInventory.java
+++ b/src/main/java/org/bukkit/inventory/BrewerInventory.java
@@ -20,6 +20,4 @@ public interface BrewerInventory extends Inventory {
      * @param ingredient The ingredient
      */
     void setIngredient(ItemStack ingredient);
-
-    BrewingStand getHolder();
 }

--- a/src/main/java/org/bukkit/inventory/FurnaceInventory.java
+++ b/src/main/java/org/bukkit/inventory/FurnaceInventory.java
@@ -48,6 +48,4 @@ public interface FurnaceInventory extends Inventory {
      * @param stack The item
      */
     void setSmelting(ItemStack stack);
-
-    Furnace getHolder();
 }

--- a/src/main/java/org/bukkit/inventory/InventoryView.java
+++ b/src/main/java/org/bukkit/inventory/InventoryView.java
@@ -225,7 +225,7 @@ public abstract class InventoryView {
      *
      * @return The title.
      */
-    public final String getTitle() {
+    public String getTitle() {
         return getTopInventory().getTitle();
     }
 }

--- a/src/main/java/org/bukkit/inventory/InventoryView.java
+++ b/src/main/java/org/bukkit/inventory/InventoryView.java
@@ -3,6 +3,7 @@ package org.bukkit.inventory;
 import org.bukkit.GameMode;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.potion.PotionEffectType;
 
 /**
  * Represents a view linking two inventories and a single player (whose
@@ -22,63 +23,69 @@ public abstract class InventoryView {
          * The progress of the down-pointing arrow in a brewing inventory.
          * This also affects the bubbles.
          */
-        BREW_TIME(0, InventoryType.BREWING),
+        BREW_TIME(0, InventoryType.BREWING, Integer.class),
         /**
          * The progress of the right-pointing arrow in a furnace inventory.
          */
-        COOK_TIME(0, InventoryType.FURNACE),
+        COOK_TIME(0, InventoryType.FURNACE, Integer.class),
         /**
          * The progress of the flame in a furnace inventory.
          */
-        BURN_TIME(1, InventoryType.FURNACE),
+        BURN_TIME(1, InventoryType.FURNACE, Integer.class),
         /**
          * How many total ticks the current fuel should last.
          * This is in effect the BURN_TIME that will make the flame full.
          */
-        TICKS_FOR_CURRENT_FUEL(2, InventoryType.FURNACE),
+        TICKS_FOR_CURRENT_FUEL(2, InventoryType.FURNACE, Integer.class),
         /**
          * In an enchanting inventory, the top button's experience level
          * value.
          */
-        ENCHANT_BUTTON1(0, InventoryType.ENCHANTING),
+        ENCHANT_BUTTON1(0, InventoryType.ENCHANTING, Integer.class),
         /**
          * In an enchanting inventory, the middle button's experience level
          * value.
          */
-        ENCHANT_BUTTON2(1, InventoryType.ENCHANTING),
+        ENCHANT_BUTTON2(1, InventoryType.ENCHANTING, Integer.class),
         /**
          * In an enchanting inventory, the bottom button's experience level
          * value.
          */
-        ENCHANT_BUTTON3(2, InventoryType.ENCHANTING),
+        ENCHANT_BUTTON3(2, InventoryType.ENCHANTING, Integer.class),
         /**
          * In an anvil inventory, the reported enchantment cost
          */
-        ANVIL_COST(0, InventoryType.ANVIL),
+        ANVIL_COST(0, InventoryType.ANVIL, Integer.class),
         /**
          * In a beacon inventory, the level of effects it enables.
          */
-        BEACON_LEVEL(0, InventoryType.BEACON),
+        BEACON_LEVEL(0, InventoryType.BEACON, Integer.class),
         /**
          * In a beacon inventory, the primary potion effect.
          * Only displayed potion effects are accepted.
          */
-        BEACON_PRIMARY(1, InventoryType.BEACON),
+        BEACON_PRIMARY(1, InventoryType.BEACON, PotionEffectType.class),
         /**
          * In a beacon inventory, the secondary potion effect.
          * Only displayed potion effects are accepted.
          */
-        BEACON_SECONDARY(2, InventoryType.BEACON),
+        BEACON_SECONDARY(2, InventoryType.BEACON, PotionEffectType.class),
         ;
         int id;
         InventoryType style;
-        private Property(int id, InventoryType appliesTo) {
+        Class<?> clz;
+        private Property(int id, InventoryType appliesTo, Class<?> value) {
             this.id = id;
             style = appliesTo;
+            clz = value;
         }
 
         public InventoryType getType() {
             return style;
+        }
+
+        public Class<?> getValueType() {
+            return clz;
         }
 
         /**
@@ -236,9 +243,60 @@ public abstract class InventoryView {
      * @param value the new value for the window property
      * @return true if the property was updated successfully, false if the
      *     property is not supported by that inventory
+     * @deprecated In favour of {@link #setIntegerProperty(Property, int)}.
      */
+    @Deprecated
     public final boolean setProperty(Property prop, int value) {
         return getPlayer().setWindowProperty(prop, value);
+    }
+
+    /**
+     * Sets an extra property of this inventory if supported by that
+     * inventory, for example the state of a progress bar.
+     *
+     * @param <T> The type of the property, as specified by the {@link Property} constant.
+     * @param prop the window property to update
+     * @param value the new value for the window property
+     * @return true if the property was updated successfully, false if the
+     *     property is not supported by that inventory or the wrong type was passed
+     */
+    public final <T> boolean setProperty(Property prop, T value) {
+        return getPlayer().setWindowProperty(prop, value);
+    }
+
+    /**
+     * Sets an extra property of this inventory if supported by that
+     * inventory, for example the state of a progress bar.
+     *
+     * @param prop the window property to update
+     * @param value the new value for the window property
+     * @return true if the property was updated successfully, false if the
+     *     property is not supported by that inventory
+     */
+    public final boolean setIntegerProperty(Property prop, int value) {
+        return getPlayer().setWindowProperty(prop, Integer.valueOf(value));
+    }
+
+    /**
+     * Fetches an extra property of this inventory if supported by that
+     * inventory, for example the state of a progress bar.
+     *
+     * @param prop The property to check
+     * @return The current value of the property, or null if unsupported by that inventory
+     */
+    public final Object getProperty(Property prop) {
+        return getPlayer().getWindowProperty(prop);
+    }
+
+    /**
+     * Fetches an extra property of this inventory if supported by that
+     * inventory, for example the state of a progress bar.
+     *
+     * @param prop The property to check
+     * @return The current value of the property, or null if unsupported by that inventory
+     */
+    public final int getIntegerProperty(Property prop) {
+        return (Integer) getProperty(prop);
     }
 
     /**

--- a/src/main/java/org/bukkit/inventory/InventoryView.java
+++ b/src/main/java/org/bukkit/inventory/InventoryView.java
@@ -20,6 +20,7 @@ public abstract class InventoryView {
     public enum Property {
         /**
          * The progress of the down-pointing arrow in a brewing inventory.
+         * This also affects the bubbles.
          */
         BREW_TIME(0, InventoryType.BREWING),
         /**
@@ -32,6 +33,7 @@ public abstract class InventoryView {
         BURN_TIME(1, InventoryType.FURNACE),
         /**
          * How many total ticks the current fuel should last.
+         * This is in effect the BURN_TIME that will make the flame full.
          */
         TICKS_FOR_CURRENT_FUEL(2, InventoryType.FURNACE),
         /**
@@ -48,7 +50,26 @@ public abstract class InventoryView {
          * In an enchanting inventory, the bottom button's experience level
          * value.
          */
-        ENCHANT_BUTTON3(2, InventoryType.ENCHANTING);
+        ENCHANT_BUTTON3(2, InventoryType.ENCHANTING),
+        /**
+         * In an anvil inventory, the reported enchantment cost
+         */
+        ANVIL_COST(0, InventoryType.ANVIL),
+        /**
+         * In a beacon inventory, the level of effects it enables.
+         */
+        BEACON_LEVEL(0, InventoryType.BEACON),
+        /**
+         * In a beacon inventory, the primary potion effect.
+         * Only displayed potion effects are accepted.
+         */
+        BEACON_PRIMARY(1, InventoryType.BEACON),
+        /**
+         * In a beacon inventory, the secondary potion effect.
+         * Only displayed potion effects are accepted.
+         */
+        BEACON_SECONDARY(2, InventoryType.BEACON),
+        ;
         int id;
         InventoryType style;
         private Property(int id, InventoryType appliesTo) {


### PR DESCRIPTION
**Description and Justification**

When you create an inventory using Bukkit.createInventory(), the inventory is always just a generic inventory. Even if you create a BREWING inventory, you can't cast it to BrewerInventory to treat it like a normal brewing inventory. While in many cases these additional methods are just conveniences, they mean you don't have to remember which slot a furnace uses for its result, for example.

Thus, this branch modifies the createInventory function to return custom inventories that implement the appropriate interface. Thus, if you call createInventory and pass InventoryType.BREWING, the returned Inventory also implements BrewerInventory and thus can safely be cast to that.

In part as support for the primary goal, this branch also adds support for beacons, workbenches, anvils, and horses. I also added support for custom titles in arbitrary inventory types, particularly custom InventoryViews.

See https://github.com/Bukkit/CraftBukkit/pull/1344 for details on testing, tickets, etc
