### PR TITLE
[B+C] Add ability to make items glow. Adds BUKKIT-4767

### DIFF
--- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
+++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
@@ -124,6 +124,36 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable {
     */
     boolean hasConflictingEnchant(Enchantment ench);
 
+    /**
+     * Checks if this item meta has a glowing effect.
+     * <p>
+     * This will return true if this item meta has enchantments or if a
+     * plugin added a glowing effect with the setGlow(boolean) method.
+     * Note that this only reads enchantment glow, so this method will
+     * not reflect what can actually be seen in game for Blocks (which
+     * cannot be enchanted) and for items like Nether Stars (which already
+     * have a different kind of glow effect).
+     *
+     * @return true if this item meta has a glowing effect, false otherwise
+     */
+    boolean hasGlow();
+
+    /**
+     * Attempt to change the glowing state of this item meta.
+     * <p>
+     * This will not do anything if this item meta has enchantments.
+     * <p>
+     * Note that this only adds/removes a fake enchantment glow, so this
+     * method will not reflect what can actually be seen in game for Blocks
+     * (which cannot be enchanted) and for items like Nether Stars (which
+     * already have a different kind of glow effect).
+     *
+     * @param value new value for the glowing effect
+     * @return true if the glowing state of this item meta changed, false
+     *     otherwise
+     */
+    boolean setGlow(boolean value);
+
     @SuppressWarnings("javadoc")
     ItemMeta clone();
 }


### PR DESCRIPTION
### The Issue:

There's no way to make an ItemStack glow without adding an Enchantment to it. Some plugins are using reflection and/or NMS access to do it.
### Justification for this PR:

This adds a simple way to make an ItemStack glow.
### PR Breakdown:
##### Bukkit

Added hasGlow() and setGlow(boolean) methods to ItemMeta.
##### CraftBukkit

Implemented hasGlow() and setGlow(boolean) methods in CraftMetaItem and make related changes to the class. We make use of the difference between a null Enchantments map and an empty Enchantments map. The glow effect without enchantments is achived by having the 'ench' NBT tag without any enchantment.
### Testing Results and Materials:

Test Plugin: https://github.com/Ribesg/TestPlugin/tree/BUKKIT-4767
Build everything yourself to test it as we're not allowed to link CB builds here.
### Relevant PR(s):

CB-1363 - https://github.com/Bukkit/CraftBukkit/pull/1363 - Associated CraftBukkit PR
### JIRA Ticket:

BUKKIT-4767 - https://bukkit.atlassian.net/browse/BUKKIT-4767
