### PR TITLE
[B+C] Add and implement an EntityDespawnEvent. adds BUKKIT-5645

### DIFF
--- a/src/main/java/org/bukkit/event/entity/EntityDespawnEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDespawnEvent.java
@@ -8,9 +8,25 @@ import org.bukkit.event.HandlerList;
  */
 public class EntityDespawnEvent extends EntityEvent {
     private static final HandlerList handlers = new HandlerList();
+    private final DespawnReason despawnReason;
 
     public EntityDespawnEvent(final Entity entity) {
         super(entity);
+        despawnReason = DespawnReason.DEFAULT;
+    }
+
+    public EntityDespawnEvent(final Entity entity, DespawnReason reason) {
+        super(entity);
+        despawnReason = reason;
+    }
+
+    /**
+     * Gets the reason for why the creature is being despawned.
+     *
+     * @return A DespawnReason value detailing the reason for the entity being despawned
+     */
+    public DespawnReason getDespawnReason() {
+        return despawnReason;
     }
 
     @Override
@@ -20,5 +36,20 @@ public class EntityDespawnEvent extends EntityEvent {
 
     public static HandlerList getHandlerList() {
         return handlers;
+    }
+
+    /**
+     * An enum to specify the type of despawning
+     */
+    public enum DespawnReason {
+
+        /**
+         * When an entity despawns due to a chunk unload
+         */
+        CHUNK_UNLOAD,
+        /**
+         * When an entity is missing a DespawnReason
+         */
+        DEFAULT
     }
 }

--- a/src/main/java/org/bukkit/event/entity/EntityDespawnEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDespawnEvent.java
@@ -7,42 +7,10 @@ import org.bukkit.event.HandlerList;
  * Called whenever an Entity is removed from the world.
  */
 public class EntityDespawnEvent extends EntityEvent {
-    private static final HandlerList handlers = new HandlerList();
-    private final DespawnReason despawnReason;
-
-    public EntityDespawnEvent(final Entity entity) {
-        super(entity);
-        despawnReason = DespawnReason.DEFAULT;
-    }
-
-    public EntityDespawnEvent(final Entity entity, DespawnReason reason) {
-        super(entity);
-        despawnReason = reason;
-    }
-
-    /**
-     * Gets the reason for why the creature is being despawned.
-     *
-     * @return A DespawnReason value detailing the reason for the entity being despawned
-     */
-    public DespawnReason getDespawnReason() {
-        return despawnReason;
-    }
-
-    @Override
-    public HandlerList getHandlers() {
-        return handlers;
-    }
-
-    public static HandlerList getHandlerList() {
-        return handlers;
-    }
-
     /**
      * An enum to specify the type of despawning
      */
     public enum DespawnReason {
-
         /**
          * When an entity despawns due to a chunk unload
          */
@@ -60,5 +28,36 @@ public class EntityDespawnEvent extends EntityEvent {
          * When an entity is missing a DespawnReason
          */
         DEFAULT
+    }
+    
+    private static final HandlerList handlers = new HandlerList();
+    private final DespawnReason despawnReason;
+
+    public EntityDespawnEvent(final Entity entity) {
+        super(entity);
+        despawnReason = DespawnReason.DEFAULT;
+    }
+
+    public EntityDespawnEvent(final Entity entity, DespawnReason reason) {
+        super(entity);
+        despawnReason = reason;
+    }
+
+    /**
+     * Gets the reason for why the entity is being despawned.
+     *
+     * @return The {@link DespawnReason} detailing the reason for the entity being despawned
+     */
+    public DespawnReason getDespawnReason() {
+        return despawnReason;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
     }
 }

--- a/src/main/java/org/bukkit/event/entity/EntityDespawnEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDespawnEvent.java
@@ -1,0 +1,24 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Thrown whenever an Entity is removed from the world
+ */
+public class EntityDespawnEvent extends EntityEvent {
+    private static final HandlerList handlers = new HandlerList();
+
+    public EntityDespawnEvent(final Entity entity) {
+        super(entity);
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/org/bukkit/event/entity/EntityDespawnEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDespawnEvent.java
@@ -48,6 +48,10 @@ public class EntityDespawnEvent extends EntityEvent {
          */
         CHUNK_UNLOAD,
         /**
+         * When a living entity despawns because it died
+         */
+        DEATH,
+        /**
          * When an entity is missing a DespawnReason
          */
         DEFAULT

--- a/src/main/java/org/bukkit/event/entity/EntityDespawnEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDespawnEvent.java
@@ -4,7 +4,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.event.HandlerList;
 
 /**
- * Thrown whenever an Entity is removed from the world
+ * Called whenever an Entity is removed from the world.
  */
 public class EntityDespawnEvent extends EntityEvent {
     private static final HandlerList handlers = new HandlerList();

--- a/src/main/java/org/bukkit/event/entity/EntityDespawnEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDespawnEvent.java
@@ -29,7 +29,7 @@ public class EntityDespawnEvent extends EntityEvent {
          */
         DEFAULT
     }
-    
+
     private static final HandlerList handlers = new HandlerList();
     private final DespawnReason despawnReason;
 

--- a/src/main/java/org/bukkit/event/entity/EntityDespawnEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDespawnEvent.java
@@ -52,6 +52,11 @@ public class EntityDespawnEvent extends EntityEvent {
          */
         DEATH,
         /**
+         * When an entity despawns because a plugin or GameRule removed it,
+         * or a non-living entity died (EG, ender crystal destroyed)
+         */
+        REMOVED,
+        /**
          * When an entity is missing a DespawnReason
          */
         DEFAULT


### PR DESCRIPTION
## The Issue:

There was not any event fired for when an entity despawns for reasons other than death, EG when a non-persistent entity is removed because no player is nearby (RemoveWhenFarAway).
## Justification for this PR:

An event to listen for entity despawns is incredibly useful for plugins.
One example of when this might be used is a plugin that needs to store information on the entity (and save it to file), but does not wish this data to persist if the entity no longer exists.
With this PR, a plugin could record the entity's UUID and map some information to it, then simply delete it if the EntityDespawnEvent is called for an entity with a matching UUID.
## PR Breakdown:
#### Bukkit-side:

Simply adds an EntityDespawnEvent with base functionality for plugins to listen to.
#### CraftBukkit-side:

Fire the EntityDespawnEvent added in Bukkit whenever an entity is removed from the world. Additionally, as there was a fair bit of code exactly duplicating the functionality in the `removeEntity()` function, change all other entity remove calls to fire the function rather than duplicate all related code.
## Testing Results and Materials:

Any default plugin or pre-existing plugin can listen to EntityDespawnEvent.
For my initial testing, I had:

```
    @EventHandler
    public void onEntityDespawn(EntityDespawnEvent event) {
        getLogger().info("Despawn: " + event.getEntity().getType().name() + " is " + event.getEntity().getUniqueId());
    }
```

This showed a fair number of regular despawns, that appeared to roughly match up to EntitySpawnEvent's (eyeballed only - obviously many entities were spawned and didn't despawn, or exist in the world prior to testing and despawned during the time)

I also integrated it into an entity-data storage system described in the justification, however, that is part of a larger system that isn't so easily copy-pasted. The stored data was confirmed as removed after the entity despawned (Entity despawn was induced by leaving a zombie in a box with a roof, then running far away, then running back)

... Also, I noticed the removeEntity() function was called fairly often with invalid / unspawned entities... I've placed the event firing inside an if block that ensures it only fires the event if the entity was spawned.
## Relevant PR(s):

CraftBukkit: https://github.com/Bukkit/CraftBukkit/pull/1386
## JIRA Ticket:

BUKKIT-5645 - https://bukkit.atlassian.net/browse/BUKKIT-5645
