### PR TITLE
Allow ItemStacks to serialize under its simple name

### DIFF
--- a/src/main/java/org/bukkit/inventory/ItemStack.java
+++ b/src/main/java/org/bukkit/inventory/ItemStack.java
@@ -16,6 +16,7 @@ import org.bukkit.material.MaterialData;
 /**
  * Represents a stack of items
  */
+@SerializableAs("ItemStack")
 public class ItemStack implements Cloneable, ConfigurationSerializable {
     private int type = 0;
     private int amount = 0;


### PR DESCRIPTION
Nice and simple, I don't foresee any conflict within the API itself either.
