### PR TITLE
[B+C] Add FallingBlockDeathEvent. Fixes BUKKIT-4160 and BUKKIT-4402

### DIFF
--- a/src/main/java/org/bukkit/event/entity/FallingBlockBreakEvent
+++ b/src/main/java/org/bukkit/event/entity/FallingBlockBreakEvent
@@ -1,0 +1,41 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.FallingBlock;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class FallingBlockBreakEvent extends Event implements Cancellable {
+
+	private static final HandlerList handlers = new HandlerList();
+	private FallingBlock block;
+	private boolean isCancelled = false;
+
+	public FallingBlockBreakEvent(FallingBlock block) {
+		this.block = block;
+	}
+
+	public FallingBlock getFallingBlock() {
+		return block;
+	}
+
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+
+	@Override
+	public boolean isCancelled() {
+		return isCancelled;
+	}
+
+	@Override
+	public void setCancelled(boolean cancel) {
+		isCancelled = cancel;
+	}
+
+}


### PR DESCRIPTION
The Issue:

The plugin developer were not able to check if a FallingBlock died.

Justification for this PR:

By accepting this PR plugin developer would be able to check if a FallingBlock died. This can be really useful if you want a certain thing to happen right after a FallingBlock gets destroyed.

PR Breakdown:

The PR does exactly what it sounds like. It'll make the EntityFallingBlock fire a FallingBlockDeathEvent right before it gets destroyed. You may even cancel its death.

Testing Results and Materials:

To test the new event I temporarily added a line that looked like this:

Bukkit.broadcastMessage("A block died :,(");

With this line added I compiled my modified CraftBukkit version, placed a sand block in the air and checked if the message appeared after the block lands. It did.

Relevant PR(s):
https://github.com/Bukkit/CraftBukkit/pull/1388 - second PR

JIRA Ticket:

BUKKIT-4402 - https://bukkit.atlassian.net/browse/BUKKIT-4402
BUKKIT-4160 - https://bukkit.atlassian.net/browse/BUKKIT-4160 
