### PR TITLE
make 'inventory' attribute of DoubleChest class final

### DIFF
--- a/src/main/java/org/bukkit/block/DoubleChest.java
+++ b/src/main/java/org/bukkit/block/DoubleChest.java
@@ -10,7 +10,7 @@ import org.bukkit.inventory.InventoryHolder;
  * Represents a double chest.
  */
 public class DoubleChest implements InventoryHolder {
-    private DoubleChestInventory inventory;
+    private final DoubleChestInventory inventory;
 
     public DoubleChest(DoubleChestInventory chest) {
         inventory = chest;


### PR DESCRIPTION
make 'inventory' attribute of DoubleChest class final since it is private and never reassigned