### PR TITLE
[B+C] Add Location.getNearbyEntities. Adds BUKKIT-3868

### DIFF
--- a/src/main/java/org/bukkit/Location.java
+++ b/src/main/java/org/bukkit/Location.java
@@ -1,8 +1,11 @@
 package org.bukkit;
 
 import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
 import org.bukkit.util.NumberConversions;
 import org.bukkit.util.Vector;
+
+import java.util.List;
 
 /**
  * Represents a 3-dimensional position in a world
@@ -80,6 +83,19 @@ public class Location implements Cloneable {
      */
     public Block getBlock() {
         return world.getBlockAt(this);
+    }
+
+    /**
+     * Returns a list of entities within a bounding box centered around this
+     * location
+     *
+     * @param x 1/2 the size of the box along x axis
+     * @param y 1/2 the size of the box along y axis
+     * @param z 1/2 the size of the box along z axis
+     * @return List<Entity> List of entities nearby
+     */
+    public List<Entity> getNearbyEntities(double x, double y, double z) {
+        return world.getEntities(this, x, y, z);
     }
 
     /**

--- a/src/main/java/org/bukkit/Location.java
+++ b/src/main/java/org/bukkit/Location.java
@@ -1,11 +1,11 @@
 package org.bukkit;
 
+import java.util.Collection;
+
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.util.NumberConversions;
 import org.bukkit.util.Vector;
-
-import java.util.Collection;
 
 /**
  * Represents a 3-dimensional position in a world

--- a/src/main/java/org/bukkit/Location.java
+++ b/src/main/java/org/bukkit/Location.java
@@ -5,7 +5,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.util.NumberConversions;
 import org.bukkit.util.Vector;
 
-import java.util.List;
+import java.util.Collection;
 
 /**
  * Represents a 3-dimensional position in a world
@@ -86,15 +86,15 @@ public class Location implements Cloneable {
     }
 
     /**
-     * Returns a list of entities within a bounding box centered around this
-     * location
+     * Returns a collection of entities within a bounding box centered
+     * around this location
      *
      * @param x 1/2 the size of the box along x axis
      * @param y 1/2 the size of the box along y axis
      * @param z 1/2 the size of the box along z axis
      * @return List<Entity> List of entities nearby
      */
