### PR TITLE
[B+C] Add entry-related methods to scoreboard API. Adds BUKKIT-5779

### DIFF
--- a/src/main/java/org/bukkit/scoreboard/Scoreboard.java
+++ b/src/main/java/org/bukkit/scoreboard/Scoreboard.java
@@ -103,8 +103,19 @@ public interface Scoreboard {
      * @param player the player to search for
      * @return the player's Team or null if the player is not on a team
      * @throws IllegalArgumentException if player is null
+     * @deprecated Scoreboards can contain entries that aren't players
      */
+    @Deprecated
     Team getPlayerTeam(OfflinePlayer player) throws IllegalArgumentException;
+
+    /**
+     * Gets an entry's Team on this Scoreboard
+     *
+     * @param entry the entry to search for
+     * @return the entry's Team or null if the entry is not on a team
+     * @throws IllegalArgumentException if entry is null
+     */
+    Team getEntryTeam(String entry) throws IllegalArgumentException;
 
     /**
      * Gets a Team by name on this Scoreboard

--- a/src/main/java/org/bukkit/scoreboard/Team.java
+++ b/src/main/java/org/bukkit/scoreboard/Team.java
@@ -115,13 +115,23 @@ public interface Team {
      *
      * @return players on the team
      * @throws IllegalStateException if this team has been unregistered
+     * @deprecated Scoreboards can contain entries that aren't players
      */
+    @Deprecated
     Set<OfflinePlayer> getPlayers() throws IllegalStateException;
+
+    /**
+     * Gets the Set of entries on the team
+     *
+     * @return players on the team
+     * @throws IllegalStateException if this team has been unregistered
+     */
+    Set<String> getEntries() throws IllegalStateException;
 
     /**
      * Gets the size of the team
      *
-     * @return number of players on the team
+     * @return number of entries on the team
      * @throws IllegalStateException if this team has been unregistered
      */
     int getSize() throws IllegalStateException;
@@ -142,8 +152,21 @@ public interface Team {
      * @param player the player to add
      * @throws IllegalArgumentException if player is null
      * @throws IllegalStateException if this team has been unregistered
+     * @deprecated Scoreboards can contain entries that aren't players
      */
+    @Deprecated
     void addPlayer(OfflinePlayer player) throws IllegalStateException, IllegalArgumentException;
+
+    /**
+     * This puts the specified entry onto this team for the scoreboard.
+     * <p>
+     * This will remove the entry from any other team on the scoreboard.
+     *
+     * @param entry the entry to add
+     * @throws IllegalArgumentException if entry is null
+     * @throws IllegalStateException if this team has been unregistered
+     */
+    void addEntry(String entry) throws IllegalStateException, IllegalArgumentException;
 
     /**
      * Removes the player from this team.
@@ -152,8 +175,20 @@ public interface Team {
      * @return if the player was on this team
      * @throws IllegalArgumentException if player is null
      * @throws IllegalStateException if this team has been unregistered
+     * @deprecated Scoreboards can contain entries that aren't players
      */
+    @Deprecated
     boolean removePlayer(OfflinePlayer player) throws IllegalStateException, IllegalArgumentException;
+
+    /**
+     * Removes the entry from this team.
+     *
+     * @param entry the entry to remove
+     * @return if the entry was on this team
+     * @throws IllegalArgumentException if entry is null
+     * @throws IllegalStateException if this team has been unregistered
+     */
+    boolean removeEntry(String entry) throws IllegalStateException, IllegalArgumentException;
 
     /**
      * Unregisters this team from the Scoreboard
@@ -169,6 +204,18 @@ public interface Team {
      * @return true if the player is a member of this team
      * @throws IllegalArgumentException if player is null
      * @throws IllegalStateException if this team has been unregistered
+     * @deprecated Scoreboards can contain entries that aren't players
      */
+    @Deprecated
     boolean hasPlayer(OfflinePlayer player) throws IllegalArgumentException, IllegalStateException;
+
+    /**
+     * Checks to see if the specified entry is a member of this team.
+     *
+     * @param entry the entry to search for
+     * @return true if the entry is a member of this team
+     * @throws IllegalArgumentException if entry is null
+     * @throws IllegalStateException if this team has been unregistered
+     */
+    boolean hasEntry(String entry) throws IllegalArgumentException, IllegalStateException;
 }


### PR DESCRIPTION
##### The Issue:

Most methods in the scoreboard API which pertain to OfflinePlayer have been deprecated in favor of the use of entries. However, some methods remain without an entry-related alternative.
##### Justification:

If OfflinePlayers in relation to the scoreboard API are to be deprecated, the change should be thorough and offer an alternative for all methods.
##### PR Breakdown:

Add getEntryTeam(String) to Scoreboard.class
Add getEntries(), addEntry(String), removeEntry(String), and hasEntry(String) to Team.class
Deprecate getPlayerTeam(OfflinePlayer) in Scoreboard.class
Deprecate getPlayers(), addPlayer(OfflinePlayer), removePlayer(OfflinePlayer), and hasPlayer(OfflinePlayer) in Team.class
##### Testing Results and Materials:

The new scoreboard API methods function as expected when employed in a basic plugin.
##### Relevant PRs:

[CB-1410](https://github.com/Bukkit/CraftBukkit/pull/1410)
##### JIRA Ticket:

[BUKKIT-5779](https://bukkit.atlassian.net/browse/BUKKIT-5779)
