### PR TITLE
More Consistent Capitalization

### DIFF
--- a/src/main/java/org/bukkit/entity/Entity.java
+++ b/src/main/java/org/bukkit/entity/Entity.java
@@ -84,7 +84,7 @@ public interface Entity extends Metadatable {
     public boolean teleport(Location location, TeleportCause cause);
 
     /**
-     * Teleports this entity to the target Entity. If this entity is riding a
+     * Teleports this Entity to the target Entity. If this Entity is riding a
      * vehicle, it will be dismounted prior to teleportation.
      *
      * @param destination Entity to teleport this entity to
@@ -93,7 +93,7 @@ public interface Entity extends Metadatable {
     public boolean teleport(Entity destination);
 
     /**
-     * Teleports this entity to the target Entity. If this entity is riding a
+     * Teleports this Entity to the target Entity. If this Entity is riding a
      * vehicle, it will be dismounted prior to teleportation.
      *
      * @param destination Entity to teleport this entity to


### PR DESCRIPTION
If Entity is a class name and technically should be capitalized, why is it only capitalized once in these javadocs and not all three times?