### PR TITLE
Create FallingBlockBreakEvent. Fixes BUKKIT-4160

### DIFF
--- a/src/main/java/org/bukkit/event/entity/FallingBlockBreakEvent
+++ b/src/main/java/org/bukkit/event/entity/FallingBlockBreakEvent
@@ -1,0 +1,41 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.FallingBlock;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class FallingBlockBreakEvent extends Event implements Cancellable {
+
+	private static final HandlerList handlers = new HandlerList();
+	private FallingBlock block;
+	private boolean isCancelled = false;
+
+	public FallingBlockBreakEvent(FallingBlock block) {
+		this.block = block;
+	}
+
+	public FallingBlock getFallingBlock() {
+		return block;
+	}
+
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+
+	@Override
+	public boolean isCancelled() {
+		return isCancelled;
+	}
+
+	@Override
+	public void setCancelled(boolean cancel) {
+		isCancelled = cancel;
+	}
+
+}


### PR DESCRIPTION
This event will be fired if a block is dying.
