### PR TITLE
[B] Corrected documentation for Material.isSolid(). Fixes BUKKIT-5729, BUKKIT-5671, BUKKIT-5559

### DIFF
--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -644,8 +644,7 @@ public enum Material {
     }
 
     /**
-     * Check if the material is a block and solid (cannot be passed through by
-     * a player)
+     * Check if the material is a block and solid (cannot be broken by liquids)
      *
      * @return True if this material is a block and solid
      */


### PR DESCRIPTION
**The Issue:**
The API documentation for `Material.isSolid()` is deceptive. It reflects behaviour from Minecraft's `Material.isSolid()` which seemingly has a different meaning.

**Justification for this PR:**
This commit changes the `Material.isSolid()` documentation to more accurately describe its behaviour.

**PR Breakdown:**
The API documentation for `Material.isSolid()` is deceptive. It reflects behaviour from Minecraft's `Material.isSolid()` which seemingly has a different meaning.

The current API documentation for `Material.isSolid()` is "Check if the material is a block and solid (cannot be passed through by a player)". This is technically incorrect. For example, players can pass through SIGN_POST and WALL_SIGN without trouble. On the other hand, FLOWER_POT is treated as a non-solid whilst players can not traverse through it.

`PerMaterialTest` tests the `Material.isSolid()` the call for each material. It ensures `Material.isSolid()` matches its native counterpart for each material. However, the native counterpart more accurately defines whether or not a liquid breaks this item. For example: SIGN_POST does not break when water flows on it and is thus a solid block. However, FLOWER_POT does break when water flows upon it and is thus a non-solid block.

**Relevant PR(s):**
https://github.com/Bukkit/Bukkit/pull/1089 - Original PR that changed `isSolid()`'s behavior. It was here that the difference in definition was discovered.

**JIRA Tickets:***
https://bukkit.atlassian.net/browse/BUKKIT-5729
https://bukkit.atlassian.net/browse/BUKKIT-5671
https://bukkit.atlassian.net/browse/BUKKIT-5559
