### PR TITLE
[B+C] Add a way to induce mob breeding, adds BUKKIT-5687

### DIFF
--- a/src/main/java/org/bukkit/entity/Animals.java
+++ b/src/main/java/org/bukkit/entity/Animals.java
@@ -37,8 +37,10 @@ public interface Animals extends Ageable {
      *
      * @param breeding whether the animal should try to breed.
      * @param player the player that induced the breeding.
+     * @param timeout how many ticks until the breeding state automatically
+     * cancels. The default is 600.
      */
-    public void setBreeding(boolean breeding, Player player);
+    public void setBreeding(boolean breeding, Player player, int timeout);
 
     /**
      * Set whether this animal is currently trying to breed.
@@ -51,6 +53,7 @@ public interface Animals extends Ageable {
      * breed from the entity, and even stop an in-progress mating session.
      * This will assume a null player, meaning that no player will be given
      * any rewards (EG: experience) for a successful breeding.
+     * This will also assume a default breed timeout of 600 ticks.
      *
      * @param breeding whether the animal should try to breed.
      */

--- a/src/main/java/org/bukkit/entity/Animals.java
+++ b/src/main/java/org/bukkit/entity/Animals.java
@@ -25,7 +25,7 @@ public interface Animals extends Ageable {
      * Specify a non-null player to indicate that the given player was the one who induced breeding, which will give any built in or plugin created rewards (EG: experience) to that player when the breeding is successful.
      *
      * @param breeding whether the animal should try to breed.
-	 * @param player the player that induced the breeding.
+     * @param player the player that induced the breeding.
      */
     public void setBreeding(boolean breeding, Player player);
 

--- a/src/main/java/org/bukkit/entity/Animals.java
+++ b/src/main/java/org/bukkit/entity/Animals.java
@@ -32,7 +32,7 @@ public interface Animals extends Ageable {
      * breed from the entity, and even stop an in-progress mating session.
      * Specify a non-null player to indicate that the given player was the
      * one who induced breeding, which will give any built in or plugin
-     * created rewards (EG: experience) to that player when the breeding
+     * created rewards (EG: an achievement) to that player when the breeding
      * is successful.
      * Specify a null player to simply not reward a player for successful
      * breeding.
@@ -54,7 +54,7 @@ public interface Animals extends Ageable {
      * If 'breeding' is false, this function will take away any desire to
      * breed from the entity, and even stop an in-progress mating session.
      * This will assume a null player, meaning that no player will be given
-     * any rewards (EG: experience) for a successful breeding.
+     * any rewards (EG: an achievement) for a successful breeding.
      * Specify a null player to simply not reward a player for successful
      * breeding.
      *
@@ -76,7 +76,7 @@ public interface Animals extends Ageable {
      * breed from the entity, and even stop an in-progress mating session.
      * Specify a non-null player to indicate that the given player was the
      * one who induced breeding, which will give any built in or plugin
-     * created rewards (EG: experience) to that player when the breeding
+     * created rewards (EG: an achievement) to that player when the breeding
      * is successful.
      * Specify a null player to simply not reward a player for successful
      * breeding.
@@ -99,7 +99,7 @@ public interface Animals extends Ageable {
      * If 'breeding' is false, this function will take away any desire to
      * breed from the entity, and even stop an in-progress mating session.
      * This will assume a null player, meaning that no player will be given
-     * any rewards (EG: experience) for a successful breeding.
+     * any rewards (EG: an achievement) for a successful breeding.
      * This will also assume a default breed timeout of 600 ticks.
      *
      * @param breeding whether the animal should try to breed.

--- a/src/main/java/org/bukkit/entity/Animals.java
+++ b/src/main/java/org/bukkit/entity/Animals.java
@@ -9,9 +9,13 @@ public interface Animals extends Ageable {
 
     /**
      * Determines if this animal is currently breeding.
-     * An animal is considered to be breeding when it has been given food (EG: wheat) and is looking for another animal of its species to mate with and produce a baby animal.
-     * Will return false again if the breeding attempt timed out or after the mating was successful and a baby is born.
-     * Will return true if the entity is actively breeding but hasn't yet had a child.
+     * An animal is considered to be breeding when it has been given food
+     * (EG: wheat) and is looking for another animal of its species to mate
+     * with and produce a baby animal.
+     * Will return false again if the breeding attempt timed out or after the
+     * mating was successful and a baby is spawned.
+     * Will return true if the entity is actively breeding but hasn't yet had
+     * a child.
      *
      * @return true if it is breeding.
      */
@@ -19,10 +23,17 @@ public interface Animals extends Ageable {
 
     /**
      * Set whether this animal is currently trying to breed.
-     * An animal is considered to be breeding when it has been given food (EG: wheat) and is looking for another animal of its species to mate with and produce a baby animal.
-     * If 'breeding' is true, this function has the same result as given the entity its breeding food (EG: wheat).
-     * If 'breeding' is false, this function will take away any desire to breed from the entity, and even stop an in-progress mating session.
-     * Specify a non-null player to indicate that the given player was the one who induced breeding, which will give any built in or plugin created rewards (EG: experience) to that player when the breeding is successful.
+     * An animal is considered to be breeding when it has been given food
+     * (EG: wheat) and is looking for another animal of its species to mate
+     * with and produce a baby animal.
+     * If 'breeding' is true, this function has the same result as given the
+     * entity its breeding food (EG: wheat).
+     * If 'breeding' is false, this function will take away any desire to
+     * breed from the entity, and even stop an in-progress mating session.
+     * Specify a non-null player to indicate that the given player was the
+     * one who induced breeding, which will give any built in or plugin
+     * created rewards (EG: experience) to that player when the breeding
+     * is successful.
      *
      * @param breeding whether the animal should try to breed.
      * @param player the player that induced the breeding.
@@ -31,10 +42,15 @@ public interface Animals extends Ageable {
 
     /**
      * Set whether this animal is currently trying to breed.
-     * An animal is considered to be breeding when it has been given food (EG: wheat) and is looking for another animal of its species to mate with and produce a baby animal.
-     * If 'breeding' is true, this function has the same result as given the entity its breeding food (EG: wheat).
-     * If 'breeding' is false, this function will take away any desire to breed from the entity, and even stop an in-progress mating session.
-     * This will assume a null player, meaning that no player will be given any rewards (EG: experience) for a successful breeding.
+     * An animal is considered to be breeding when it has been given food
+     * (EG: wheat) and is looking for another animal of its species to mate
+     * with and produce a baby animal.
+     * If 'breeding' is true, this function has the same result as given the
+     * entity its breeding food (EG: wheat).
+     * If 'breeding' is false, this function will take away any desire to
+     * breed from the entity, and even stop an in-progress mating session.
+     * This will assume a null player, meaning that no player will be given
+     * any rewards (EG: experience) for a successful breeding.
      *
      * @param breeding whether the animal should try to breed.
      */

--- a/src/main/java/org/bukkit/entity/Animals.java
+++ b/src/main/java/org/bukkit/entity/Animals.java
@@ -109,6 +109,7 @@ public interface Animals extends Ageable {
     /**
     * Instantly breeds this animal with another.
     * Will spawn a baby animal at this animal's location.
+    * The input animal must be of the same entity type as this animal.
     *
     * @param animal the animal to breed with.
     */

--- a/src/main/java/org/bukkit/entity/Animals.java
+++ b/src/main/java/org/bukkit/entity/Animals.java
@@ -9,6 +9,9 @@ public interface Animals extends Ageable {
 
     /**
      * Determines if this animal is currently breeding.
+     * An animal is considered to be breeding when it has been given food (EG: wheat) and is looking for another animal of its species to mate with and produce a baby animal.
+     * Will return false again if the breeding attempt timed out or after the mating was successful and a baby is born.
+     * Will return true if the entity is actively breeding but hasn't yet had a child.
      *
      * @return true if it is breeding.
      */
@@ -16,6 +19,10 @@ public interface Animals extends Ageable {
 
     /**
      * Set whether this animal is currently trying to breed.
+     * An animal is considered to be breeding when it has been given food (EG: wheat) and is looking for another animal of its species to mate with and produce a baby animal.
+     * If 'breeding' is true, this function has the same result as given the entity its breeding food (EG: wheat).
+     * If 'breeding' is false, this function will take away any desire to breed from the entity, and even stop an in-progress mating session.
+     * Specify a non-null player to indicate that the given player was the one who induced breeding, which will give any built in or plugin created rewards (EG: experience) to that player when the breeding is successful.
      *
      * @param breeding whether the animal should try to breed.
 	 * @param player the player that induced the breeding.
@@ -24,6 +31,10 @@ public interface Animals extends Ageable {
 
     /**
      * Set whether this animal is currently trying to breed.
+     * An animal is considered to be breeding when it has been given food (EG: wheat) and is looking for another animal of its species to mate with and produce a baby animal.
+     * If 'breeding' is true, this function has the same result as given the entity its breeding food (EG: wheat).
+     * If 'breeding' is false, this function will take away any desire to breed from the entity, and even stop an in-progress mating session.
+     * This will assume a null player, meaning that no player will be given any rewards (EG: experience) for a successful breeding.
      *
      * @param breeding whether the animal should try to breed.
      */

--- a/src/main/java/org/bukkit/entity/Animals.java
+++ b/src/main/java/org/bukkit/entity/Animals.java
@@ -60,7 +60,6 @@ public interface Animals extends Ageable {
      * breeding.
      *
      * @param breeding whether the animal should try to breed.
-     * @param player the player that induced the breeding.
      * @param timeout how many ticks until the breeding state automatically
      * cancels. The default is 600.
      */
@@ -85,8 +84,6 @@ public interface Animals extends Ageable {
      *
      * @param breeding whether the animal should try to breed.
      * @param player the player that induced the breeding.
-     * @param timeout how many ticks until the breeding state automatically
-     * cancels. The default is 600.
      */
     public void setBreeding(boolean breeding, Player player);
 

--- a/src/main/java/org/bukkit/entity/Animals.java
+++ b/src/main/java/org/bukkit/entity/Animals.java
@@ -111,4 +111,11 @@ public interface Animals extends Ageable {
      * @param breeding whether the animal should try to breed.
      */
     public void setBreeding(boolean breeding);
+
+    /**
+     * Gets the Player that last caused this animal to breed, if any.
+     *
+     * @return the breeder player, or null if none.
+     */
+    public Player getBreeder();
 }

--- a/src/main/java/org/bukkit/entity/Animals.java
+++ b/src/main/java/org/bukkit/entity/Animals.java
@@ -111,16 +111,4 @@ public interface Animals extends Ageable {
      * @param breeding whether the animal should try to breed.
      */
     public void setBreeding(boolean breeding);
-
-    /**
-    * Instantly breeds this animal with another.
-    * Will spawn a baby animal at this animal's location.
-    * The input animal must be of the same entity type as this animal.
-    * Both this animal and the input animal will be unable to breed natural
-    * for a short period of time.
-    * Returns the baby entity created, or null if the event was cancelled.
-    *
-    * @param animal the animal to breed with.
-    */
-    public Ageable breedWith(Animals animal);
 }

--- a/src/main/java/org/bukkit/entity/Animals.java
+++ b/src/main/java/org/bukkit/entity/Animals.java
@@ -106,4 +106,11 @@ public interface Animals extends Ageable {
      */
     public void setBreeding(boolean breeding);
 
+    /**
+    * Instantly breeds this animal with another.
+    * Will spawn a baby animal at this animal's location.
+    *
+    * @param animal the animal to breed with.
+    */
+    public void breedWith(Animals animal);
 }

--- a/src/main/java/org/bukkit/entity/Animals.java
+++ b/src/main/java/org/bukkit/entity/Animals.java
@@ -34,6 +34,8 @@ public interface Animals extends Ageable {
      * one who induced breeding, which will give any built in or plugin
      * created rewards (EG: experience) to that player when the breeding
      * is successful.
+     * Specify a null player to simply not reward a player for successful
+     * breeding.
      *
      * @param breeding whether the animal should try to breed.
      * @param player the player that induced the breeding.

--- a/src/main/java/org/bukkit/entity/Animals.java
+++ b/src/main/java/org/bukkit/entity/Animals.java
@@ -1,6 +1,7 @@
 package org.bukkit.entity;
 
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Ageable;
 
 /**
  * Represents an Animal.
@@ -110,8 +111,11 @@ public interface Animals extends Ageable {
     * Instantly breeds this animal with another.
     * Will spawn a baby animal at this animal's location.
     * The input animal must be of the same entity type as this animal.
+    * Both this animal and the input animal will be unable to breed natural
+    * for a short period of time.
+    * Returns the baby entity created, or null if the event was cancelled.
     *
     * @param animal the animal to breed with.
     */
-    public void breedWith(Animals animal);
+    public Ageable breedWith(Animals animal);
 }

--- a/src/main/java/org/bukkit/entity/Animals.java
+++ b/src/main/java/org/bukkit/entity/Animals.java
@@ -37,6 +37,8 @@ public interface Animals extends Ageable {
      * is successful.
      * Specify a null player to simply not reward a player for successful
      * breeding.
+     * If the first argument is true, this will force the entity to be able
+     * to breed, which will turn baby animals into adults.
      *
      * @param breeding whether the animal should try to breed.
      * @param player the player that induced the breeding.
@@ -58,6 +60,8 @@ public interface Animals extends Ageable {
      * any rewards (EG: an achievement) for a successful breeding.
      * Specify a null player to simply not reward a player for successful
      * breeding.
+     * If the first argument is true, this will force the entity to be able
+     * to breed, which will turn baby animals into adults.
      *
      * @param breeding whether the animal should try to breed.
      * @param timeout how many ticks until the breeding state automatically
@@ -81,6 +85,8 @@ public interface Animals extends Ageable {
      * Specify a null player to simply not reward a player for successful
      * breeding.
      * This will also assume a default breed timeout of 600 ticks.
+     * If the first argument is true, this will force the entity to be able
+     * to breed, which will turn baby animals into adults.
      *
      * @param breeding whether the animal should try to breed.
      * @param player the player that induced the breeding.
@@ -99,6 +105,8 @@ public interface Animals extends Ageable {
      * This will assume a null player, meaning that no player will be given
      * any rewards (EG: an achievement) for a successful breeding.
      * This will also assume a default breed timeout of 600 ticks.
+     * If the first argument is true, this will force the entity to be able
+     * to breed, which will turn baby animals into adults.
      *
      * @param breeding whether the animal should try to breed.
      */

--- a/src/main/java/org/bukkit/entity/Animals.java
+++ b/src/main/java/org/bukkit/entity/Animals.java
@@ -55,6 +55,51 @@ public interface Animals extends Ageable {
      * breed from the entity, and even stop an in-progress mating session.
      * This will assume a null player, meaning that no player will be given
      * any rewards (EG: experience) for a successful breeding.
+     * Specify a null player to simply not reward a player for successful
+     * breeding.
+     *
+     * @param breeding whether the animal should try to breed.
+     * @param player the player that induced the breeding.
+     * @param timeout how many ticks until the breeding state automatically
+     * cancels. The default is 600.
+     */
+    public void setBreeding(boolean breeding, int timeout);
+
+    /**
+     * Set whether this animal is currently trying to breed.
+     * An animal is considered to be breeding when it has been given food
+     * (EG: wheat) and is looking for another animal of its species to mate
+     * with and produce a baby animal.
+     * If 'breeding' is true, this function has the same result as given the
+     * entity its breeding food (EG: wheat).
+     * If 'breeding' is false, this function will take away any desire to
+     * breed from the entity, and even stop an in-progress mating session.
+     * Specify a non-null player to indicate that the given player was the
+     * one who induced breeding, which will give any built in or plugin
+     * created rewards (EG: experience) to that player when the breeding
+     * is successful.
+     * Specify a null player to simply not reward a player for successful
+     * breeding.
+     * This will also assume a default breed timeout of 600 ticks.
+     *
+     * @param breeding whether the animal should try to breed.
+     * @param player the player that induced the breeding.
+     * @param timeout how many ticks until the breeding state automatically
+     * cancels. The default is 600.
+     */
+    public void setBreeding(boolean breeding, Player player);
+
+    /**
+     * Set whether this animal is currently trying to breed.
+     * An animal is considered to be breeding when it has been given food
+     * (EG: wheat) and is looking for another animal of its species to mate
+     * with and produce a baby animal.
+     * If 'breeding' is true, this function has the same result as given the
+     * entity its breeding food (EG: wheat).
+     * If 'breeding' is false, this function will take away any desire to
+     * breed from the entity, and even stop an in-progress mating session.
+     * This will assume a null player, meaning that no player will be given
+     * any rewards (EG: experience) for a successful breeding.
      * This will also assume a default breed timeout of 600 ticks.
      *
      * @param breeding whether the animal should try to breed.

--- a/src/main/java/org/bukkit/entity/Animals.java
+++ b/src/main/java/org/bukkit/entity/Animals.java
@@ -1,6 +1,32 @@
 package org.bukkit.entity;
 
+import org.bukkit.entity.Player;
+
 /**
  * Represents an Animal.
  */
-public interface Animals extends Ageable {}
+public interface Animals extends Ageable {
+
+    /**
+     * Determines if this animal is currently breeding.
+     *
+     * @return true if it is breeding.
+     */
+    public boolean isBreeding();
+
+    /**
+     * Set whether this animal is currently trying to breed.
+     *
+     * @param breeding whether the animal should try to breed.
+	 * @param player the player that induced the breeding.
+     */
+    public void setBreeding(boolean breeding, Player player);
+
+    /**
+     * Set whether this animal is currently trying to breed.
+     *
+     * @param breeding whether the animal should try to breed.
+     */
+    public void setBreeding(boolean breeding);
+
+}

--- a/src/main/java/org/bukkit/event/entity/EntityBreedEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityBreedEvent.java
@@ -15,14 +15,14 @@ public class EntityBreedEvent extends EntityEvent implements Cancellable {
     private final Ageable baby;
     private Player breeder;
     private boolean cancelled;
-    private int XP;
+    private int xp;
 
-    public EntityBreedEvent(final Animals entity, final Animals entityTwo, final Player breeder, final Ageable baby, final int XP) {
+    public EntityBreedEvent(final Animals entity, final Animals entityTwo, final Player breeder, final Ageable baby, final int xp) {
         super(entity);
         this.entityTwo = entityTwo;
         this.breeder = breeder;
         this.baby = baby;
-        this.XP = XP;
+        this.xp = xp;
     }
 
     @Override
@@ -94,7 +94,7 @@ public class EntityBreedEvent extends EntityEvent implements Cancellable {
      * @return the total amount of experience.
      */
     public int getExperience() {
-        return XP;
+        return xp;
     }
 
     /**
@@ -103,6 +103,6 @@ public class EntityBreedEvent extends EntityEvent implements Cancellable {
      * @param newXP the amount of XP to drop.
      */
     public void setExperience(int newXP) {
-        XP = newXP;
+        xp = newXP;
     }
 }

--- a/src/main/java/org/bukkit/event/entity/EntityBreedEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityBreedEvent.java
@@ -13,14 +13,12 @@ public class EntityBreedEvent extends EntityEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private final Animals entityTwo;
     private final Ageable baby;
-    private Player breeder;
     private boolean cancelled;
     private int xp;
 
-    public EntityBreedEvent(final Animals entity, final Animals entityTwo, final Player breeder, final Ageable baby, final int xp) {
+    public EntityBreedEvent(final Animals entity, final Animals entityTwo, final Ageable baby, final int xp) {
         super(entity);
         this.entityTwo = entityTwo;
-        this.breeder = breeder;
         this.baby = baby;
         this.xp = xp;
     }
@@ -56,29 +54,6 @@ public class EntityBreedEvent extends EntityEvent implements Cancellable {
     */
     public Ageable getBaby() {
         return baby;
-    }
-
-    /**
-    * Gets the player that started the breeding, if any.
-    * If breeding was induced by plugin, may return null.
-    *
-    * @returns the breeder player, or null if none.
-    */
-    public Player getBreeder() {
-        return breeder;
-    }
-
-    /**
-    * Sets the player that is considered to have started the breeding,
-    * if any.
-    * The player set will receive potential rewards for breeding,
-    * (EG: an achievement).
-    * Set the player null to give nobody the reward.
-    *
-    * @param player the new breeder player, or null for none.
-    */
-    public void setBreeder(Player player) {
-        breeder = player;
     }
 
     public boolean isCancelled() {

--- a/src/main/java/org/bukkit/event/entity/EntityBreedEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityBreedEvent.java
@@ -1,0 +1,88 @@
+package org.bukkit.event.entity;
+
+import org.bukkit.entity.Animals;
+import org.bukkit.entity.Ageable;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Called when an {@link Animals} breeds with another animal.
+ */
+public class EntityBreedEvent extends EntityEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private final Animals entityTwo;
+    private final Ageable baby;
+    private Player breeder;
+    private boolean cancelled;
+
+    public EntityBreedEvent(final Animals entity, final Animals entityTwo, final Player breeder, final Ageable baby) {
+        super(entity);
+        this.entityTwo = entityTwo;
+        this.breeder = breeder;
+        this.baby = baby;
+    }
+
+    @Override
+    public Animals getEntity() {
+        return (Animals) entity;
+    }
+
+    /**
+    * Returns the living entity that the main entity has bred with.
+    *
+    * @return the living entity that was bred with.
+    */
+    public Animals getBredWith() {
+        return entityTwo;
+    }
+
+    /**
+    * Returns the (currently unspawned) baby entity.
+    *
+    * @return the baby entity.
+    */
+    public Ageable getBaby() {
+        return baby;
+    }
+
+    /**
+    * Gets the player that started the breeding, if any.
+    * If breeding was induced by plugin, may return null.
+    *
+    * @returns the breeder player, or null if none.
+    */
+    public Player getBreeder() {
+        return breeder;
+    }
+
+    /**
+    * Sets the player that is considered to have started the breeding,
+    * if any.
+    * The player set will receive potential rewards for breeding,
+    * (EG: an achievement).
+    * Set the player null to give nobody the reward.
+    *
+    * @param player the new breeder player, or null for none.
+    */
+    public void setBreeder(Player player) {
+        breeder = player;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(boolean cancel) {
+        cancelled = cancel;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/org/bukkit/event/entity/EntityBreedEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityBreedEvent.java
@@ -40,6 +40,16 @@ public class EntityBreedEvent extends EntityEvent implements Cancellable {
     }
 
     /**
+     * Returns an array containing both parent entities.
+     * The array always has a length of 2.
+     *
+     * @return an array of both parent entities.
+     */
+    public Animals[] getParents() {
+        return new Animals[] { (Animals)entity, entityTwo };
+    }
+
+    /**
     * Returns the (currently unspawned) baby entity.
     *
     * @return the baby entity.

--- a/src/main/java/org/bukkit/event/entity/EntityBreedEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityBreedEvent.java
@@ -15,12 +15,14 @@ public class EntityBreedEvent extends EntityEvent implements Cancellable {
     private final Ageable baby;
     private Player breeder;
     private boolean cancelled;
+    private int XP;
 
-    public EntityBreedEvent(final Animals entity, final Animals entityTwo, final Player breeder, final Ageable baby) {
+    public EntityBreedEvent(final Animals entity, final Animals entityTwo, final Player breeder, final Ageable baby, final int XP) {
         super(entity);
         this.entityTwo = entityTwo;
         this.breeder = breeder;
         this.baby = baby;
+        this.XP = XP;
     }
 
     @Override
@@ -84,5 +86,23 @@ public class EntityBreedEvent extends EntityEvent implements Cancellable {
 
     public static HandlerList getHandlerList() {
         return handlers;
+    }
+
+    /**
+     * Gets the amount of experience that will be dropped by this event.
+     *
+     * @return the total amount of experience.
+     */
+    public int getExperience() {
+        return XP;
+    }
+
+    /**
+     * Changes the amount of XP this event will drop.
+     *
+     * @param newXP the amount of XP to drop.
+     */
+    public void setExperience(int newXP) {
+        XP = newXP;
     }
 }

--- a/src/main/java/org/bukkit/event/entity/EntityBreedEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityBreedEvent.java
@@ -11,30 +11,21 @@ import org.bukkit.event.HandlerList;
  */
 public class EntityBreedEvent extends EntityEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
-    private final Animals entityTwo;
-    private final Ageable baby;
+    private final Animals parentOne;
+    private final Animals parentTwo;
     private boolean cancelled;
     private int xp;
 
-    public EntityBreedEvent(final Animals entity, final Animals entityTwo, final Ageable baby, final int xp) {
-        super(entity);
-        this.entityTwo = entityTwo;
-        this.baby = baby;
+    public EntityBreedEvent(final Animals parentOne, final Animals parentTwo, final Ageable baby, final int xp) {
+        super(baby);
+        this.parentOne = parentOne;
+        this.parentTwo = parentTwo;
         this.xp = xp;
     }
 
     @Override
-    public Animals getEntity() {
-        return (Animals) entity;
-    }
-
-    /**
-    * Returns the living entity that the main entity has bred with.
-    *
-    * @return the living entity that was bred with.
-    */
-    public Animals getBredWith() {
-        return entityTwo;
+    public Ageable getEntity() {
+        return (Ageable) entity;
     }
 
     /**
@@ -44,16 +35,7 @@ public class EntityBreedEvent extends EntityEvent implements Cancellable {
      * @return an array of both parent entities.
      */
     public Animals[] getParents() {
-        return new Animals[] { (Animals)entity, entityTwo };
-    }
-
-    /**
-    * Returns the (currently unspawned) baby entity.
-    *
-    * @return the baby entity.
-    */
-    public Ageable getBaby() {
-        return baby;
+        return new Animals[] { parentOne, parentTwo };
     }
 
     public boolean isCancelled() {


### PR DESCRIPTION
## The Issue:

There is not a way to induce mob breeding, or check whether they are trying to breed.
An animal is considered to be breeding when it has been given food (EG: wheat) and is looking for another animal of its species to mate with and produce a baby animal.
## Justification for this PR:

This new API feature will be useful for any plugin that wishes to induce mob breeding. An example case would be an NPC Farmer - without a way to make mobs breed, it would have to be faked with workarounds, EG manually spawning heart particles and manually spawning baby entities.
## PR Breakdown:
#### Bukkit-side:

Adds the functions in `Animals` to induce breeding / check breeding attempt.
#### CraftBukkit-side:

Implements the functions in `CraftAnimals` to induce breeding / check breeding attempt. Mostly just wrapping some NMS functions.
## Testing Results and Materials:

Any default plugin or pre-existing plugin can simply run the functions and output results.
I personally tested by inducing two cows to breed and observing their `isBreeding` state throughout the process.

Quick example code would be a command that executes:

```
for (Entity entity: player.getNearbyEntities(20, 20, 20)) {
    if (entity.getType() instanceof Animals) {
        ((Animals)entity).setBreeding(true);
    }
}
```
## Relevant PR(s):

CraftBukkit: https://github.com/Bukkit/CraftBukkit/pull/1400
## JIRA Ticket:

BUKKIT-5687 - https://bukkit.atlassian.net/browse/BUKKIT-5687
