### PR TITLE
[B+C] Biome distribution for world generation. Adds BUKKIT-5544

### DIFF
--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -1,6 +1,7 @@
 package org.bukkit;
 
 import java.io.File;
+import org.bukkit.generator.BiomeGenerator;
 import org.bukkit.generator.ChunkGenerator;
 import java.util.Collection;
 import java.util.HashMap;
@@ -660,6 +661,13 @@ public interface World extends PluginMessageRecipient, Metadatable {
      * @return ChunkGenerator associated with this world
      */
     public ChunkGenerator getGenerator();
+
+    /**
+     * Gets the biome generator for this world
+     *
+     * @return BiomeGenerator associated with this world
+     */
+    public BiomeGenerator getBiomeGenerator();
 
     /**
      * Saves world to disk

--- a/src/main/java/org/bukkit/generator/BiomeGenerator.java
+++ b/src/main/java/org/bukkit/generator/BiomeGenerator.java
@@ -1,0 +1,34 @@
+package org.bukkit.generator;
+
+import org.bukkit.World;
+import org.bukkit.block.Biome;
+
+public abstract class BiomeGenerator {
+    /**
+     * Determines which biomes should be used for world generation for the given chunk. Result must be a Biome[256] for
+     * the 16x16 area of the chunk.
+     * 
+     * @param world The world the chunk is for
+     * @param x X-coordinate of the chunk
+     * @param z Z-coordinate of the chunk
+     * @return Biome[256] containing biomes for each location in the chunk
+     */
+    public abstract Biome[] generateChunkBiomes(World world, int x, int z);
+
+    /**
+     * Determines which biome should used for world generation at the given coordinates.
+     * 
+     * @param world The world the biome is for
+     * @param x X-coordinate for the biome
+     * @param z Z-coordinate for the biome
+     * @return Biome for the location
+     */
+    public abstract Biome generateBiome(World world, int x, int z);
+
+    /**
+     * Called by the server every tick. Can be used to occasionally clean up old data from a cache if needed.
+     * 
+     * @param world The world the cache is for
+     */
+    public abstract void cleanupCache(World world);
+}

--- a/src/main/java/org/bukkit/plugin/Plugin.java
+++ b/src/main/java/org/bukkit/plugin/Plugin.java
@@ -7,6 +7,7 @@ import java.util.logging.Logger;
 import org.bukkit.Server;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.generator.BiomeGenerator;
 import org.bukkit.generator.ChunkGenerator;
 
 import com.avaje.ebean.EbeanServer;
@@ -167,6 +168,17 @@ public interface Plugin extends TabExecutor {
      * @return ChunkGenerator for use in the default world generation
      */
     public ChunkGenerator getDefaultWorldGenerator(String worldName, String id);
+
+    /**
+     * Gets a {@link BiomeGenerator} for use in a default world, as specified
+     * in the server configuration
+     *
+     * @param worldName Name of the world that this will be applied to
+     * @param id Unique ID, if any, that was specified to indicate which
+     *     biome-generator was requested
+     * @return BiomeGenerator for use in the default world generation
+     */
+    public BiomeGenerator getDefaultBiomeGenerator(String worldName, String id);
 
     /**
      * Returns the plugin logger associated with this server's logger. The

--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
@@ -20,6 +20,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.generator.BiomeGenerator;
 import org.bukkit.generator.ChunkGenerator;
 import org.bukkit.plugin.AuthorNagException;
 import org.bukkit.plugin.PluginBase;
@@ -369,6 +370,10 @@ public abstract class JavaPlugin extends PluginBase {
     public void onEnable() {}
 
     public ChunkGenerator getDefaultWorldGenerator(String worldName, String id) {
+        return null;
+    }
+
+    public BiomeGenerator getDefaultBiomeGenerator(String worldName, String id) {
         return null;
     }
 

--- a/src/test/java/org/bukkit/plugin/TestPlugin.java
+++ b/src/test/java/org/bukkit/plugin/TestPlugin.java
@@ -8,6 +8,7 @@ import org.bukkit.Server;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.generator.BiomeGenerator;
 import org.bukkit.generator.ChunkGenerator;
 
 import com.avaje.ebean.EbeanServer;
@@ -98,6 +99,10 @@ public class TestPlugin extends PluginBase {
     }
 
     public ChunkGenerator getDefaultWorldGenerator(String worldName, String id) {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    public BiomeGenerator getDefaultBiomeGenerator(String worldName, String id) {
         throw new UnsupportedOperationException("Not supported.");
     }
 


### PR DESCRIPTION
## The Issue:

No way to influence biome distribution of vanilla world generation.
## Justification for this PR:

Implements the desired feature from BUKKIT-5544. Does not require changes to new NMS classes. Works very similar to ChunkGenerators so interface is familiar to users.
## PR Breakdown:

BiomeGenerator's behave for the most part just like ChunkGenerator's. They are stored in the same places. They are created by querying a plugin. They are specified by the user in bukkit.yml.

The biggest addition to CB is the CustomWorldChunkManager which extends the NMS class WorldChunkManager. This new class is used in place of the NMS one only if a BiomeGenerator plugin is being used. Therefore there should be no significant effect on servers which are not using this new feature. The implementation of CustomWorldChunkManager is largely inspired by that of the NMS one, only it allows a BiomeGenerator to be passed as a parameter to the constructor to change the biome distribution.

Big changes to Bukkit are the new abstract class BiomeGenerator which is used much like a ChunkGenerator. And there is a new method (getDefaultBiomeGenerator) on Plugin which users can override to install their BiomeGenerator, again much like ChunkGenerator.
## Testing Results and Materials:

Ran server with modifications but without changing any settings. World generation was unaffected.

Ran server with modifications and added a biome-generator to bukkit.yml for default world. Biome distribution was modified as specified in my test biome-generator (https://github.com/hoqhuuep/ExampleBiomeGenerator/blob/master/ExampleBiomeGenerator/src/main/java/com/github/hoqhuuep/biomegenerator/ExampleBiomeGenerator.java).
## Relevant PR(s):

CB-1364 - https://github.com/Bukkit/CraftBukkit/pull/1364
Bukkit PR (this PR)
## JIRA Ticket:

https://bukkit.atlassian.net/browse/BUKKIT-5544
