### PR TITLE
Pollution Clear for setExtended in PotionTest

### DIFF
--- a/src/main/java/org/bukkit/potion/PotionEffectType.java
+++ b/src/main/java/org/bukkit/potion/PotionEffectType.java
@@ -266,4 +266,14 @@ public abstract class PotionEffectType {
     public static PotionEffectType[] values() {
         return byId.clone();
     }
+
+    /**
+     * Clear byId and byName
+     */
+    public static void clear() {
+        for (int i = 0; i < byId.length; i++) {
+            byId[i] = null;
+        }
+	byName.clear();
+    }
 }

--- a/src/test/java/org/bukkit/potion/PotionTest.java
+++ b/src/test/java/org/bukkit/potion/PotionTest.java
@@ -65,6 +65,7 @@ public class PotionTest {
         potion.setHasExtendedDuration(true);
         assertTrue(potion.hasExtendedDuration());
         assertTrue((potion.toDamageValue() & EXTENDED_BIT) != 0);
+        PotionEffectType.clear();
     }
 
     @Test


### PR DESCRIPTION
This PR aims to improve a test `org.bukkit.potion.PotionTest.setExtended`, which is non-idempotent and fails if run twice in the same JVM. The failure message is as follows
```
Tests in error: 
  setExtended(org.bukkit.potion.PotionTest): Cannot set already-set type

Tests run: 2, Failures: 0, Errors: 1, Skipped: 0
```

The reason for this is because it pollutes state (`byId` and `byName` in the main code) shared among tests.
Though it seems to be a minor issue, we propose that it might be good to clean this state pollution after the execution of this test so that some other tests do not fail in the future due to the shared state polluted by this test.