### PR TITLE
Refactor Animals interface to Animal. Fixes BUKKIT-5770

### DIFF
--- a/src/main/java/org/bukkit/entity/Animal.java
+++ b/src/main/java/org/bukkit/entity/Animal.java
@@ -1,0 +1,7 @@
+package org.bukkit.entity;
+
+/**
+ * Represents an Animal.
+ */
+@SuppressWarnings("deprecation")
+public interface Animal extends Animals {}

--- a/src/main/java/org/bukkit/entity/Animals.java
+++ b/src/main/java/org/bukkit/entity/Animals.java
@@ -4,4 +4,5 @@ package org.bukkit.entity;
  * Represents an Animal.
  * @deprecated use {@link Animal} instead
  */
+@Deprecated
 public interface Animals extends Ageable {}

--- a/src/main/java/org/bukkit/entity/Animals.java
+++ b/src/main/java/org/bukkit/entity/Animals.java
@@ -2,5 +2,6 @@ package org.bukkit.entity;
 
 /**
  * Represents an Animal.
+ * @deprecated use {@link Animal} instead
  */
 public interface Animals extends Ageable {}

--- a/src/main/java/org/bukkit/entity/Chicken.java
+++ b/src/main/java/org/bukkit/entity/Chicken.java
@@ -3,4 +3,4 @@ package org.bukkit.entity;
 /**
  * Represents a Chicken.
  */
-public interface Chicken extends Animals {}
+public interface Chicken extends Animal {}

--- a/src/main/java/org/bukkit/entity/Cow.java
+++ b/src/main/java/org/bukkit/entity/Cow.java
@@ -3,4 +3,4 @@ package org.bukkit.entity;
 /**
  * Represents a Cow.
  */
-public interface Cow extends Animals {}
+public interface Cow extends Animal {}

--- a/src/main/java/org/bukkit/entity/Horse.java
+++ b/src/main/java/org/bukkit/entity/Horse.java
@@ -6,7 +6,7 @@ import org.bukkit.inventory.InventoryHolder;
 /**
  * Represents a Horse.
  */
-public interface Horse extends Animals, Vehicle, InventoryHolder, Tameable {
+public interface Horse extends Animal, Vehicle, InventoryHolder, Tameable {
 
     /**
      * Represents the different types of horses that may exist.

--- a/src/main/java/org/bukkit/entity/Ocelot.java
+++ b/src/main/java/org/bukkit/entity/Ocelot.java
@@ -4,7 +4,7 @@ package org.bukkit.entity;
 /**
  * A wild tameable cat
  */
-public interface Ocelot extends Animals, Tameable {
+public interface Ocelot extends Animal, Tameable {
 
     /**
      * Gets the current type of this cat.

--- a/src/main/java/org/bukkit/entity/Pig.java
+++ b/src/main/java/org/bukkit/entity/Pig.java
@@ -3,7 +3,7 @@ package org.bukkit.entity;
 /**
  * Represents a Pig.
  */
-public interface Pig extends Animals, Vehicle {
+public interface Pig extends Animal, Vehicle {
 
     /**
      * Check if the pig has a saddle.

--- a/src/main/java/org/bukkit/entity/Sheep.java
+++ b/src/main/java/org/bukkit/entity/Sheep.java
@@ -5,7 +5,7 @@ import org.bukkit.material.Colorable;
 /**
  * Represents a Sheep.
  */
-public interface Sheep extends Animals, Colorable {
+public interface Sheep extends Animal, Colorable {
 
     /**
      * @return Whether the sheep is sheared.

--- a/src/main/java/org/bukkit/entity/Wolf.java
+++ b/src/main/java/org/bukkit/entity/Wolf.java
@@ -5,7 +5,7 @@ import org.bukkit.DyeColor;
 /**
  * Represents a Wolf
  */
-public interface Wolf extends Animals, Tameable {
+public interface Wolf extends Animal, Tameable {
 
     /**
      * Checks if this wolf is angry


### PR DESCRIPTION
##### The Issue:

The Animals interface is improperly named, and should be renamed to Animal.
##### Justification:

A class extending the interface refers to only one animal in the world; as such, the interface's name should be singular.
##### PR Breakdown:

Refactors Animals interface to Animal. The old class remains fundamentally unchanged (albeit deprecated), and the new class now extends the old class to ensure the possibility of compatibility in both directions.
##### Testing Results and Materials:

Non-breaking cosmetic change to API; no in-depth testing required. API compiles as it did before.
##### JIRA Ticket:

BUKKIT-5770 - https://bukkit.atlassian.net/browse/BUKKIT-5770
