### PR TITLE
[B] Allow null modifier functions in EntityDamageEvent. Fixes Bukkit-5688

### DIFF
--- a/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
@@ -42,8 +42,10 @@ public class EntityDamageEvent extends EntityEvent implements Cancellable {
         Validate.isTrue(modifiers.containsKey(DamageModifier.BASE), "BASE DamageModifier missing");
         Validate.isTrue(!modifiers.containsKey(null), "Cannot have null DamageModifier");
         Validate.noNullElements(modifiers.values(), "Cannot have null modifier values");
-        Validate.isTrue(modifiers.keySet().equals(modifierFunctions.keySet()), "Must have a modifier function for each DamageModifier");
-        Validate.noNullElements(modifierFunctions.values(), "Cannot have null modifier function");
+        if (modifierFunctions != null) {
+            Validate.isTrue(modifiers.keySet().equals(modifierFunctions.keySet()), "Must have a modifier function for each DamageModifier");
+            Validate.noNullElements(modifierFunctions.values(), "Cannot have null modifier function");
+        }
         this.originals = new EnumMap<DamageModifier, Double>(modifiers);
         this.cause = cause;
         this.modifiers = modifiers;


### PR DESCRIPTION
<b>The Issue:</b>

Currently, damaging a non-living entity (such as an item frame) throws an NPE and crashes the server.

<b>Justification for this PR</b>

This pull request fixes a huge internal server error caused by Bukkit.

<b>PR Breakdown:</b>

Checks for a null value of modifierFunctions in EntityDamageEvent, and refrains from accessing the variable to prevent an NPE.

<b>JIRA Ticket:</b>

BUKKIT-5688 - https://bukkit.atlassian.net/browse/BUKKIT-5688
