### PR TITLE
[B+C] Added iron golem holding flower methods. Adds BUKKIT-5440

### DIFF
--- a/src/main/java/org/bukkit/entity/IronGolem.java
+++ b/src/main/java/org/bukkit/entity/IronGolem.java
@@ -19,4 +19,19 @@ public interface IronGolem extends Golem {
      *     player created, false if you want it to be a natural village golem.
      */
     public void setPlayerCreated(boolean playerCreated);
+
+    /**
+     * Gets whether this iron golem holds flower.
+     *
+     * @return Whether this iron golem holds flower.
+     */
+    public boolean isHoldingFlower();
+
+    /**
+     * Sets whether this iron golem holds flower or not.
+     *
+     * @param holdingFlower true if you want to set the iron golem to hold
+     *     flower, false if you want it to not hold anything.
+     */
+    public void setHoldingFlower(boolean holdingFlower);
 }

--- a/src/main/java/org/bukkit/entity/IronGolem.java
+++ b/src/main/java/org/bukkit/entity/IronGolem.java
@@ -28,7 +28,8 @@ public interface IronGolem extends Golem {
     public boolean isHoldingFlower();
 
     /**
-     * Sets whether this iron golem holds flower or not.
+     * Sets whether this iron golem holds flower or not. 
+     * Iron golem holds flower only for 400 ticks.
      *
      * @param holdingFlower true if you want to set the iron golem to hold
      *     flower, false if you want it to not hold anything.


### PR DESCRIPTION
##### The Issue:

Iron Golem randomly holds flower to give it to random villager (pathfind magic). It only last 20 seconds (400 game ticks), but there is no way to get or set holding of flower.
##### Justification:

There is no way to get if iron golem is holding flower or set iron golem to hold flower.
##### PR Breakdown:

This PR adds a method to get if iron golem is holding flower and method to set iron holem to hold flower.
##### CraftBukkit PR:

[Bukkit/CraftBukkit#1348](https://github.com/Bukkit/CraftBukkit/pull/1348)
##### JIRA Ticket:

[JIRA Ticket #5440](https://bukkit.atlassian.net/browse/BUKKIT-5440)
