### PR TITLE
[B+C] Add API to get last known player name. Add BUKKIT-5551

### DIFF
--- a/src/main/java/org/bukkit/OfflinePlayer.java
+++ b/src/main/java/org/bukkit/OfflinePlayer.java
@@ -117,6 +117,8 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
 
     /**
     * Get LastKnown Player Name in case name changed.
+    * LastName is stored while the previous game session.
+    * This name is not unique, see {@link #getUniqueId()} instead.
     * @return Last known name if exists, otherwise current name.
     */
     public String getLastKnownName();

--- a/src/main/java/org/bukkit/OfflinePlayer.java
+++ b/src/main/java/org/bukkit/OfflinePlayer.java
@@ -115,4 +115,11 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
      */
     public Location getBedSpawnLocation();
 
+    /**
+    * Get LastKnown Player Name in case name changing
+    * @return Last known name if exists, otherwise null,
+    * will return null if last known name equals actual name
+    */
+    public String getLastKnownName();
+
 }

--- a/src/main/java/org/bukkit/OfflinePlayer.java
+++ b/src/main/java/org/bukkit/OfflinePlayer.java
@@ -116,9 +116,8 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
     public Location getBedSpawnLocation();
 
     /**
-    * Get LastKnown Player Name in case name changing
-    * @return Last known name if exists, otherwise null,
-    * will return null if last known name equals actual name
+    * Get LastKnown Player Name in case name changed.
+    * @return Last known name if exists, otherwise current name.
     */
     public String getLastKnownName();
 


### PR DESCRIPTION
The Issue:

There is no api to get last known player name in case future name changing.

Justification for this PR:

This adds a simple getLastKnownName to OfflinePlayer

PR Breakdown:

Bukkit

Add getLastKnownName to OfflinePlayer

CraftBukkit

Implement getLastKnownName by getting correct nbttag

Relevant PR(s):

CB-1365 - https://github.com/Bukkit/CraftBukkit/pull/1365 - Associated CraftBukkit PR

JIRA Ticket:

BUKKIT-5551 - https://bukkit.atlassian.net/browse/BUKKIT-5551
