### PR TITLE
Added functionality to send JSON messages

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -117,7 +117,12 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      * @param msg message to print
      */
     public void chat(String msg);
-
+    
+    /**
+     * Sends a JSON formatted message to the client
+     */
+    public void sendJsonMessage(String json);
+    
     /**
      * Makes the player perform the given command
      *


### PR DESCRIPTION
This change in the API (and in CraftBukkit) should make it possible to send JSON formatted messages to players. This has not been put in CommandSender.java on purpose, because ConsoleCommandSenders can't receive these JSON messages.
