### PR TITLE
make 'id' and 'byId' attributes of PistonMoveReaction enum final

### DIFF
--- a/src/main/java/org/bukkit/block/PistonMoveReaction.java
+++ b/src/main/java/org/bukkit/block/PistonMoveReaction.java
@@ -18,8 +18,8 @@ public enum PistonMoveReaction {
      */
     BLOCK(2);
 
-    private int id;
-    private static Map<Integer, PistonMoveReaction> byId = new HashMap<Integer, PistonMoveReaction>();
+    private final int id;
+    private static final Map<Integer, PistonMoveReaction> byId = new HashMap<Integer, PistonMoveReaction>();
     static {
         for (PistonMoveReaction reaction : PistonMoveReaction.values()) {
             byId.put(reaction.id, reaction);


### PR DESCRIPTION
make 'id' and 'byId' attributes of PistonMoveReaction enum final since they are private and never reassigned