### PR TITLE
[B+C] Add getResourcePack(). Adds BUKKIT-3615

### DIFF
--- a/src/main/java/org/bukkit/Bukkit.java
+++ b/src/main/java/org/bukkit/Bukkit.java
@@ -666,11 +666,7 @@ public final class Bukkit {
     }
 
     /**
-     * Gets the user-specified resource pack URL.
-     * 
-     * Defaults to an empty string if there is none.
-     * 
-     * @return the resource pack the server provides
+     * @see Server#getResourcePack()
      */
     public static String getResourcePack() {
         return server.getResourcePack();

--- a/src/main/java/org/bukkit/Bukkit.java
+++ b/src/main/java/org/bukkit/Bukkit.java
@@ -664,6 +664,10 @@ public final class Bukkit {
     public static ScoreboardManager getScoreboardManager() {
         return server.getScoreboardManager();
     }
+    
+    public static String getResourcePack() {
+        return server.getResourcePack();
+    }
 
     /**
      * @see Server#getServerIcon()

--- a/src/main/java/org/bukkit/Bukkit.java
+++ b/src/main/java/org/bukkit/Bukkit.java
@@ -664,7 +664,14 @@ public final class Bukkit {
     public static ScoreboardManager getScoreboardManager() {
         return server.getScoreboardManager();
     }
-    
+
+    /**
+     * Gets the user-specified resource pack URL.
+     * 
+     * Defaults to an empty string if there is none.
+     * 
+     * @return the resource pack the server provides
+     */
     public static String getResourcePack() {
         return server.getResourcePack();
     }

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -644,7 +644,7 @@ public interface Server extends PluginMessageRecipient {
      *
      * @param owner The holder of the inventory; can be null if there's no
      *     holder.
-     * @param type The type of inventory to create.~/Documents/mcdevelopment/TestPluginBukkit3615
+     * @param type The type of inventory to create.
      * @return The new inventory.
      */
     Inventory createInventory(InventoryHolder owner, InventoryType type);
@@ -671,7 +671,7 @@ public interface Server extends PluginMessageRecipient {
      * @param title The title of the inventory, to be displayed when it is
      *     viewed.
      * @return The new inventory.
-     * @throws IllegalArgumentException If the size is not a multiple of~/Documents/mcdevelopment/TestPluginBukkit3615 9.
+     * @throws IllegalArgumentException If the size is not a multiple of 9.
      */
     Inventory createInventory(InventoryHolder owner, int size, String title);
 

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -809,6 +809,12 @@ public interface Server extends PluginMessageRecipient {
     public int getIdleTimeout();
 
     /**
+     * Gets the user-specified resource pack URL
+     * @return the resource pack the server provides
+     */
+    public String getResourcePack();
+
+    /**
      * @see UnsafeValues
      */
     @Deprecated

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -809,9 +809,8 @@ public interface Server extends PluginMessageRecipient {
     public int getIdleTimeout();
 
     /**
-     * Gets the user-specified resource pack URL.
-     * 
-     * Defaults to an empty string if there is none.
+     * Gets the user-specified resource pack URL. It defaults to an empty string
+     * if there is no specified URL.
      * 
      * @return the resource pack the server provides
      */

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -644,7 +644,7 @@ public interface Server extends PluginMessageRecipient {
      *
      * @param owner The holder of the inventory; can be null if there's no
      *     holder.
-     * @param type The type of inventory to create.
+     * @param type The type of inventory to create.~/Documents/mcdevelopment/TestPluginBukkit3615
      * @return The new inventory.
      */
     Inventory createInventory(InventoryHolder owner, InventoryType type);
@@ -671,7 +671,7 @@ public interface Server extends PluginMessageRecipient {
      * @param title The title of the inventory, to be displayed when it is
      *     viewed.
      * @return The new inventory.
-     * @throws IllegalArgumentException If the size is not a multiple of 9.
+     * @throws IllegalArgumentException If the size is not a multiple of~/Documents/mcdevelopment/TestPluginBukkit3615 9.
      */
     Inventory createInventory(InventoryHolder owner, int size, String title);
 
@@ -809,7 +809,10 @@ public interface Server extends PluginMessageRecipient {
     public int getIdleTimeout();
 
     /**
-     * Gets the user-specified resource pack URL
+     * Gets the user-specified resource pack URL.
+     * 
+     * Defaults to an empty string if there is none.
+     * 
      * @return the resource pack the server provides
      */
     public String getResourcePack();


### PR DESCRIPTION
##### The Issue:

Most values from `server.properties` are exposed via `Bukkit` and `Server`, however the `resource-pack` value is not.
##### Justification:

This is needed to expose the `resource-pack` value of the `server.properties` file. It can be used for re-sending the resource-pack to the player, or just for info in general.
##### PR Breakdown:

Adds `getResourcePack()` to `Bukkit` and `Server`, and implemented in `CraftServer` like other `server.properties` values.
##### Testing:

Test plugin here: https://github.com/kenzierocks/TestPluginBukkit3615
It logs the value of `resource-pack` on startup.
##### Relevant PRs:

CB: https://github.com/Bukkit/CraftBukkit/pull/1355
##### Ticket:

https://bukkit.atlassian.net/browse/BUKKIT-3615
