### PR TITLE
Rename Material.WATCH to Material.CLOCK

### DIFF
--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -327,7 +327,7 @@ public enum Material {
     EGG(344, 16),
     COMPASS(345),
     FISHING_ROD(346, 1, 64),
-    WATCH(347),
+    CLOCK(347),
     GLOWSTONE_DUST(348),
     RAW_FISH(349),
     COOKED_FISH(350),


### PR DESCRIPTION
Rename the WATCH material to CLOCK so that people don't get confused while searching for materials.

It is also more matching to the item and really should be called clock.
