### PR TITLE
[B+C] Update SkullMeta to use UUIDs. Adds BUKKIT-5614

### DIFF
--- a/src/main/java/org/bukkit/inventory/meta/SkullMeta.java
+++ b/src/main/java/org/bukkit/inventory/meta/SkullMeta.java
@@ -1,5 +1,7 @@
 package org.bukkit.inventory.meta;
 
+import java.util.UUID;
+
 import org.bukkit.Material;
 
 /**
@@ -22,12 +24,17 @@ public interface SkullMeta extends ItemMeta {
     boolean hasOwner();
 
     /**
-     * Sets the owner of the skull.
-     * <p>
-     * Plugins should check that hasOwner() returns true before calling this
-     * plugin.
+     * Sets the owner of the skull by UUID.
      *
-     * @param owner the new owner of the skull
+     * @param owner the UUID of the new owner of the skull
+     * @return true if the owner was successfully set
+     */
+    boolean setOwner(UUID owner);
+
+    /**
+     * Sets the owner of the skull by name.
+     *
+     * @param owner the name of the new owner of the skull
      * @return true if the owner was successfully set
      */
     boolean setOwner(String owner);


### PR DESCRIPTION
**The Issue**:

SkullMeta.setOwner() does not populate the skull's GameProfile information

**Justification for this PR**:

It's not possible to spawn a skull item with a texture attached to it.  Skull items can be worn on the head, and thus need their textures attached as soon as they exist.

**PR Breakdown**:

SkullMeta tracks a new key 'skull-owner-uuid'
CraftMetaSkull.setOwner(String) has been modified to call MinecraftSessionService.fillProfileProperties()
CraftMetaSkull.setOwner(UUID) has been added, which also calls MinecraftSessionService.fillProfileProperties()

The fillProfileProperties() function attaches all profile data, including textures, to the item.

(Note: This PR was originally by @TehRainbowGuy for Spigot, I've converted it for this project, and made some modifications.)

**Relevant PR**:

CB-1396 - https://github.com/Bukkit/CraftBukkit/pull/1396

**JIRA Ticket**:

BUKKIT-5614 - https://bukkit.atlassian.net/browse/BUKKIT-5614
