### PR TITLE
[B] Tab complete crashes large servers. Fixes BUKKIT-5742

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/DeopCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/DeopCommand.java
@@ -49,9 +49,9 @@ public class DeopCommand extends VanillaCommand {
 
         if (args.length == 1) {
             List<String> completions = new ArrayList<String>();
-            for (OfflinePlayer player : Bukkit.getOfflinePlayers()) {
+            for (OfflinePlayer player : Bukkit.getOperators()) {
                 String playerName = player.getName();
-                if (player.isOp() && StringUtil.startsWithIgnoreCase(playerName, args[0])) {
+                if (StringUtil.startsWithIgnoreCase(playerName, args[0])) {
                     completions.add(playerName);
                 }
             }

--- a/src/main/java/org/bukkit/command/defaults/WhitelistCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/WhitelistCommand.java
@@ -102,16 +102,7 @@ public class WhitelistCommand extends VanillaCommand {
         if (args.length == 1) {
             return StringUtil.copyPartialMatches(args[0], WHITELIST_SUBCOMMANDS, new ArrayList<String>(WHITELIST_SUBCOMMANDS.size()));
         } else if (args.length == 2) {
-            if (args[0].equalsIgnoreCase("add")) {
-                List<String> completions = new ArrayList<String>();
-                for (OfflinePlayer player : Bukkit.getOfflinePlayers()) {
-                    String name = player.getName();
-                    if (StringUtil.startsWithIgnoreCase(name, args[1]) && !player.isWhitelisted()) {
-                        completions.add(name);
-                    }
-                }
-                return completions;
-            } else if (args[0].equalsIgnoreCase("remove")) {
+            if (args[0].equalsIgnoreCase("remove")) {
                 List<String> completions = new ArrayList<String>();
                 for (OfflinePlayer player : Bukkit.getWhitelistedPlayers()) {
                     String name = player.getName();


### PR DESCRIPTION
If you are on a large server, and you press [tab] after typing '/deop' or '/whitelist add', it can crash large servers.
This is a result of calling the method getOfflinePlayers, which is not an appropriate method to be calling. getOperators makes much more sense for '/deop' as it is a much smaller Collection. The only downside is that because it is a Set rather than a list, iterating through it is a small bit slower than iterating through a List of the same size, but iterating through a Set of maybe 10 people is much more efficient than iterating through a list of a few thousand.

Proof of concept: http://pastebin.com/35yFbfz9

This increases efficiency by a very large amount. Doing this with other commands does not have a similar effect as they do not call the getOfflinePlayers() method, but with this command it will crash any large server.

In terms of /whitelist add, the tab completion for that should be removed in general. It is an extremely minor inconvenience, but fixes something that could easily crash any large server. While permissions are needed. it is very easy to want to add a friend to a lobby that was previously unwhitelisted, but now is. You type most of their name, tab complete, and instead of whitelisting your friend, the server crashes.

JIRA bug:
BUKKIT-5742 - https://bukkit.atlassian.net/browse/BUKKIT-5742
