### PR TITLE
[B+C] Add EntitySpawnEvent. Adds Bukkit-1559

### DIFF
--- a/src/main/java/org/bukkit/event/entity/EntitySpawnEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntitySpawnEvent.java
@@ -1,0 +1,83 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.Location;
+import org.bukkit.entity.CreatureType;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Called when a entity is spawned into a world.
+ * <p>
+ * If a Entity Spawn event is cancelled, the entity will not spawn.
+ */
+public class EntitySpawnEvent extends EntityEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean canceled;
+    private final SpawnReason spawnReason;
+
+    public EntitySpawnEvent(final Entity spawnee, final SpawnReason spawnReason) {
+        super(spawnee);
+        this.spawnReason = spawnReason;
+    }
+
+    public boolean isCancelled() {
+        return canceled;
+    }
+
+    public void setCancelled(boolean cancel) {
+        canceled = cancel;
+    }
+
+    @Override
+    public LivingEntity getEntity() {
+        return (LivingEntity) entity;
+    }
+
+    /**
+     * Gets the location at which the entity is spawning.
+     *
+     * @return The location at which the entity is spawning
+     */
+    public Location getLocation() {
+        return getEntity().getLocation();
+    }
+
+    /**
+     * Gets the reason for why the entity is being spawned.
+     *
+     * @return A SpawnReason value detailing the reason for the entity being
+     *     spawned
+     */
+    public SpawnReason getSpawnReason() {
+        return spawnReason;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    /**
+     * An enum to specify the type of spawning
+     */
+    public enum SpawnReason {
+    	/**
+    	 * When an entity is spawned via dispenser
+    	 */
+    	DISPENSER,
+        /**
+         * When an entity is spawned by plugins
+         */
+        CUSTOM,
+        /**
+         * When an entity is missing a SpawnReason
+         */
+        DEFAULT
+    }
+}

--- a/src/main/java/org/bukkit/event/entity/EntitySpawnEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntitySpawnEvent.java
@@ -1,16 +1,30 @@
 package org.bukkit.event.entity;
 
 import org.bukkit.Location;
-import org.bukkit.entity.CreatureType;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Projectile;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
 
 /**
- * Called when a entity is spawned into a world.
+ * Called when a entity is spawned into a world. This is not called for some
+ * entities, see table below for the right events for those.
  * <p>
  * If a Entity Spawn event is cancelled, the entity will not spawn.
+ * </p>
+ * <p>
+ * Entity spawns not handled by this event are {@link LivingEntity},
+ * {@link Item}, and {@link Projectile} spawns. They can be tracked with the
+ * existing events {@link CreatureSpawnEvent}, {@link ItemSpawnEvent}, and
+ * {@link ProjectileLaunchEvent}, respectively.
+ * </p>
+ * 
+ * @see CreatureSpawnEvent
+ * @see ItemSpawnEvent
+ * @see ProjectileLaunchEvent
  */
 public class EntitySpawnEvent extends EntityEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
@@ -31,13 +45,13 @@ public class EntitySpawnEvent extends EntityEvent implements Cancellable {
     }
 
     @Override
-    public LivingEntity getEntity() {
-        return (LivingEntity) entity;
+    public Entity getEntity() {
+        return entity;
     }
 
     /**
      * Gets the location at which the entity is spawning.
-     *
+     * 
      * @return The location at which the entity is spawning
      */
     public Location getLocation() {
@@ -46,9 +60,9 @@ public class EntitySpawnEvent extends EntityEvent implements Cancellable {
 
     /**
      * Gets the reason for why the entity is being spawned.
-     *
+     * 
      * @return A SpawnReason value detailing the reason for the entity being
-     *     spawned
+     *         spawned
      */
     public SpawnReason getSpawnReason() {
         return spawnReason;
@@ -61,23 +75,5 @@ public class EntitySpawnEvent extends EntityEvent implements Cancellable {
 
     public static HandlerList getHandlerList() {
         return handlers;
-    }
-
-    /**
-     * An enum to specify the type of spawning
-     */
-    public enum SpawnReason {
-    	/**
-    	 * When an entity is spawned via dispenser
-    	 */
-    	DISPENSER,
-        /**
-         * When an entity is spawned by plugins
-         */
-        CUSTOM,
-        /**
-         * When an entity is missing a SpawnReason
-         */
-        DEFAULT
     }
 }

--- a/src/main/java/org/bukkit/event/entity/EntitySpawnEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntitySpawnEvent.java
@@ -21,7 +21,7 @@ import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
  * existing events {@link CreatureSpawnEvent}, {@link ItemSpawnEvent}, and
  * {@link ProjectileLaunchEvent}, respectively.
  * </p>
- * 
+ *
  * @see CreatureSpawnEvent
  * @see ItemSpawnEvent
  * @see ProjectileLaunchEvent
@@ -51,7 +51,7 @@ public class EntitySpawnEvent extends EntityEvent implements Cancellable {
 
     /**
      * Gets the location at which the entity is spawning.
-     * 
+     *
      * @return The location at which the entity is spawning
      */
     public Location getLocation() {
@@ -60,7 +60,7 @@ public class EntitySpawnEvent extends EntityEvent implements Cancellable {
 
     /**
      * Gets the reason for why the entity is being spawned.
-     * 
+     *
      * @return A SpawnReason value detailing the reason for the entity being
      *         spawned
      */


### PR DESCRIPTION
##### The Issue:

Most entity spawns cannot be tracked with events, and polling is required to track new entities.
##### Justification:

Polling the server with background loops is heavy on performance. The proper way to check for spawning in Bukkit is through CreatureSpawnEvent, but this only handles LivingEntity.
##### PR Breakdown:

Adds a new event called EntitySpawnEvent, which tracks all entity spawns not already handled by events (LivingEntity, Item, and Projectile).
##### Testing:

Test plugin here: https://github.com/kenzierocks/TestPluginBukkit1559/
It tracks all entity spawns via the new event, and logs them to the console. Use /cancel-spawns to toggle canceling the event.
##### Relevant PRs:

CB: https://github.com/Bukkit/CraftBukkit/pull/1354
##### Ticket:

https://bukkit.atlassian.net/browse/BUKKIT-1559
