### PR TITLE
[B+C] HangingType and VehicleType enums. Adds BUKKIT-5778.

### DIFF
--- a/src/main/java/org/bukkit/entity/Hanging.java
+++ b/src/main/java/org/bukkit/entity/Hanging.java
@@ -19,4 +19,11 @@ public interface Hanging extends Entity, Attachable {
      *     attach to in order to face the given direction.
      */
     public boolean setFacingDirection(BlockFace face, boolean force);
+    
+    /**
+     * Get the type of the hanging.
+     *
+     * @return The hanging type.
+     */
+    public HangingType getHangingType();
 }

--- a/src/main/java/org/bukkit/entity/HangingType.java
+++ b/src/main/java/org/bukkit/entity/HangingType.java
@@ -20,7 +20,12 @@ public enum HangingType {
     /**
      * An item frame on a wall.
      */
-    ITEM_FRAME(EntityType.ITEM_FRAME);
+    ITEM_FRAME(EntityType.ITEM_FRAME),
+
+    /**
+     * An unknown entity without an Entity Class
+     */
+    UNKNOWN(EntityType.UNKNOWN);
 
     /**
      * The {@link EntityType} that corresponds with this.

--- a/src/main/java/org/bukkit/entity/HangingType.java
+++ b/src/main/java/org/bukkit/entity/HangingType.java
@@ -1,0 +1,177 @@
+package org.bukkit.entity;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang.Validate;
+
+/**
+ * An enum of all types of {@link Hanging hangings}.
+ */
+public enum HangingType {
+    /**
+     * A leash attached to a fencepost.
+     */
+    LEASH_HITCH(EntityType.LEASH_HITCH),
+    /**
+     * A painting on a wall.
+     */
+    PAINTING(EntityType.PAINTING),
+    /**
+     * An item frame on a wall.
+     */
+    ITEM_FRAME(EntityType.ITEM_FRAME);
+
+    /**
+     * The {@link EntityType} that corresponds with this.
+     */
+    private EntityType type;
+
+    /**
+     * Contains a map of these by {@linkplain EntityType#getName() internal save
+     * file name}.
+     */
+    private static final Map<String, HangingType> NAME_MAP = new HashMap<String, HangingType>();
+    /**
+     * Contains a map of these by {@linkplain EntityType#getTypeId() internal
+     * Type ID}.
+     */
+    private static final Map<Short, HangingType> ID_MAP = new HashMap<Short, HangingType>();
+    /**
+     * Contains a map of these by {@linkplain EntityType}.
+     */
+    private static final Map<EntityType, HangingType> ENTITYTYPE_MAP = new HashMap<EntityType, HangingType>();
+
+    // Set up the above maps.
+    static {
+        for (HangingType type : values()) {
+            if (type.getName() != null) {
+                NAME_MAP.put(type.getName().toLowerCase(), type);
+            }
+            if (type.getTypeId() > 0) {
+                ID_MAP.put(type.getTypeId(), type);
+            }
+            ENTITYTYPE_MAP.put(type.getEntityType(), type);
+        }
+    }
+
+    private HangingType(EntityType type) {
+        this.type = type;
+    }
+
+    /**
+     * Checks if an {@link EntityType} is also a HangingType.
+     *
+     * @param type
+     *            The {@link EntityType} to check.
+     * @return true if is a HangingType
+     */
+    public static boolean isHanging(EntityType type) {
+        Validate.notNull(type, "Type cannot be null");
+
+        return ENTITYTYPE_MAP.containsKey(type);
+    }
+
+    /**
+     * Gets the HangingType version of an {@link EntityType}.
+     *
+     * @param type
+     *            The {@link EntityType} to start with.
+     * @return HangingType if found, or null otherwise
+     */
+    public static HangingType getHangingType(EntityType type) {
+        return ENTITYTYPE_MAP.get(type);
+    }
+
+    /**
+     * Gets the {@link EntityType} that corresponds with this.
+     */
+    public EntityType getEntityType() {
+        return this.type;
+    }
+
+    // Methods ported from EntityType...
+    /**
+     *
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public String getName() {
+        return type.getName();
+    }
+
+    public Class<? extends Entity> getEntityClass() {
+        return type.getEntityClass();
+    }
+
+    /**
+     *
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public short getTypeId() {
+        return type.getTypeId();
+    }
+
+    /**
+     *
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public static HangingType fromName(String name) {
+        if (name == null) {
+            return null;
+        }
+        return NAME_MAP.get(name.toLowerCase());
+    }
+
+    /**
+     *
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public static HangingType fromId(int id) {
+        if (id > Short.MAX_VALUE) {
+            return null;
+        }
+        return ID_MAP.get((short) id);
+    }
+
+    /**
+     * Attempts to match the HangingType with the given name.
+     * <p>
+     * This is a match lookup; names will be converted to lowercase, then
+     * stripped of special characters in an attempt to format it like the enum.
+     * <p>
+     * Using this for match by ID is deprecated.
+     *
+     * @param name
+     *            Name of the hanging type to get
+     * @return HangingType if found, or null otherwise
+     */
+    public static HangingType matchHangingType(final String name) {
+        Validate.notNull(name, "Name cannot be null");
+
+        HangingType result = null;
+
+        try {
+            result = fromId(Integer.parseInt(name));
+        } catch (NumberFormatException ex) {
+        }
+
+        if (result == null) {
+            String filtered = name.toLowerCase();
+
+            filtered = filtered.replaceAll("\\s+", "_").replaceAll("\\W", "");
+            result = fromName(filtered);
+            if (result == null) {
+                try {
+                    result = HangingType.valueOf(filtered.toUpperCase());
+                } catch (IllegalArgumentException ex) {
+                } // okay to swallow it; we'll just return null
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/org/bukkit/entity/Vehicle.java
+++ b/src/main/java/org/bukkit/entity/Vehicle.java
@@ -20,4 +20,11 @@ public interface Vehicle extends Entity {
      * @param vel velocity vector
      */
     public void setVelocity(Vector vel);
+    
+    /**
+     * Get the type of the vehicle.
+     *
+     * @return The vehicle type.
+     */
+    public VehicleType getVehicleType();
 }

--- a/src/main/java/org/bukkit/entity/VehicleType.java
+++ b/src/main/java/org/bukkit/entity/VehicleType.java
@@ -1,0 +1,206 @@
+package org.bukkit.entity;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang.Validate;
+import org.bukkit.entity.minecart.CommandMinecart;
+import org.bukkit.entity.minecart.ExplosiveMinecart;
+import org.bukkit.entity.minecart.HopperMinecart;
+import org.bukkit.entity.minecart.PoweredMinecart;
+import org.bukkit.entity.minecart.RideableMinecart;
+import org.bukkit.entity.minecart.SpawnerMinecart;
+import org.bukkit.entity.minecart.StorageMinecart;
+
+/**
+ * An enum of all types of {@link Vehicle vehicles}.
+ */
+public enum VehicleType {
+    /**
+     * A placed boat.
+     */
+    BOAT(EntityType.BOAT),
+    /**
+     * @see RideableMinecart
+     */
+    MINECART(EntityType.MINECART),
+    /**
+     * @see StorageMinecart
+     */
+    MINECART_CHEST(EntityType.MINECART_CHEST),
+    /**
+     * @see CommandMinecart
+     */
+    MINECART_COMMAND(EntityType.MINECART_COMMAND),
+    /**
+     * @see PoweredMinecart
+     */
+    MINECART_FURNACE(EntityType.MINECART_FURNACE),
+    /**
+     * @see ExplosiveMinecart
+     */
+    MINECART_TNT(EntityType.MINECART_TNT),
+    /**
+     * @see HopperMinecart
+     */
+    MINECART_HOPPER(EntityType.MINECART_HOPPER),
+    /**
+     * @see SpawnerMinecart
+     */
+    MINECART_MOB_SPAWNER(EntityType.MINECART_MOB_SPAWNER),
+
+    PIG(EntityType.PIG), HORSE(EntityType.HORSE);
+
+    /**
+     * The {@link EntityType} that corresponds with this.
+     */
+    private EntityType type;
+
+    /**
+     * Contains a map of these by {@linkplain EntityType#getName() internal save
+     * file name}.
+     */
+    private static final Map<String, VehicleType> NAME_MAP = new HashMap<String, VehicleType>();
+    /**
+     * Contains a map of these by {@linkplain EntityType#getTypeId() internal
+     * Type ID}.
+     */
+    private static final Map<Short, VehicleType> ID_MAP = new HashMap<Short, VehicleType>();
+    /**
+     * Contains a map of these by {@linkplain EntityType}.
+     */
+    private static final Map<EntityType, VehicleType> ENTITYTYPE_MAP = new HashMap<EntityType, VehicleType>();
+
+    // Set up the above maps.
+    static {
+        for (VehicleType type : values()) {
+            if (type.getName() != null) {
+                NAME_MAP.put(type.getName().toLowerCase(), type);
+            }
+            if (type.getTypeId() > 0) {
+                ID_MAP.put(type.getTypeId(), type);
+            }
+            ENTITYTYPE_MAP.put(type.getEntityType(), type);
+        }
+    }
+
+    private VehicleType(EntityType type) {
+        this.type = type;
+    }
+
+    /**
+     * Checks if an {@link EntityType} is also a VehicleType.
+     *
+     * @param type
+     *            The {@link EntityType} to check.
+     * @return true if is a VehicleType
+     */
+    public static boolean isVehicle(EntityType type) {
+        Validate.notNull(type, "Type cannot be null");
+
+        return ENTITYTYPE_MAP.containsKey(type);
+    }
+
+    /**
+     * Gets the VehicleType version of an {@link EntityType}.
+     *
+     * @param type
+     *            The {@link EntityType} to start with.
+     * @return VehicleType if found, or null otherwise
+     */
+    public static VehicleType getVehicleType(EntityType type) {
+        return ENTITYTYPE_MAP.get(type);
+    }
+
+    /**
+     * Gets the {@link EntityType} that corresponds with this.
+     */
+    public EntityType getEntityType() {
+        return this.type;
+    }
+
+    // Methods ported from EntityType...
+    /**
+     *
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public String getName() {
+        return type.getName();
+    }
+
+    public Class<? extends Entity> getEntityClass() {
+        return type.getEntityClass();
+    }
+
+    /**
+     *
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public short getTypeId() {
+        return type.getTypeId();
+    }
+
+    /**
+     *
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public static VehicleType fromName(String name) {
+        if (name == null) {
+            return null;
+        }
+        return NAME_MAP.get(name.toLowerCase());
+    }
+
+    /**
+     *
+     * @deprecated Magic value
+     */
+    @Deprecated
+    public static VehicleType fromId(int id) {
+        if (id > Short.MAX_VALUE) {
+            return null;
+        }
+        return ID_MAP.get((short) id);
+    }
+
+    /**
+     * Attempts to match the VehicleType with the given name.
+     * <p>
+     * This is a match lookup; names will be converted to lowercase, then
+     * stripped of special characters in an attempt to format it like the enum.
+     * <p>
+     * Using this for match by ID is deprecated.
+     *
+     * @param name
+     *            Name of the vehicle type to get
+     * @return VehicleType if found, or null otherwise
+     */
+    public static VehicleType matchVehicleType(final String name) {
+        Validate.notNull(name, "Name cannot be null");
+
+        VehicleType result = null;
+
+        try {
+            result = fromId(Integer.parseInt(name));
+        } catch (NumberFormatException ex) {
+        }
+
+        if (result == null) {
+            String filtered = name.toLowerCase();
+
+            filtered = filtered.replaceAll("\\s+", "_").replaceAll("\\W", "");
+            result = fromName(filtered);
+            if (result == null) {
+                try {
+                    result = VehicleType.valueOf(filtered.toUpperCase());
+                } catch (IllegalArgumentException ex) {
+                } // okay to swallow it; we'll just return null
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/org/bukkit/entity/VehicleType.java
+++ b/src/main/java/org/bukkit/entity/VehicleType.java
@@ -49,7 +49,13 @@ public enum VehicleType {
      */
     MINECART_MOB_SPAWNER(EntityType.MINECART_MOB_SPAWNER),
 
-    PIG(EntityType.PIG), HORSE(EntityType.HORSE);
+    PIG(EntityType.PIG), 
+    HORSE(EntityType.HORSE),
+
+    /**
+     * An unknown entity without an Entity Class
+     */
+    UNKNOWN(EntityType.UNKNOWN);
 
     /**
      * The {@link EntityType} that corresponds with this.

--- a/src/main/java/org/bukkit/event/hanging/HangingEvent.java
+++ b/src/main/java/org/bukkit/event/hanging/HangingEvent.java
@@ -1,6 +1,7 @@
 package org.bukkit.event.hanging;
 
 import org.bukkit.entity.Hanging;
+import org.bukkit.entity.HangingType;
 import org.bukkit.event.Event;
 
 /**
@@ -20,5 +21,9 @@ public abstract class HangingEvent extends Event {
      */
     public Hanging getEntity() {
         return hanging;
+    }
+    
+    public HangingType getHangingType() {
+        return hanging.getHangingType();
     }
 }

--- a/src/main/java/org/bukkit/event/vehicle/VehicleEvent.java
+++ b/src/main/java/org/bukkit/event/vehicle/VehicleEvent.java
@@ -1,6 +1,7 @@
 package org.bukkit.event.vehicle;
 
 import org.bukkit.entity.Vehicle;
+import org.bukkit.entity.VehicleType;
 import org.bukkit.event.Event;
 
 /**
@@ -20,5 +21,9 @@ public abstract class VehicleEvent extends Event {
      */
     public final Vehicle getVehicle() {
         return vehicle;
+    }
+    
+    public VehicleType getVehicleType() {
+        return vehicle.getVehicleType();
     }
 }

--- a/src/test/java/org/bukkit/HangingTypeTest.java
+++ b/src/test/java/org/bukkit/HangingTypeTest.java
@@ -3,11 +3,13 @@ package org.bukkit;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.HangingType;
 import org.junit.Test;
 
 public class HangingTypeTest {
 
+    //Getting tests.
     @Test
     public void getByName() {
         for (HangingType hangingType : HangingType.values()) {
@@ -40,6 +42,7 @@ public class HangingTypeTest {
         assertThat(HangingType.fromName(null), is(nullValue()));
     }
 
+    //Matching tests.
     @Test(expected = IllegalArgumentException.class)
     public void matchHangingTypeByNull() {
         HangingType.matchHangingType(null);
@@ -88,6 +91,24 @@ public class HangingTypeTest {
         for (HangingType hangingType : HangingType.values()) {
             String name = hangingType.toString().replaceAll("_", " ").toLowerCase();
             assertThat(HangingType.matchHangingType(name), is(hangingType));
+        }
+    }
+
+    //EntityType conversion tests.
+    @Test
+    public void validEntityTypeShouldBeHangingType() {
+        for (HangingType hangingType : HangingType.values()) {
+            assertThat(HangingType.isHanging(hangingType.getEntityType()), is(true));
+        }
+    }
+
+    @Test
+    public void validEntityTypesShouldMatchInName() {
+        //Tests that all valid hanging types are by the by the same name in EntityType,
+        //and that they are the same value.
+        for (HangingType hangingType : HangingType.values()) {
+            assertThat(EntityType.valueOf(hangingType.name()), notNullValue());
+            assertThat(EntityType.valueOf(hangingType.name()), is(hangingType.getEntityType()));
         }
     }
 }

--- a/src/test/java/org/bukkit/HangingTypeTest.java
+++ b/src/test/java/org/bukkit/HangingTypeTest.java
@@ -94,6 +94,13 @@ public class HangingTypeTest {
         }
     }
 
+    @Test
+    public void entityTypeClassShouldMatchHangingTypeClass() {
+        for (HangingType hangingType : HangingType.values()) {
+            assertEquals(hangingType.getEntityClass(), hangingType.getEntityType().getEntityClass());
+        }
+    }
+
     //EntityType conversion tests.
     @Test
     public void validEntityTypeShouldBeHangingType() {

--- a/src/test/java/org/bukkit/HangingTypeTest.java
+++ b/src/test/java/org/bukkit/HangingTypeTest.java
@@ -1,0 +1,94 @@
+package org.bukkit;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import org.bukkit.entity.HangingType;
+import org.junit.Test;
+
+public class HangingTypeTest {
+
+    @Test
+    public void getByName() {
+        for (HangingType hangingType : HangingType.values()) {
+            if (hangingType.getName() != null) {
+                assertThat(HangingType.fromName(hangingType.getName()), is(hangingType));
+            }
+        }
+    }
+
+    @Test
+    public void getById() throws Throwable {
+        for (HangingType hangingType : HangingType.values()) {
+            if (hangingType.getClass().getField(hangingType.name()).getAnnotation(Deprecated.class) != null) {
+                continue;
+            }
+            if (hangingType.getTypeId() >= 0) { // ensure that it's not a special case
+                assertThat(HangingType.fromId(hangingType.getTypeId()), is(hangingType));
+            }
+        }
+    }
+
+    @Test
+    public void getByOutOfRangeId() {
+        assertThat(HangingType.fromId(Integer.MAX_VALUE), is(nullValue()));
+        assertThat(HangingType.fromId(Integer.MIN_VALUE), is(nullValue()));
+    }
+
+    @Test
+    public void getByNameNull() {
+        assertThat(HangingType.fromName(null), is(nullValue()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void matchHangingTypeByNull() {
+        HangingType.matchHangingType(null);
+    }
+
+    @Test
+    public void matchHangingTypeById() throws Throwable {
+        for (HangingType hangingType : HangingType.values()) {
+            if (hangingType.getClass().getField(hangingType.name()).getAnnotation(Deprecated.class) != null) {
+                continue;
+            }
+            if (hangingType.getTypeId() >= 0) {
+                assertThat(HangingType.matchHangingType(String.valueOf(hangingType.getTypeId())), is(hangingType));
+            }
+        }
+    }
+
+    @Test
+    public void matchHangingTypeByName() {
+        for (HangingType hangingType : HangingType.values()) {
+            if (hangingType.getName() != null) {
+                assertThat(HangingType.matchHangingType(hangingType.getName()), is(hangingType));
+            }
+        }
+    }
+
+    @Test
+    public void matchHangingTypeByNameUpperCaseAndSpaces() {
+        for (HangingType hangingType : HangingType.values()) {
+            if (hangingType.getName() != null){
+                String name = hangingType.getName().replaceAll("_", " ").toUpperCase();
+                assertThat(HangingType.matchHangingType(name), is(hangingType));
+            }
+        }
+    }
+
+    @Test
+    public void matchHangingTypeByValue() {
+        for (HangingType hangingType : HangingType.values()) {
+            assertThat(HangingType.matchHangingType(hangingType.toString()), is(hangingType));
+        }
+    }
+
+    @Test
+    public void matchHangingTypeByValueLowerCaseAndSpaces() {
+        for (HangingType hangingType : HangingType.values()) {
+            String name = hangingType.toString().replaceAll("_", " ").toLowerCase();
+            assertThat(HangingType.matchHangingType(name), is(hangingType));
+        }
+    }
+}
+

--- a/src/test/java/org/bukkit/VehicleTypeTest.java
+++ b/src/test/java/org/bukkit/VehicleTypeTest.java
@@ -1,0 +1,94 @@
+package org.bukkit;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import org.bukkit.entity.VehicleType;
+import org.junit.Test;
+
+public class VehicleTypeTest {
+
+    @Test
+    public void getByName() {
+        for (VehicleType vehicleType : VehicleType.values()) {
+            if (vehicleType.getName() != null) {
+                assertThat(VehicleType.fromName(vehicleType.getName()), is(vehicleType));
+            }
+        }
+    }
+
+    @Test
+    public void getById() throws Throwable {
+        for (VehicleType vehicleType : VehicleType.values()) {
+            if (vehicleType.getClass().getField(vehicleType.name()).getAnnotation(Deprecated.class) != null) {
+                continue;
+            }
+            if (vehicleType.getTypeId() >= 0) { // ensure that it's not a special case
+                assertThat(VehicleType.fromId(vehicleType.getTypeId()), is(vehicleType));
+            }
+        }
+    }
+
+    @Test
+    public void getByOutOfRangeId() {
+        assertThat(VehicleType.fromId(Integer.MAX_VALUE), is(nullValue()));
+        assertThat(VehicleType.fromId(Integer.MIN_VALUE), is(nullValue()));
+    }
+
+    @Test
+    public void getByNameNull() {
+        assertThat(VehicleType.fromName(null), is(nullValue()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void matchVehicleTypeByNull() {
+        VehicleType.matchVehicleType(null);
+    }
+
+    @Test
+    public void matchVehicleTypeById() throws Throwable {
+        for (VehicleType vehicleType : VehicleType.values()) {
+            if (vehicleType.getClass().getField(vehicleType.name()).getAnnotation(Deprecated.class) != null) {
+                continue;
+            }
+            if (vehicleType.getTypeId() >= 0) {
+                assertThat(VehicleType.matchVehicleType(String.valueOf(vehicleType.getTypeId())), is(vehicleType));
+            }
+        }
+    }
+
+    @Test
+    public void matchVehicleTypeByName() {
+        for (VehicleType vehicleType : VehicleType.values()) {
+            if (vehicleType.getName() != null) {
+                assertThat(VehicleType.matchVehicleType(vehicleType.getName()), is(vehicleType));
+            }
+        }
+    }
+
+    @Test
+    public void matchVehicleTypeByNameUpperCaseAndSpaces() {
+        for (VehicleType vehicleType : VehicleType.values()) {
+            if (vehicleType.getName() != null){
+                String name = vehicleType.getName().replaceAll("_", " ").toUpperCase();
+                assertThat(VehicleType.matchVehicleType(name), is(vehicleType));
+            }
+        }
+    }
+
+    @Test
+    public void matchVehicleTypeByValue() {
+        for (VehicleType vehicleType : VehicleType.values()) {
+            assertThat(VehicleType.matchVehicleType(vehicleType.toString()), is(vehicleType));
+        }
+    }
+
+    @Test
+    public void matchVehicleTypeByValueLowerCaseAndSpaces() {
+        for (VehicleType vehicleType : VehicleType.values()) {
+            String name = vehicleType.toString().replaceAll("_", " ").toLowerCase();
+            assertThat(VehicleType.matchVehicleType(name), is(vehicleType));
+        }
+    }
+}
+

--- a/src/test/java/org/bukkit/VehicleTypeTest.java
+++ b/src/test/java/org/bukkit/VehicleTypeTest.java
@@ -92,6 +92,13 @@ public class VehicleTypeTest {
         }
     }
 
+    @Test
+    public void entityTypeClassShouldMatchVehicleTypeClass() {
+        for (VehicleType vehicleType : VehicleType.values()) {
+            assertEquals(vehicleType.getEntityClass(), vehicleType.getEntityType().getEntityClass());
+        }
+    }
+
     //EntityType conversion tests.
     @Test
     public void validEntityTypeShouldBeVehicleType() {

--- a/src/test/java/org/bukkit/VehicleTypeTest.java
+++ b/src/test/java/org/bukkit/VehicleTypeTest.java
@@ -3,6 +3,7 @@ package org.bukkit;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.VehicleType;
 import org.junit.Test;
 
@@ -88,6 +89,24 @@ public class VehicleTypeTest {
         for (VehicleType vehicleType : VehicleType.values()) {
             String name = vehicleType.toString().replaceAll("_", " ").toLowerCase();
             assertThat(VehicleType.matchVehicleType(name), is(vehicleType));
+        }
+    }
+
+    //EntityType conversion tests.
+    @Test
+    public void validEntityTypeShouldBeVehicleType() {
+        for (VehicleType vehicleType : VehicleType.values()) {
+            assertThat(VehicleType.isVehicle(vehicleType.getEntityType()), is(true));
+        }
+    }
+
+    @Test
+    public void validEntityTypesShouldMatchInName() {
+        //Tests that all valid vehicle types are by the by the same name in EntityType,
+        //and that they are the same value.
+        for (VehicleType vehicleType : VehicleType.values()) {
+            assertThat(EntityType.valueOf(vehicleType.name()), notNullValue());
+            assertThat(EntityType.valueOf(vehicleType.name()), is(vehicleType.getEntityType()));
         }
     }
 }


### PR DESCRIPTION
##### The Issue:

There are no HangingType nor VehicleType enums.
##### Justification for this PR:

There are several places where Hanging/Vehicle enums would be useful:
- Dealing with different Hanging/Vehicles differently in events, without having to get the [EntityType](http://jd.bukkit.org/beta/apidocs/org/bukkit/entity/EntityType.html).
- Easy tab-completion of commands requiring a vehicle (or hanging), such as a command that only allows specific players to use, say, horses.
  - Easy checking of valid values in such commands.
##### PR Breakdown:

In Bukkit: 

1. Creates [HangingType](https://github.com/Pokechu22/Bukkit/tree/BUKKIT-5778/src/main/java/org/bukkit/entity/HangingType.java) and [VehicleType](https://github.com/Pokechu22/Bukkit/tree/BUKKIT-5778/src/main/java/org/bukkit/entity/VehicleType.java) enums, containing all hangings and vehicles currently in existence.
- Constructor based off of an  [EntityType](http://jd.bukkit.org/beta/apidocs/org/bukkit/entity/EntityType.html), meaning modifications to the base [EntityType](http://jd.bukkit.org/beta/apidocs/org/bukkit/entity/EntityType.html) are also applied.
- Contains methods from [EntityType](http://jd.bukkit.org/beta/apidocs/org/bukkit/entity/EntityType.html), as well as a method to get the corresponding [EntityType](http://jd.bukkit.org/beta/apidocs/org/bukkit/entity/EntityType.html).
- Contains parse method from ([BUKKIT-5777](https://bukkit.atlassian.net/browse/BUKKIT-5777)).  

2. Added `getVehicleType()` method to [Vehicle](http://jd.bukkit.org/beta/apidocs/org/bukkit/entity/Vehicle.html) and [VehicleEvent](http://jd.bukkit.org/beta/apidocs/org/bukkit/event/vehicle/VehicleEvent.html), and `getHangingType()` method to [Hanging](http://jd.bukkit.org/beta/apidocs/org/bukkit/entity/Hanging.html) and [HangingEvent](http://jd.bukkit.org/beta/apidocs/org/bukkit/event/hanging/HangingEvent.html).  

3. Added tests for HangingType and VehicleType enums.

In CraftBukkit: 
1. Added implementations of `getVehicleType()` and `getHangingType()` to the necessary classes.  
##### Testing Results and Materials:

See [org.bukkit.HangingTypeTest.java](https://github.com/Pokechu22/Bukkit/tree/BUKKIT-5778/src/test/java/org/bukkit/HangingTypeTest.java) and [org.bukkit.VehicleTypeTest.java](https://github.com/Pokechu22/Bukkit/tree/BUKKIT-5778/src/test/java/org/bukkit/VehicleTypeTest.java).  These tests cover the HangingType and VehicleType enums only, not the getters on the events or entities themselves.
##### Relevant PR(s):

B-1107 - https://github.com/Bukkit/Bukkit/pull/1107 - Adds a parsing method to EntityType, which I ~~stole~~ _borrowed_ for use in VehicleType and HangingType.  ([BUKKIT-5777](https://bukkit.atlassian.net/browse/BUKKIT-5777))

B-1109 - https://github.com/Bukkit/Bukkit/pull/1109 - This Pull Request
CB-1411 - https://github.com/Bukkit/CraftBukkit/pull/1411 - CraftBukkit Counterpart of this Pull Request
##### JIRA Ticket:

BUKKIT-5778 - https://bukkit.atlassian.net/browse/BUKKIT-5778
##### EDITS:
1. Added partner pull-request for CraftBukkit.
