### PR TITLE
[B] Stop help topics with no value printing nothing - Fixes BUKKIT-5623

### DIFF
--- a/src/main/java/org/bukkit/help/GenericCommandHelpTopic.java
+++ b/src/main/java/org/bukkit/help/GenericCommandHelpTopic.java
@@ -1,13 +1,11 @@
 package org.bukkit.help;
 
+import org.apache.commons.lang.StringUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
-import org.apache.commons.lang.StringUtils;
 import org.bukkit.command.ConsoleCommandSender;
-import org.bukkit.command.PluginCommand;
 import org.bukkit.command.defaults.VanillaCommand;
-import org.bukkit.help.HelpTopic;
 
 /**
  * Lacking an alternative, the help system will create instances of
@@ -42,14 +40,26 @@ public class GenericCommandHelpTopic extends HelpTopic {
         sb.append(ChatColor.GOLD);
         sb.append("Description: ");
         sb.append(ChatColor.WHITE);
-        sb.append(command.getDescription());
+
+        if (command.getDescription().isEmpty()) {
+            sb.append(ChatColor.ITALIC);
+            sb.append("No information available.");
+        } else {
+            sb.append(command.getDescription());
+        }
 
         sb.append("\n");
 
         sb.append(ChatColor.GOLD);
         sb.append("Usage: ");
         sb.append(ChatColor.WHITE);
-        sb.append(command.getUsage().replace("<command>", name.substring(1)));
+
+        if (command.getUsage().isEmpty()) {
+            sb.append(ChatColor.ITALIC);
+            sb.append("No information available.");
+        } else {
+            sb.append(command.getUsage().replace("<command>", name.substring(1)));
+        }
 
         if (command.getAliases().size() > 0) {
             sb.append("\n");

--- a/src/main/java/org/bukkit/help/IndexHelpTopic.java
+++ b/src/main/java/org/bukkit/help/IndexHelpTopic.java
@@ -106,7 +106,7 @@ public class IndexHelpTopic extends HelpTopic {
         line.append(topic.getName());
         line.append(": ");
         line.append(ChatColor.WHITE);
-        line.append(topic.getShortText());
+        line.append(topic.getShortText().isEmpty() ? ChatColor.ITALIC + "No information available." : topic.getShortText());
         return line.toString();
     }
 }


### PR DESCRIPTION
**The Issue:**
When a HelpTopic's ShortText is empty, the ingame help menu will print this empty text resulting in the blank space as shown below. This is not very helpful, and could confuse any person seeking help from this topic.

**Justification for this PR:**
To clear any confusion from missing values in command help and information,

**PR Breakdown:**
_GenericCommandHelpTopic.java (Look at the second screenshot)_
The modifications to this file are in direct relation to specific command help. The changes check if the commands description and usage message are empty, then echo that no help is available instead of nothing. As the second screenshot shows, the before and after of these changes are much more organized and user friendly.

_IndexHelpTopic.java_
The inline if statement follows the same changes as GenericCommandHelpTopicreceived, which is checking if the shortText is empty, and if so echoing that no help is available.

**Testing Results and Materials:**
Used a custom built plugin with a command, that has no description/usage values. Compiled and tested locally, as reflected in the screenshots below.

**Relevant PR(s):**
There are no relevant PRs to this issue.

_Before changes_
![Before changes](http://i.imgur.com/gsoajJm.png)

_After changes_
![After changes](http://i.imgur.com/HAoA4tq.png)

**JIRA Ticket:**
BUKKIT-5623 - https://bukkit.atlassian.net/browse/BUKKIT-5623