-    public List<Entity> getNearbyEntities(double x, double y, double z) {
+    public Collection<Entity> getNearbyEntities(double x, double y, double z) {
         return world.getEntities(this, x, y, z);
     }
 

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -430,6 +430,18 @@ public interface World extends PluginMessageRecipient, Metadatable {
     public Collection<Entity> getEntitiesByClasses(Class<?>... classes);
 
     /**
+     * Returns a list of entities within a bounding box centered around the
+     * specified location
+     *
+     * @param center the center of the bounding box
+     * @param x 1/2 the size of the box along x axis
+     * @param y 1/2 the size of the box along y axis
+     * @param z 1/2 the size of the box along z axis
+     * @return List<Entity> List of entities nearby
+     */
+    public List<Entity> getEntities(Location center, double x, double y, double z);
+
+    /**
      * Get a list of all players in this World
      *
      * @return A list of all Players currently residing in this world

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -430,7 +430,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
     public Collection<Entity> getEntitiesByClasses(Class<?>... classes);
 
     /**
-     * Returns a list of entities within a bounding box centered around the
+     * Returns a collection of entities within a bounding box centered around the
      * specified location
      *
      * @param center the center of the bounding box
@@ -439,7 +439,35 @@ public interface World extends PluginMessageRecipient, Metadatable {
      * @param z 1/2 the size of the box along z axis
      * @return List<Entity> List of entities nearby
      */
-    public List<Entity> getEntities(Location center, double x, double y, double z);
+    public Collection<Entity> getEntities(Location center, double x, double y, double z);
+
+    /**
+     * Get a collection of all entities in this World matching the given
+     * class/interface within a specific area
+     *
+     * @param center the center of the bounding box
+     * @param x 1/2 the size of the box along x axis
+     * @param y 1/2 the size of the box along y axis
+     * @param z 1/2 the size of the box along z axis
+     * @param cls The class representing the type of entity to match
+     * @return A List of all Entities currently residing in this world that
+     *     match the given class/interface within the given area
+     */
+    public <T extends Entity> Collection<T> getEntitiesByClass(Location center, double x, double y, double z, Class<T> cls);
+
+    /**
+     * Get a collection of all entities in this World matching any of the
+     * given classes/interfaces within a specific area
+     *
+     * @param center the center of the bounding box
+     * @param x 1/2 the size of the box along x axis
+     * @param y 1/2 the size of the box along y axis
+     * @param z 1/2 the size of the box along z axis
+     * @param classes The classes representing the types of entity to match
+     * @return A List of all Entities currently residing in this world that
+     *     match one or more of the given classes/interfaces in the area
+     */
+    public Collection<Entity> getEntitiesByClasses(Location center, double x, double y, double z, Class<?>... classes);
 
     /**
      * Get a list of all players in this World

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -437,7 +437,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
      * @param x 1/2 the size of the box along x axis
      * @param y 1/2 the size of the box along y axis
      * @param z 1/2 the size of the box along z axis
-     * @return List<Entity> List of entities nearby
+     * @return A Collection of entities nearby
      */
     public Collection<Entity> getEntities(Location center, double x, double y, double z);
 
@@ -449,11 +449,11 @@ public interface World extends PluginMessageRecipient, Metadatable {
      * @param x 1/2 the size of the box along x axis
      * @param y 1/2 the size of the box along y axis
      * @param z 1/2 the size of the box along z axis
-     * @param cls The class representing the type of entity to match
-     * @return A List of all Entities currently residing in this world that
+     * @param clazz The class representing the type of entity to match
+     * @return A Collection of all Entities currently residing in this world that
      *     match the given class/interface within the given area
      */
-    public <T extends Entity> Collection<T> getEntitiesByClass(Location center, double x, double y, double z, Class<T> cls);
+    public <T extends Entity> Collection<T> getEntitiesByClass(Location center, double x, double y, double z, Class<T> clazz);
 
     /**
      * Get a collection of all entities in this World matching any of the
@@ -464,7 +464,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
      * @param y 1/2 the size of the box along y axis
      * @param z 1/2 the size of the box along z axis
      * @param classes The classes representing the types of entity to match
-     * @return A List of all Entities currently residing in this world that
+     * @return A Collection of all Entities currently residing in this world that
      *     match one or more of the given classes/interfaces in the area
      */
     public Collection<Entity> getEntitiesByClasses(Location center, double x, double y, double z, Class<?>... classes);


### PR DESCRIPTION
## The Issue

There is currently an Entity.getNearbyEntities() method, but no way to perform a similar check on an arbitrary Location without an Entity.
## Justification for this PR

This PR adds the Location.getNearbyEntities method requested in BUKKIT-3868, as well as a World.getEntities(Location, x, y, z) method that backs it. These additional utility methods provide a way for developers to efficiently query for entities within a given area, without needing a source Entity.
## PR Breakdown
### Bukkit

Add Location.getNearbyEntities(double x, double y, double z) and World.getEntities(Location center, double x, double y, double z)
### CraftBukkit

CraftWorld implements getEntities similarly to CraftEntity, except it passes in a null source Entity (given current NMS code, this is safe, the entity parameter is only used with "==" to filter out the source entity) and it creates an AABB rather than using a modified Entity BB.
## Testing Results and Materials

A test plugin can be found here:

https://github.com/NathanWolf/Bukkit-Unit-Tests/tree/Fix-BUKKIT-3868
http://mine.elmakers.com/share/Test-Fix-BUKKIT-3868.jar

This plugin will search for entities at your target block (block under cursor) when you swing (left-click) a stick or blaze rod.

A stick will check within 8 blocks, a blaze rod within 64. It will print a list of entity counts by type in the area, and can be used to validate that the correct entities are found.
## Relevant PR(s)

CB-1384: https://github.com/Bukkit/CraftBukkit/pull/1384 - Associated CB PR
## JIRA Ticket

https://bukkit.atlassian.net/browse/BUKKIT-3868
