### PR TITLE
Add matchEntityType(String) method to EntityType class. Adds BUKKIT-5777

### DIFF
--- a/src/main/java/org/bukkit/entity/EntityType.java
+++ b/src/main/java/org/bukkit/entity/EntityType.java
@@ -3,6 +3,7 @@ package org.bukkit.entity;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang.Validate;
 import org.bukkit.entity.minecart.CommandMinecart;
 import org.bukkit.entity.minecart.HopperMinecart;
 import org.bukkit.entity.minecart.SpawnerMinecart;
@@ -247,6 +248,37 @@ public enum EntityType {
             return null;
         }
         return ID_MAP.get((short) id);
+    }
+    
+    /**
+     * Attempts to match the Material with the given name.
+     * <p>
+     * This is a match lookup; names will be converted to uppercase, then
+     * stripped of special characters in an attempt to format it like the
+     * enum.
+     * <p>
+     * Using this for match by ID is deprecated.
+     *
+     * @param name Name of the material to get
+     * @return Material if found, or null
+     */
+    public static EntityType matchEntityType(final String name) {
+        Validate.notNull(name, "Name cannot be null");
+
+        EntityType result = null;
+
+        try {
+            result = fromId(Integer.parseInt(name));
+        } catch (NumberFormatException ex) {}
+
+        if (result == null) {
+            String filtered = name.toLowerCase();
+
+            filtered = filtered.replaceAll("\\s+", "_").replaceAll("\\W", "");
+            result = NAME_MAP.get(filtered);
+        }
+
+        return result;
     }
 
     /**

--- a/src/main/java/org/bukkit/entity/EntityType.java
+++ b/src/main/java/org/bukkit/entity/EntityType.java
@@ -1,5 +1,6 @@
 package org.bukkit.entity;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -14,6 +15,8 @@ import org.bukkit.entity.minecart.StorageMinecart;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.Location;
 import org.bukkit.World;
+
+import com.google.common.collect.Lists;
 
 public enum EntityType {
 
@@ -139,7 +142,7 @@ public enum EntityType {
     WOLF("Wolf", Wolf.class, 95),
     MUSHROOM_COW("MushroomCow", MushroomCow.class, 96),
     SNOWMAN("SnowMan", Snowman.class, 97),
-    OCELOT("Ozelot", Ocelot.class, 98),
+    OCELOT("Ocelot", Ocelot.class, 98),
     IRON_GOLEM("VillagerGolem", IronGolem.class, 99),
     HORSE("EntityHorse", Horse.class, 100),
     VILLAGER("Villager", Villager.class, 120),
@@ -235,6 +238,8 @@ public enum EntityType {
         if (name == null) {
             return null;
         }
+        if (name.equalsIgnoreCase("Ozelot")) // special case in lieu of long-standing typo
+     	    return EntityType.OCELOT;
         return NAME_MAP.get(name.toLowerCase());
     }
 
@@ -275,7 +280,12 @@ public enum EntityType {
             String filtered = name.toLowerCase();
 
             filtered = filtered.replaceAll("\\s+", "_").replaceAll("\\W", "");
-            result = NAME_MAP.get(filtered);
+            result = fromName(filtered);
+            if (result == null)
+            	try {
+            	    result = EntityType.valueOf(filtered.toUpperCase());
+            	}
+                catch (IllegalArgumentException ex){} // okay to swallow it; we'll just return null
         }
 
         return result;

--- a/src/main/java/org/bukkit/entity/EntityType.java
+++ b/src/main/java/org/bukkit/entity/EntityType.java
@@ -251,16 +251,16 @@ public enum EntityType {
     }
     
     /**
-     * Attempts to match the Material with the given name.
+     * Attempts to match the EntityType with the given name.
      * <p>
-     * This is a match lookup; names will be converted to uppercase, then
+     * This is a match lookup; names will be converted to lowercase, then
      * stripped of special characters in an attempt to format it like the
      * enum.
      * <p>
      * Using this for match by ID is deprecated.
      *
-     * @param name Name of the material to get
-     * @return Material if found, or null
+     * @param name Name of the entity type to get
+     * @return EntityType if found, or null
      */
     public static EntityType matchEntityType(final String name) {
         Validate.notNull(name, "Name cannot be null");

--- a/src/main/java/org/bukkit/entity/EntityType.java
+++ b/src/main/java/org/bukkit/entity/EntityType.java
@@ -142,7 +142,7 @@ public enum EntityType {
     WOLF("Wolf", Wolf.class, 95),
     MUSHROOM_COW("MushroomCow", MushroomCow.class, 96),
     SNOWMAN("SnowMan", Snowman.class, 97),
-    OCELOT("Ocelot", Ocelot.class, 98),
+    OCELOT("Ozelot", Ocelot.class, 98),
     IRON_GOLEM("VillagerGolem", IronGolem.class, 99),
     HORSE("EntityHorse", Horse.class, 100),
     VILLAGER("Villager", Villager.class, 120),
@@ -238,8 +238,6 @@ public enum EntityType {
         if (name == null) {
             return null;
         }
-        if (name.equalsIgnoreCase("Ozelot")) // special case in lieu of long-standing typo
-     	    return EntityType.OCELOT;
         return NAME_MAP.get(name.toLowerCase());
     }
 

--- a/src/test/java/org/bukkit/EntityTypeTest.java
+++ b/src/test/java/org/bukkit/EntityTypeTest.java
@@ -1,0 +1,89 @@
+package org.bukkit;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import org.bukkit.entity.EntityType;
+import org.junit.Test;
+
+public class EntityTypeTest {
+
+    @Test
+    public void getByName() {
+        for (EntityType entityType : EntityType.values()) {
+        	if (entityType.getName() != null)
+                assertThat(EntityType.fromName(entityType.getName()), is(entityType));
+        }
+    }
+
+    @Test
+    public void getById() throws Throwable {
+        for (EntityType entityType : EntityType.values()) {
+            if (entityType.getClass().getField(entityType.name()).getAnnotation(Deprecated.class) != null) {
+                continue;
+            }
+            if (entityType.getTypeId() >= 0) // ensure that it's not a special case
+                assertThat(EntityType.fromId(entityType.getTypeId()), is(entityType));
+        }
+    }
+
+    @Test
+    public void getByOutOfRangeId() {
+        assertThat(EntityType.fromId(Integer.MAX_VALUE), is(nullValue()));
+        assertThat(EntityType.fromId(Integer.MIN_VALUE), is(nullValue()));
+    }
+
+    @Test
+    public void getByNameNull() {
+        assertThat(EntityType.fromName(null), is(nullValue()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void matchEntityTypeByNull() {
+        EntityType.matchEntityType(null);
+    }
+
+    @Test
+    public void matchEntityTypeById() throws Throwable {
+        for (EntityType entityType : EntityType.values()) {
+            if (entityType.getClass().getField(entityType.name()).getAnnotation(Deprecated.class) != null) {
+                continue;
+            }
+            if (entityType.getTypeId() >= 0)
+                assertThat(EntityType.matchEntityType(String.valueOf(entityType.getTypeId())), is(entityType));
+        }
+    }
+
+    @Test
+    public void matchEntityTypeByName() {
+        for (EntityType entityType : EntityType.values()) {
+        	if (entityType.getName() != null)
+                assertThat(EntityType.matchEntityType(entityType.getName()), is(entityType));
+        }
+    }
+
+    @Test
+    public void matchEntityTypeByNameUpperCaseAndSpaces() {
+        for (EntityType entityType : EntityType.values()) {
+        	if (entityType.getName() != null){
+                String name = entityType.getName().replaceAll("_", " ").toUpperCase();
+                assertThat(EntityType.matchEntityType(name), is(entityType));
+        	}
+        }
+    }
+
+    @Test
+    public void matchEntityTypeByValue() {
+        for (EntityType entityType : EntityType.values()) {
+            assertThat(EntityType.matchEntityType(entityType.toString()), is(entityType));
+        }
+    }
+
+    @Test
+    public void matchEntityTypeByValueLowerCaseAndSpaces() {
+        for (EntityType entityType : EntityType.values()) {
+            String name = entityType.toString().replaceAll("_", " ").toLowerCase();
+            assertThat(EntityType.matchEntityType(name), is(entityType));
+        }
+    }
+}


### PR DESCRIPTION
##### The Issue:

The EntityType enum, while mostly identical to the Material enum, lacks a method corresponding to Material#matchMaterial(String).
##### Justification:

In the interest of consistency and ease of use, a corresponding method is beneficial to the API.
##### PR Breakdown:

Creates a method in EntityType called matchEntityType(String), which formats the argument appropriately and matches it to a corresponding value of the enum. Returns null if none is found.
##### Testing Results and Materials:

See EntityTypeTest.java.
##### JIRA Ticket:

Bukkit-5777 - https://bukkit.atlassian.net/browse/BUKKIT-5777?filter=10004
