### PR TITLE
[B+C] Add new title-based inventory methods. Adds BUKKIT-1899

### DIFF
--- a/src/main/java/org/bukkit/inventory/Inventory.java
+++ b/src/main/java/org/bukkit/inventory/Inventory.java
@@ -350,6 +350,20 @@ public interface Inventory extends Iterable<ItemStack> {
      * @return A String with the title.
      */
     public String getTitle();
+    
+    /**
+     * Sets the title of this inventory. This will have no effect if {@link Inventory#isNameable()} returns false.
+     * 
+     * @param title the new title of this inventory.
+     */
+    public void setTitle(String title);
+
+    /**
+     * Returns whether this inventory is renameable.
+     *
+     * @return whether this inventory is nameable.
+     */
+    public boolean isNameable();
 
     /**
      * Returns what type of inventory this is.


### PR DESCRIPTION
##### The Issue:

Bukkit currently lacks a way to set the title of an inventory through its API, forcing those who wish to implement such a functionality to use (already existing) NMS methods.
##### Justification:

There are plenty of scenarios in which the ability to rename an inventory is useful, and seeing as it is a fairly simple task, it should not require the recreation of the inventory with the new title or the use of NMS. Simply put, it's overkill.
##### PR Breakdown:

This pull request adds two methods to Inventory.java:

**setInventoryTitle(String)** - Sets the title of the inventory.
**isNameable()** - returns a boolean representing whether the inventory may be named. The setInventoryTitle() method exists even if this returns false, but will have no effect.

Additionally, all direct or indirect subclasses of Inventory have been given or have inherited proper implementations of these two methods.
##### Testing Results and Materials:

See [InventoryTitleTest.java](https://github.com/mproncace/CraftBukkit/blob/BUKKIT-1899/src/test/java/org/bukkit/craftbukkit/inventory/InventoryTitleTest.java) in the sister commit.
##### Relevant PRs:

[CB-1412](https://github.com/Bukkit/CraftBukkit/pull/1412) - sister ticket for implementation
##### JIRA ticket:

[BUKKIT-1899](https://bukkit.atlassian.net/browse/BUKKIT-1899)
