### PR TITLE
[B] Minecraft allows a length of 20 for the Channel Name not 16

### DIFF
--- a/src/main/java/org/bukkit/plugin/messaging/Messenger.java
+++ b/src/main/java/org/bukkit/plugin/messaging/Messenger.java
@@ -18,7 +18,7 @@ public interface Messenger {
     /**
      * Represents the largest size that a Plugin Channel may be.
      */
-    public static final int MAX_CHANNEL_SIZE = 16;
+    public static final int MAX_CHANNEL_SIZE = 20;
 
     /**
      * Checks if the specified channel is a reserved name.

--- a/src/test/java/org/bukkit/plugin/messaging/StandardMessengerTest.java
+++ b/src/test/java/org/bukkit/plugin/messaging/StandardMessengerTest.java
@@ -2,10 +2,15 @@ package org.bukkit.plugin.messaging;
 
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.TestPlugin;
-import java.util.Collection;
 import org.junit.Test;
-import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.*;
+
+import java.util.Collection;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class StandardMessengerTest {
     public StandardMessenger getMessenger() {
@@ -280,6 +285,31 @@ public class StandardMessengerTest {
         assertEquals(messenger.getIncomingChannelRegistrations(plugin2, "baz"), registration5, registration6);
         assertEquals(messenger.getIncomingChannelRegistrations(plugin1, "baz"));
         assertEquals(messenger.getIncomingChannelRegistrations(plugin3, "qux"));
+    }
+
+    @Test(expected = ChannelNameTooLongException.class)
+    public void testIncomingChannelNameTooLong() {
+        Messenger messenger = getMessenger();
+        TestPlugin plugin1 = getPlugin();
+
+        messenger.registerIncomingPluginChannel(plugin1, "ThisShouldFailSinceItIsLongerAsMaximumAllowedCharacters", new TestMessageListener("foo", "bar".getBytes()));
+    }
+
+    @Test(expected = ChannelNameTooLongException.class)
+    public void testOutgoingChannelNameTooLong() {
+        Messenger messenger = getMessenger();
+        TestPlugin plugin1 = getPlugin();
+
+        messenger.registerOutgoingPluginChannel(plugin1, "ThisShouldFailSinceItIsLongerAsMaximumAllowedCharacters");
+    }
+
+    @Test
+    public void testChannelNameLengthRegister() {
+        Messenger messenger = getMessenger();
+        TestPlugin plugin1 = getPlugin();
+
+        PluginMessageListenerRegistration registration1 = messenger.registerIncomingPluginChannel(plugin1, "ThisIs20CharsLong...", new TestMessageListener("foo", "bar".getBytes()));
+        assertEquals(messenger.getIncomingChannelRegistrations(plugin1, "ThisIs20CharsLong..."), registration1);
     }
 
     private static <T> void assertEquals(Collection<T> actual, T... expected) {


### PR DESCRIPTION
The Issue:

Bukkit throws a Exception because the Channel Name is too long when using a Plugin Message Channel of the length of 18.

Justification for this PR:

Set the Bukkit allowed max Channel length to 20 to match up the latest NMS Code for CustomPayloads

Testing Results and Materials:

This PR does only change the limit. It works fine now with a 18 character long Plugin Message Channel

JIRA Ticket:

BUKKIT-5472: https://bukkit.atlassian.net/browse/BUKKIT-5472
