### PR TITLE
[B] Fix for resetting the BukkitRunnable taskId to -1 when canceled. Fixes BUKKIT-5529

### DIFF
--- a/src/main/java/org/bukkit/scheduler/BukkitRunnable.java
+++ b/src/main/java/org/bukkit/scheduler/BukkitRunnable.java
@@ -16,6 +16,7 @@ public abstract class BukkitRunnable implements Runnable {
      */
     public synchronized void cancel() throws IllegalStateException {
         Bukkit.getScheduler().cancelTask(getTaskId());
+        this.taskId = -1;
     }
 
     /**


### PR DESCRIPTION
**The Issue:**

BukkitRunnable does not set the stored taskId back to -1 once the cancel() method is called, thus preventing it from later rescheduling using its runTask methods

**Justification for this PR:**

One of the purposes for the BukkitRunnable class is for convenience, and this bug defeats that purpose. Currently, it is only useful for scheduling the task once, and if someone wants to cancel the task and then schedule it again later, they will get an IllegalStateException since the taskId still has the value of the previous schedule.

**PR Breakdown:**

This PR simply adds one line to the cancel method after the scheduler cancel method is called to set the private taskId to -1.

```
public synchronized void cancel() throws IllegalStateException {
    Bukkit.getScheduler().cancelTask(getTaskId());
    this.taskId = -1;
}
```

**Testing Results and Materials:**

I set up a simple scheduler class that extended BukkitRunnable, to test if I could cancel the currently running task, and schedule a new task with a different tick repeat rate. Previously, calling `super.runTaskTimer(plugin, 0, MINUTE_IN_TICKS);` after calling `super.cancel()`, would throw `IllegalStateException("Already scheduled as " + taskId)`, but now that the taskId is set back to -1 when canceling, the scheduler behaved like it should have, and I was able to cancel the currently running task, and schedule a new task with a new tick repeat rate.

**JIRA Ticket:**

BUKKIT-5529 - https://bukkit.atlassian.net/browse/BUKKIT-5529
