### PR TITLE
redundant null check for immutable (final) 'loaders' attribute

### DIFF
--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
@@ -112,9 +112,6 @@ public final class JavaPluginLoader implements PluginLoader {
         }
 
         for (final String pluginName : description.getDepend()) {
-            if (loaders == null) {
-                throw new UnknownDependencyException(pluginName);
-            }
             PluginClassLoader current = loaders.get(pluginName);
 
             if (current == null) {


### PR DESCRIPTION
redundant null check for immutable (final) 'loaders' attribute in JavaPluginLoader class.