### PR TITLE
Add string 'getCleanName()'

### DIFF
--- a/src/main/java/org/bukkit/inventory/ItemStack.java
+++ b/src/main/java/org/bukkit/inventory/ItemStack.java
@@ -297,6 +297,15 @@ public class ItemStack implements Cloneable, ConfigurationSerializable {
         }
         return toString.append('}').toString();
     }
+    @Override
+    @Utility
+    public String getCleanName(boolean capitals, ItemStack is) {
+        String CleanName == is.getItemMeta().getDisplayName().replace("_", " ").toLowerCase();
+        if(capitals == true) {
+            WordUtils.capitalize(CleanName);
+        }
+        return CleanName
+    }
 
     @Override
     @Utility


### PR DESCRIPTION
Adding 
'getCleanName(boolean capitals, ItemStack is)' adds a clean name of the material, not something like
'DIAMOND_SWORD', Don't like it; How about 'Diamond Sword',
and with boolean capitals off, 'diamond sword'.
