### PR TITLE
[B+C] Add keepInventory API. Adds BUKKIT-5724

### DIFF
--- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
+++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
@@ -16,20 +16,21 @@ public class PlayerDeathEvent extends EntityDeathEvent {
     private boolean keepLevel = false;
     private boolean keepInventory = false;
 
-    public PlayerDeathEvent(final Player player, final List<ItemStack> drops, final int droppedExp, final String deathMessage) {
-        this(player, drops, droppedExp, 0, deathMessage);
+    public PlayerDeathEvent(final Player player, final List<ItemStack> drops, final int droppedExp, final String deathMessage, final boolean keepInventory) {
+        this(player, drops, droppedExp, 0, deathMessage, keepInventory);
     }
 
-    public PlayerDeathEvent(final Player player, final List<ItemStack> drops, final int droppedExp, final int newExp, final String deathMessage) {
-        this(player, drops, droppedExp, newExp, 0, 0, deathMessage);
+    public PlayerDeathEvent(final Player player, final List<ItemStack> drops, final int droppedExp, final int newExp, final String deathMessage, final boolean keepInventory) {
+        this(player, drops, droppedExp, newExp, 0, 0, deathMessage, keepInventory);
     }
 
-    public PlayerDeathEvent(final Player player, final List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, final String deathMessage) {
+    public PlayerDeathEvent(final Player player, final List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, final String deathMessage, final boolean keepInventory) {
         super(player, drops, droppedExp);
         this.newExp = newExp;
         this.newTotalExp = newTotalExp;
         this.newLevel = newLevel;
         this.deathMessage = deathMessage;
+        this.keepInventory = keepInventory;
     }
 
     @Override

--- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
+++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
@@ -16,21 +16,20 @@ public class PlayerDeathEvent extends EntityDeathEvent {
     private boolean keepLevel = false;
     private boolean keepInventory = false;
 
-    public PlayerDeathEvent(final Player player, final List<ItemStack> drops, final int droppedExp, final String deathMessage, final boolean keepInventory) {
-        this(player, drops, droppedExp, 0, deathMessage, keepInventory);
+    public PlayerDeathEvent(final Player player, final List<ItemStack> drops, final int droppedExp, final String deathMessage) {
+        this(player, drops, droppedExp, 0, deathMessage);
     }
 
-    public PlayerDeathEvent(final Player player, final List<ItemStack> drops, final int droppedExp, final int newExp, final String deathMessage, final boolean keepInventory) {
-        this(player, drops, droppedExp, newExp, 0, 0, deathMessage, keepInventory);
+    public PlayerDeathEvent(final Player player, final List<ItemStack> drops, final int droppedExp, final int newExp, final String deathMessage) {
+        this(player, drops, droppedExp, newExp, 0, 0, deathMessage);
     }
 
-    public PlayerDeathEvent(final Player player, final List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, final String deathMessage, final boolean keepInventory) {
+    public PlayerDeathEvent(final Player player, final List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, final String deathMessage) {
         super(player, drops, droppedExp);
         this.newExp = newExp;
         this.newTotalExp = newTotalExp;
         this.newLevel = newLevel;
         this.deathMessage = deathMessage;
-        this.keepInventory = keepInventory;
     }
 
     @Override

--- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
+++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
@@ -138,18 +138,18 @@ public class PlayerDeathEvent extends EntityDeathEvent {
     }
 
     /**
-     * Sets if the Player should keep their inventory at respawn.
+     * Sets if the Player keeps inventory on death.
      *
-     * @param keepInventory True to keep the current inventory
+     * @param keepInventory True to keep the inventory
      */
     public void setKeepInventory(boolean keepInventory) {
         this.keepInventory = keepInventory;
     }
 
     /**
-     * Gets if the Player should keep their inventory at respawn.
+     * Gets if the Player keeps inventory on death.
      *
-     * @return True if the player should keep their inventory at respawn
+     * @return True if the player keeps inventory on death
      */
     public boolean getKeepInventory() {
         return keepInventory;

--- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
+++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
@@ -14,6 +14,7 @@ public class PlayerDeathEvent extends EntityDeathEvent {
     private int newLevel = 0;
     private int newTotalExp = 0;
     private boolean keepLevel = false;
+    private boolean keepInventory = false;
 
     public PlayerDeathEvent(final Player player, final List<ItemStack> drops, final int droppedExp, final String deathMessage) {
         this(player, drops, droppedExp, 0, deathMessage);
@@ -134,5 +135,23 @@ public class PlayerDeathEvent extends EntityDeathEvent {
      */
     public void setKeepLevel(boolean keepLevel) {
         this.keepLevel = keepLevel;
+    }
+
+    /**
+     * Sets if the Player should keep their inventory at respawn.
+     *
+     * @param keepInventory True to keep the current inventory
+     */
+    public void setKeepInventory(boolean keepInventory) {
+        this.keepInventory = keepInventory;
+    }
+
+    /**
+     * Gets if the Player should keep their inventory at respawn.
+     *
+     * @return True if the player should keep their inventory at respawn
+     */
+    public boolean getKeepInventory() {
+        return keepInventory;
     }
 }


### PR DESCRIPTION
**The Issue:**
There is currently no easy way to designate that a player's inventory should be kept when a player dies through an `PlayerDeathEvent`.

**Justification for this PR:**
This PR adds functionality to PlayerDeathEvent. Plugins can now use `event.setKeepInventory(true)` to designate that a player's inventory is to be kept at respawn.

**PR Breakdown:**
Plugins will now be able to use `PlayerDeathEvent.setKeepInventory(boolean)` and `PlayerDeathEvent.getKeepInventory()`. `getKeepInventory()` will return the value that would occur if the event is left unchanged as defined by the appropriate GameRule. When a player dies (`EntityPlayer.die()`), the event will be instantiated with the value of its default behaviour. Plugins may then modify this result when the event is handled.

**Testing Results and Materials:**
A simple test can be found here: https://github.com/JeromSar/KeepInventoryTest
A compiled binary can be found here: https://github.com/JeromSar/KeepInventoryTest/releases

The plugin in question demonstrates the new functionality by keeping the inventory for operators whilst keeping the default behaviour for non-operators. This way, the newly added functionality can be easily tested. It also displays the default value before modifying it, thus the default `keepInventory` behaviour as defined by its designated GameRule can be verify.

**Relevant PR(s)**
https://github.com/Bukkit/CraftBukkit/pull/1403

**JIRA Tickets:**
https://bukkit.atlassian.net/browse/BUKKIT-5724
