### PR TITLE
[B+C] Allows us to detect when entities dismount

### DIFF
--- a/src/main/java/org/bukkit/event/entity/EntityDismountEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDismountEvent.java
@@ -1,0 +1,46 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Called whenever an entity dismounts from another entity.
+ */
+public class EntityDismountEvent extends EntityEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+
+    private boolean cancelled;
+    private Entity exited = null;
+
+    public EntityDismountEvent(Entity passenger, Entity exited) {
+        super(passenger);
+        this.exited = exited;
+    }
+
+    /**
+     * Get the exited entity.
+     */
+    public Entity getExited() {
+        return this.exited;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}


### PR DESCRIPTION
The Issue:

We cannot detect when an entity dismounts from an entity yet without using dodgy/buggy methods such as scheduling a task every tick. (Schedulers has been tested and glitches a lot)

Justification for this PR:

This is an event that should have been added long ago in my, and many other developers' opinions as we should be able to detect when an entity ejects from being a passenger. This will be very useful in cases such as having multiple inventories for players on different entities and so you can detect when the player ejects and set their inventory back to their original inventory.

PR Breakdown:

I added an EntityDismountEvent class that will be called when setPassenger(null) is called or eject() (if eject() does not already call setPassenger(null)).

Testing Results and Materials:

Doesn't need testing yet as I must add this to CraftBukkit.

Relevant PR(s):

B-1062 - https://github.com/Bukkit/Bukkit/pull/1062 - Added EntityDismountEvent

JIRA Ticket:

BUKKIT-5602 - https://bukkit.atlassian.net/browse/BUKKIT-5602
