### PR TITLE
very minor parameter name changes

### DIFF
--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -162,13 +162,13 @@ public final class JavaPluginLoader implements PluginLoader {
             if (jar != null) {
                 try {
                     jar.close();
-                } catch (IOException e) {
+                } catch (IOException ignored) {
                 }
             }
             if (stream != null) {
                 try {
                     stream.close();
-                } catch (IOException e) {
+                } catch (IOException ignored) {
                 }
             }
         }
@@ -189,7 +189,7 @@ public final class JavaPluginLoader implements PluginLoader {
 
                 try {
                     cachedClass = loader.findClass(name, false);
-                } catch (ClassNotFoundException cnfe) {}
+                } catch (ClassNotFoundException ignored) {}
                 if (cachedClass != null) {
                     return cachedClass;
                 }


### PR DESCRIPTION
if catch block is empty in JavaPluginLoader class then rename catch parameter to ignored