### PR TITLE
[B+C] Add Unbreakable API. Adds BUKKIT-5675

### DIFF
--- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
+++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
@@ -124,6 +124,20 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable {
     */
     boolean hasConflictingEnchant(Enchantment ench);
 
+    /**
+     * Returns whether this does not lose durability on use.
+     *
+     * @return true if this does not lose durability on use, false otherwise.
+     */
+    boolean isUnbreakable();
+
+    /**
+     * Sets whether this does not lose durability on use
+     *
+     * @param unbreakable this indicates whether this does not lose durability on use
+     */
+    void setUnbreakable(boolean unbreakable);
+
     @SuppressWarnings("javadoc")
     ItemMeta clone();
 }


### PR DESCRIPTION
##### The Issue:

Adds API to toggle the Unbreakable item property. If this tag is enabled the item won't lose durability on use.
##### Justification for this PR:

Unbreakable is a native minecraft functionality, this PR just adds the ability to toggle it through Bukkit's API
##### PR Breakdown:
- Add members to toggle Unbreakable to the base ItemMeta API
- Modify CraftItemMeta to implement API and account for Unbreakable in equals/hashcode
- Add serialization of the unbreakable property, defaulting to no unbreakable. (Default behaviour in MC, since Unbreakable is only available through spawning)
##### Testing Results and Materials:

The implementation was tested through a plugin using 3 commands:
- **/ubreak bow** spawns a bow with unbreakable enabled, doesn't lose durability when firing
- **/ubreak eqcheck** performs hashcode and equals checks on two ItemMeta's, with one being a clone with unbreaking enabled. It shows not equal for modified itemmeta, equality between clones was checked to verify it was still correct.
- **/ubreak serial** serializes an itemstack with unbreaking to a string and back to an itemstack, verifying the equality between the original and the serialized version.

[Test Plugin JAR](http://serverpeon.net/unbreakable-test-1.0-SNAPSHOT.jar) or [Test Plugin Sources](http://serverpeon.net/UnbreakableTest.zip)
##### Relevant PR(s):

B-1083 - https://github.com/Bukkit/Bukkit/pull/1083 - Add Unbreakable API  
CB-1398 - https://github.com/Bukkit/CraftBukkit/pull/1398 - Implement Unbreakable API and serialization of the Unbreakable property
##### JIRA Ticket:

BUKKIT-5675 - https://bukkit.atlassian.net/browse/BUKKIT-5675
