### PR TITLE
[B] Corrected solid property of various materials. Fixes BUKKIT-5671, BUKKIT-5559

### DIFF
--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -701,10 +701,7 @@ public enum Material {
             case SIGN_POST:
             case WOODEN_DOOR:
             case COBBLESTONE_STAIRS:
-            case WALL_SIGN:
-            case STONE_PLATE:
             case IRON_DOOR_BLOCK:
-            case WOOD_PLATE:
             case REDSTONE_ORE:
             case GLOWING_REDSTONE_ORE:
             case ICE:
@@ -758,8 +755,6 @@ public enum Material {
             case COBBLE_WALL:
             case ANVIL:
             case TRAPPED_CHEST:
-            case GOLD_PLATE:
-            case IRON_PLATE:
             case DAYLIGHT_DETECTOR:
             case REDSTONE_BLOCK:
             case QUARTZ_ORE:
@@ -777,6 +772,7 @@ public enum Material {
             case ACACIA_STAIRS:
             case DARK_OAK_STAIRS:
             case PACKED_ICE:
+            case FLOWER_POT:
                 return true;
             default:
                 return false;

--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -700,7 +700,9 @@ public enum Material {
             case BURNING_FURNACE:
             case WOODEN_DOOR:
             case COBBLESTONE_STAIRS:
+            case STONE_PLATE:
             case IRON_DOOR_BLOCK:
+            case WOOD_PLATE:
             case REDSTONE_ORE:
             case GLOWING_REDSTONE_ORE:
             case ICE:
@@ -754,6 +756,8 @@ public enum Material {
             case COBBLE_WALL:
             case ANVIL:
             case TRAPPED_CHEST:
+            case GOLD_PLATE:
+            case IRON_PLATE:
             case DAYLIGHT_DETECTOR:
             case REDSTONE_BLOCK:
             case QUARTZ_ORE:
@@ -772,10 +776,6 @@ public enum Material {
             case DARK_OAK_STAIRS:
             case PACKED_ICE:
             case FLOWER_POT:
-            case STONE_PLATE:
-            case WOOD_PLATE:
-            case IRON_PLATE:
-            case GOLD_PLATE:
                 return true;
             default:
                 return false;

--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -698,7 +698,6 @@ public enum Material {
             case SOIL:
             case FURNACE:
             case BURNING_FURNACE:
-            case SIGN_POST:
             case WOODEN_DOOR:
             case COBBLESTONE_STAIRS:
             case IRON_DOOR_BLOCK:

--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -772,6 +772,10 @@ public enum Material {
             case DARK_OAK_STAIRS:
             case PACKED_ICE:
             case FLOWER_POT:
+            case STONE_PLATE:
+            case WOOD_PLATE:
+            case IRON_PLATE:
+            case GOLD_PLATE:
                 return true;
             default:
                 return false;


### PR DESCRIPTION
**The Issue:**
Various blocks are marked as solid blocks whilst the player may pass freely through them. Likewise, `FLOWER_POT` was not recognized as a solid block.

**Justification for this PR:**
Previously, `WALL_SIGN` and `SIGN_POST` were recognised as a solid blocks although players can pass through them.

~~Likewise, `WOOD_PLATE`, `STONE_PLATE`, `GOLD_PLATE` and `IRON_PLATE` were treated as solid blocks although none of those blocks prevent the player from passing through.~~ _NMS treats plates as solid blocks. These have been re-added._

Lastly, `FLOWER_POT` was not recognised as a solid block. This block does prevent the player from passing through.

**PR Breakdown:**
This PR corrects the `isSolid()` method in Material.java, removing all materials mentioned above and adding `FLOWER_POT` as a recognised solid block.

**Testing Results and Materials:**
The changes in this PR are too trivial to require individual testing. The changes in this PR compile without compile warnings nor compile errors.

**Relevant PR(s):**
Bukkit/Bukkit#1087 - The original code was inspired from @xa112. His PR did not qualify to the contributing guidelines.

**JIRA Tickets:**
https://bukkit.atlassian.net/browse/BUKKIT-5671
https://bukkit.atlassian.net/browse/BUKKIT-5559
