### PR TITLE
[B] Added Missing Villager Profession. Fixes BUKKIT-5765

### DIFF
--- a/src/main/java/org/bukkit/entity/Villager.java
+++ b/src/main/java/org/bukkit/entity/Villager.java
@@ -28,7 +28,8 @@ public interface Villager extends Ageable, NPC {
         LIBRARIAN(1),
         PRIEST(2),
         BLACKSMITH(3),
-        BUTCHER(4);
+        BUTCHER(4),
+        GENERIC(5);
 
         private static final Profession[] professions = new Profession[Profession.values().length];
         private final int id;


### PR DESCRIPTION
Issue:
Missing GENERIC Villager profession

Ticket:
BUKKIT-5765 - https://bukkit.atlassian.net/browse/BUKKIT-5765
