### PR TITLE
[B+C] Add FallingBlockDeathEvent. Fixes BUKKIT-4160 and BUKKIT-4402

### DIFF
--- a/src/main/java/org/bukkit/event/entity/FallingBlockDeathEvent
+++ b/src/main/java/org/bukkit/event/entity/FallingBlockDeathEvent
@@ -1,0 +1,41 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.FallingBlock;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class FallingBlockDeathEvent extends Event implements Cancellable {
+
+    private static HandlerList handlers = new HandlerList();
+    private FallingBlock fallingBlock;
+    private boolean isCancelled = false;
+
+    public FallingBlockDeathEvent(FallingBlock fallingBlock) {
+        this.fallingBlock = fallingBlock;
+    }
+
+    public FallingBlock getFallingBlock() {
+        return fallingBlock;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return isCancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        isCancelled = cancel;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+}

--- a/src/main/java/org/bukkit/event/entity/FallingBlockDeathEvent
+++ b/src/main/java/org/bukkit/event/entity/FallingBlockDeathEvent
@@ -5,16 +5,27 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
+/**
+ * Called when a FallingBlock dies.
+ */
 public class FallingBlockDeathEvent extends Event implements Cancellable {
 
     private static HandlerList handlers = new HandlerList();
     private FallingBlock fallingBlock;
     private boolean isCancelled = false;
 
+    /**
+     * @param fallingBlock the FallingBlock that calling the event.
+     */
     public FallingBlockDeathEvent(FallingBlock fallingBlock) {
         this.fallingBlock = fallingBlock;
     }
 
+    /**
+     * Gets the dying FallingBlock
+     * 
+     * @return the FallingBlock that is dying
+     */
     public FallingBlock getFallingBlock() {
         return fallingBlock;
     }

--- a/src/main/java/org/bukkit/event/entity/FallingBlockDeathEvent
+++ b/src/main/java/org/bukkit/event/entity/FallingBlockDeathEvent
@@ -1,33 +1,22 @@
 package org.bukkit.event.entity;
 
-import org.bukkit.entity.FallingBlock;
+import org.bukkit.entity.Entity;
 import org.bukkit.event.Cancellable;
-import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
 /**
  * Called when a FallingBlock dies.
  */
-public class FallingBlockDeathEvent extends Event implements Cancellable {
+public class FallingBlockDeathEvent extends EntityEvent implements Cancellable {
 
     private static HandlerList handlers = new HandlerList();
-    private FallingBlock fallingBlock;
     private boolean isCancelled = false;
 
     /**
-     * @param fallingBlock the FallingBlock that calling the event.
+     * @param what the FallingBlock which called the event.
      */
-    public FallingBlockDeathEvent(FallingBlock fallingBlock) {
-        this.fallingBlock = fallingBlock;
-    }
-
-    /**
-     * Gets the dying FallingBlock
-     * 
-     * @return the FallingBlock that is dying
-     */
-    public FallingBlock getFallingBlock() {
-        return fallingBlock;
+    public FallingBlockDeathEvent(Entity what) {
+        super(what);
     }
 
     @Override

--- a/src/main/java/org/bukkit/event/entity/FallingBlockDeathEvent
+++ b/src/main/java/org/bukkit/event/entity/FallingBlockDeathEvent
@@ -1,32 +1,20 @@
 package org.bukkit.event.entity;
 
 import org.bukkit.entity.Entity;
-import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
 /**
  * Called when a FallingBlock dies.
  */
-public class FallingBlockDeathEvent extends EntityEvent implements Cancellable {
+public class FallingBlockDeathEvent extends EntityEvent {
 
     private static HandlerList handlers = new HandlerList();
-    private boolean isCancelled = false;
 
     /**
      * @param what the FallingBlock which called the event.
      */
     public FallingBlockDeathEvent(Entity what) {
         super(what);
-    }
-
-    @Override
-    public boolean isCancelled() {
-        return isCancelled;
-    }
-
-    @Override
-    public void setCancelled(boolean cancel) {
-        isCancelled = cancel;
     }
 
     public static HandlerList getHandlerList() {


### PR DESCRIPTION
The Issue:

The plugin developer were not able to check if a FallingBlock died.

Justification for this PR:

By accepting this PR plugin developer would be able to check if a FallingBlock died. This can be really useful if you want a certain thing to happen right after a FallingBlock gets destroyed.

PR Breakdown:

The PR does exactly what it sounds like. It'll make the EntityFallingBlock fire a FallingBlockDeathEvent right before it gets destroyed. You may even cancel its death.

Testing Results and Materials:

To test the new event I temporarily added a line to the FallingBlockDeathEvent constructor that looked like this:

Bukkit.broadcastMessage("A block died :,(");

With this line added I compiled my modified CraftBukkit version, placed a sand block in the air and checked if the message appeared after the block lands. It did.

Relevant PR(s):

https://github.com/Bukkit/CraftBukkit/pull/1392 - second PR

JIRA Ticket:

BUKKIT-4402 - https://bukkit.atlassian.net/browse/BUKKIT-4402
BUKKIT-4160 - https://bukkit.atlassian.net/browse/BUKKIT-4160

Additional information:

I'm really sorry for making that many PRs but I already removed my original branch and reforked Bukkit/CraftBukkit to rewrite my code from scratch to fit the guidelines. so I CAN'T update the others PRs anymore.. I'm sorry for that and it won't happen again.
