### PR TITLE
Corrected return value of getFacing() for Pumpkin

### DIFF
--- a/src/main/java/org/bukkit/material/Pumpkin.java
+++ b/src/main/java/org/bukkit/material/Pumpkin.java
@@ -96,7 +96,7 @@ public class Pumpkin extends MaterialData implements Directional {
 
         case 0x3:
         default:
-            return BlockFace.EAST;
+            return BlockFace.WEST;
         }
     }
 


### PR DESCRIPTION
Both data values 0x1 and 0x3 were returning BlockFace.EAST when a data value of 0x3 should return BlockFace.WEST