### PR TITLE
[B] Only loop through op players when tab completing /deop. Fixes BUKKIT-5748

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/DeopCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/DeopCommand.java
@@ -49,9 +49,9 @@ public class DeopCommand extends VanillaCommand {
 
         if (args.length == 1) {
             List<String> completions = new ArrayList<String>();
-            for (OfflinePlayer player : Bukkit.getOfflinePlayers()) {
+            for (OfflinePlayer player : Bukkit.getOperators()) {
                 String playerName = player.getName();
-                if (player.isOp() && StringUtil.startsWithIgnoreCase(playerName, args[0])) {
+                if (StringUtil.startsWithIgnoreCase(playerName, args[0])) {
                     completions.add(playerName);
                 }
             }


### PR DESCRIPTION
**The Issue**

The deop command currently goes through all the offline players to and checks
if they're op when tab completing. With this commit, it only loops through
the current operators.

**Justification for this PR**

Looping through all offline players on big servers can be heavy for the server and is unnecessary since there is a way to get the operators directly.

**PR Breakdown**

The new code iterates through Bukkit.getOperators() instead of Bukkit.getOfflinePlayers() when tab completing the deop command. The now useless player.isOp() check has also be removed.

**Testing Results and Materials**

I'm not able to get a server with enough offline players to test the changes, but it seems pretty self explanatory to me.

**Relevant PR(s)**

This is PR contains a part of the changes proposed in #1094 but without the changes to the whitelist command.

**JIRA Ticket**
https://bukkit.atlassian.net/browse/BUKKIT-5748
