### PR TITLE
[B+C] Add Sign GUI API. Adds BUKKIT-5437

### DIFF
--- a/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -92,18 +92,27 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, Permissible, Inv
     public InventoryView openEnchanting(Location location, boolean force);
 
     /**
-     * Opens a sign window for editing the specified sign. When the player closes the
-     * window, a {@link SignChangeEvent} will be triggered.
-     * @param sign The sign you want to edit.
-     * @param editable Whether the sign change should be automatically accepted by the server.
-     */
-    public void openSign(Sign sign, boolean editable);
-
-    /**
-     * Opens a sign window not linked to a physical sign in the world. When the player closes the
-     * window, a {@link SignChangeEvent} will be triggered.
+     * Opens a sign window not linked to a physical sign in the world. When the
+     * player closes the window, a {@link SignChangeEvent} will be triggered.
      */
     public void openSign();
+
+    /**
+     * Opens a sign window for editing the specified sign. When the player
+     * closes the window, a {@link SignChangeEvent} will be triggered.
+     *
+     * @param sign The sign you want to edit
+     */
+    public void openSign(Sign sign);
+
+    /**
+     * Opens a sign window for editing the specified sign. When the player closes
+     * the window, a {@link SignChangeEvent} will be triggered.
+     *
+     * @param sign The sign you want to edit
+     * @param editable Whether the sign change should be automatically accepted by the server
+     */
+    public void openSign(Sign sign, boolean editable);
 
     /**
      * Opens an inventory window to the specified inventory view.

--- a/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -2,6 +2,7 @@ package org.bukkit.entity;
 
 import org.bukkit.GameMode;
 import org.bukkit.Location;
+import org.bukkit.block.Sign;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.InventoryView;
@@ -88,6 +89,12 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, Permissible, Inv
      *     opened.
      */
     public InventoryView openEnchanting(Location location, boolean force);
+
+    /**
+     * Opens a sign window for editing the specified sign.
+     * @param sign The sign you want to edit.
+     */
+    public void openSign(Sign sign);
 
     /**
      * Opens an inventory window to the specified inventory view.

--- a/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -93,11 +93,17 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, Permissible, Inv
 
     /**
      * Opens a sign window for editing the specified sign. When the player closes the
-     * window, a {@link SignChangeEvent} will be triggered;
+     * window, a {@link SignChangeEvent} will be triggered.
      * @param sign The sign you want to edit.
      * @param editable Whether the sign change should be automatically accepted by the server.
      */
     public void openSign(Sign sign, boolean editable);
+
+    /**
+     * Opens a sign window not linked to a physical sign in the world. When the player closes the
+     * window, a {@link SignChangeEvent} will be triggered.
+     */
+    public void openSign();
 
     /**
      * Opens an inventory window to the specified inventory view.

--- a/src/main/java/org/bukkit/entity/HumanEntity.java
+++ b/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -3,6 +3,7 @@ package org.bukkit.entity;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.block.Sign;
+import org.bukkit.event.block.SignChangeEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.InventoryView;
@@ -91,10 +92,12 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, Permissible, Inv
     public InventoryView openEnchanting(Location location, boolean force);
 
     /**
-     * Opens a sign window for editing the specified sign.
+     * Opens a sign window for editing the specified sign. When the player closes the
+     * window, a {@link SignChangeEvent} will be triggered;
      * @param sign The sign you want to edit.
+     * @param editable Whether the sign change should be automatically accepted by the server.
      */
-    public void openSign(Sign sign);
+    public void openSign(Sign sign, boolean editable);
 
     /**
      * Opens an inventory window to the specified inventory view.


### PR DESCRIPTION
**The Issue:**
There is currently no easy way to access the sign GUI without hacking into sign placement.

**Justification for this PR:**
This PR adds functionality to `HumanEntity`. Plugins can now open a client-side sign GUI which interacts with a sign on the server. Additionally, this PR allows plugins to open "phantom signs" which aren't tied to any sign on the server. The resulting `SignChangeEvent` will always be cancelled by default.

**PR Breakdown:**
This PR adds three new methods to `HumanEntity`: `openSign()`, `openSign(Sign)` and `openSign(Sign, boolean)`. `openSign()` opens a new "phantom sign" which is not tied to any sign on the server. Its resulting `SignChangeEvent` will always be cancelled by default. `openSign(Sign, boolean)` will open a new sign GUI for the given Sign. The second parameter indicates if the server should accept the player's edit by default. The resulting `SignChangeEvent` might be cancelled by default depending on the second flag. `openSign(Sign)` is a shorthand for `openSign(Sign, true)`.

**Testing Results and Materials:**
A simple test plugin can be found here: https://github.com/JeromSar/SignEditTest
A compiled binary can be found here: https://github.com/JeromSar/SignEditTest/releases/

When the plugin is enabled on a server, it will attempt to log all `SignEditEvent` events to the console. The log entry contains the default `isCancelled()` value and the contents of the first line. Players right-click with a stick in the air to open a phantom sign. This sign is not attached to any Sign blockstate and the resulting `SignEditEvent` will thus be cancelled by default. Right clicking on a `SIGN_POST` will show a sign GUI to the player and accept its result (update the sign on the server). Right-clicking on a `WALL_SIGN` will open the sign GUI but will discard the result by default. On both accounts, an `SignEditEvent` will be called and logged.

**Relevant PR(s)**
- https://github.com/Bukkit/Bukkit/pull/1038 and https://github.com/Bukkit/CraftBukkit/pull/1345 - The original PRs by @CelticMinstrel. The PRs lacked testing materials and needed to be merged with master.
- https://github.com/Bukkit/CraftBukkit/pull/1404 - Implementation

**JIRA Tickets:**
https://bukkit.atlassian.net/browse/BUKKIT-5437
