### PR TITLE
[B] /deop <tab> no longer crashes large servers. Fixes BUKKIT-5742

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/DeopCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/DeopCommand.java
@@ -49,9 +49,9 @@ public class DeopCommand extends VanillaCommand {
 
         if (args.length == 1) {
             List<String> completions = new ArrayList<String>();
-            for (OfflinePlayer player : Bukkit.getOfflinePlayers()) {
+            for (OfflinePlayer player : Bukkit.getOperators()) {
                 String playerName = player.getName();
-                if (player.isOp() && StringUtil.startsWithIgnoreCase(playerName, args[0])) {
+                if (StringUtil.startsWithIgnoreCase(playerName, args[0])) {
                     completions.add(playerName);
                 }
             }


### PR DESCRIPTION
If you are on a large server, and you press [tab] when doing the first argument of /deop, it can crash large servers.
This is a result of calling the method getOfflinePlayers, which is not an appropriate method to be calling. getOperators makes much more sense as it is a much smaller Collection. The only downside is that because it is a Set rather than a list, iterating through it is a small bit slower than iterating through a List of the same size, but iterating through a Set of maybe 10 people is much more efficient than iterating through a list of a few thousand.

Proof of concept: http://pastebin.com/35yFbfz9

This increases efficiency by a very large amount. Doing this with other commands does not have a similar effect as they do not call the getOfflinePlayers() method, but with this command it will crash any large server.

JIRA bug:
BUKKIT-5742 - https://bukkit.atlassian.net/browse/BUKKIT-5742
