### PR TITLE
[B+C] Adds replacement block data related methods. Adds BUKKIT-5444

### DIFF
--- a/src/main/java/org/bukkit/block/Block.java
+++ b/src/main/java/org/bukkit/block/Block.java
@@ -82,7 +82,7 @@ public interface Block extends Metadatable {
      */
     @Deprecated
     int getTypeId();
-    
+
     /**
      * Gets the type and metadata for this block
      *
@@ -229,7 +229,7 @@ public interface Block extends Metadatable {
      */
     @Deprecated
     boolean setTypeIdAndData(int type, byte data, boolean applyPhysics);
-    
+
     /**
      * Sets the type of this block
      *
@@ -238,7 +238,7 @@ public interface Block extends Metadatable {
      * @return whether the block was changed
      */
     boolean setTypeData(MaterialData data, boolean applyPhysics);
-    
+
     /**
      * Sets the type of this block
      *

--- a/src/main/java/org/bukkit/block/Block.java
+++ b/src/main/java/org/bukkit/block/Block.java
@@ -7,6 +7,7 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.Location;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.material.MaterialData;
 import org.bukkit.metadata.Metadatable;
 
 /**
@@ -21,6 +22,7 @@ public interface Block extends Metadatable {
      * Gets the metadata for this block
      *
      * @return block specific metadata
+     * @see #getTypeData()
      * @deprecated Magic value
      */
     @Deprecated
@@ -80,6 +82,13 @@ public interface Block extends Metadatable {
      */
     @Deprecated
     int getTypeId();
+    
+    /**
+     * Gets the type and metadata for this block
+     *
+     * @return type and metadata as a MaterialData object
+     */
+    MaterialData getTypeData();
 
     /**
      * Gets the light level between 0-15
@@ -163,6 +172,7 @@ public interface Block extends Metadatable {
      * Sets the metadata for this block
      *
      * @param data New block specific metadata
+     * @see #setType(MaterialData data)
      * @deprecated Magic value
      */
     @Deprecated
@@ -173,6 +183,7 @@ public interface Block extends Metadatable {
      *
      * @param data New block specific metadata
      * @param applyPhysics False to cancel physics from the changed block.
+     * @see #setType(MaterialData data, boolean applyPhysics)
      * @deprecated Magic value
      */
     @Deprecated
@@ -213,10 +224,28 @@ public interface Block extends Metadatable {
      * @param data The data value to change this block to
      * @param applyPhysics False to cancel physics on the changed block
      * @return whether the block was changed
+     * @see #setType(MaterialData data, boolean applyPhysics)
      * @deprecated Magic value
      */
     @Deprecated
     boolean setTypeIdAndData(int type, byte data, boolean applyPhysics);
+    
+    /**
+     * Sets the type of this block
+     *
+     * @param data The type and data value to change this block to
+     * @param applyPhysics False to cancel physics on the changed block
+     * @return whether the block was changed
+     */
+    boolean setType(MaterialData data, boolean applyPhysics);
+    
+    /**
+     * Sets the type of this block
+     *
+     * @param data The type and data value to change this block to
+     * @return whether the block was changed
+     */
+    boolean setType(MaterialData data);
 
     /**
      * Gets the face relation of this block compared to the given block

--- a/src/main/java/org/bukkit/block/Block.java
+++ b/src/main/java/org/bukkit/block/Block.java
@@ -172,7 +172,7 @@ public interface Block extends Metadatable {
      * Sets the metadata for this block
      *
      * @param data New block specific metadata
-     * @see #setType(MaterialData data)
+     * @see #setTypeData(MaterialData data)
      * @deprecated Magic value
      */
     @Deprecated
@@ -183,7 +183,7 @@ public interface Block extends Metadatable {
      *
      * @param data New block specific metadata
      * @param applyPhysics False to cancel physics from the changed block.
-     * @see #setType(MaterialData data, boolean applyPhysics)
+     * @see #setTypeData(MaterialData data, boolean applyPhysics)
      * @deprecated Magic value
      */
     @Deprecated
@@ -224,7 +224,7 @@ public interface Block extends Metadatable {
      * @param data The data value to change this block to
      * @param applyPhysics False to cancel physics on the changed block
      * @return whether the block was changed
-     * @see #setType(MaterialData data, boolean applyPhysics)
+     * @see #setTypeData(MaterialData data, boolean applyPhysics)
      * @deprecated Magic value
      */
     @Deprecated
@@ -237,7 +237,7 @@ public interface Block extends Metadatable {
      * @param applyPhysics False to cancel physics on the changed block
      * @return whether the block was changed
      */
-    boolean setType(MaterialData data, boolean applyPhysics);
+    boolean setTypeData(MaterialData data, boolean applyPhysics);
     
     /**
      * Sets the type of this block
@@ -245,7 +245,7 @@ public interface Block extends Metadatable {
      * @param data The type and data value to change this block to
      * @return whether the block was changed
      */
-    boolean setType(MaterialData data);
+    boolean setTypeData(MaterialData data);
 
     /**
      * Gets the face relation of this block compared to the given block


### PR DESCRIPTION
#### The Issue:

When magic values were deprecated, no direct way was provided for dealing with block data that wasnt deprecated. This PR adds 3 new methods for using MaterialData to set and get block data.
#### Justification for this PR:

The existing way to set a block type based on material data involves creating a BlockState instance, setting the data, then updating it. This process should be simplified to improve code readability, and awareness of this alternative to setting raw data values.
#### PR Breakdown:

This PR adds 3 methods to Block.java:
- setTypeData(MaterialData data)
- setTypeData(MaterialData data, boolean allowPhysics)
- MaterialData getTypeData()

The methods for setting MaterialData set both type and data value from the MaterialData object.
#### Testing Results and Materials:

A simple plugin was used. On a right click of a block, it grabbed the MaterialData object through the getTypeData() method, then if it was a sign it inverted the direction; if it was a log, it cycled the direction of the log. Last, it set the block back to the MaterialData object using the setTypeData(MaterialData, boolean) method. 

In all cases the block was set back to the correct block type (the same type for everything except signs and logs). Planks did cycle through their data values but this is because they use the Tree MaterialData object as well as logs

Test plugin (source inside jar):
https://www.dropbox.com/s/kvsfjkmobe9ixkb/TestPlugin.jar
#### Relevant PR(s):

CraftBukkit Pull Request: Bukkit/CraftBukkit#1350
#### JIRA Ticket:

https://bukkit.atlassian.net/browse/BUKKIT-5444
